### PR TITLE
feat: Add position management to career lookup (#625)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
           cache: npm
 
       - name: Install dependencies
@@ -27,6 +27,9 @@ jobs:
 
       - name: Run linting
         run: npm run lint
+
+      - name: Run tests
+        run: npm run test:run
 
       - name: Build project
         run: npm run build

--- a/app/career-lookup/page.tsx
+++ b/app/career-lookup/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type React from 'react';
-import type { Footballer, FootballerNationStat, n8nWikiPlayerData } from '@/types/player';
+import type { Footballer, FootballerNationStat, FootballerPosition, n8nWikiPlayerData } from '@/types/player';
 import {
   AlertCircle,
 } from 'lucide-react';
@@ -48,15 +48,13 @@ export default function FootballerCareerApp() {
   // State for database national team stats
   const [dbNationalTeams, setDbNationalTeams] = useState<FootballerNationStat[]>([]);
 
+  // State for database footballer positions (refetched after save, like dbNationalTeams)
+  const [dbFootballerPositions, setDbFootballerPositions] = useState<FootballerPosition[]>([]);
+
   // State for selected positions from PositionCard
   const [selectedPositions, setSelectedPositions] = useState<SelectedPosition[]>([]);
-  const [positionsSynced, setPositionsSynced] = useState(false);
   const handleSelectedPositionsChange = useCallback((positions: SelectedPosition[]) => {
     setSelectedPositions(positions);
-    setPositionsSynced(false);
-  }, []);
-  const handlePositionsApplied = useCallback(() => {
-    setPositionsSynced(true);
   }, []);
 
   // Initialize with URL parameters
@@ -94,10 +92,19 @@ export default function FootballerCareerApp() {
         setDbNationalTeams([]);
       }
 
+      // Also fetch footballer positions
+      try {
+        const positions = await FootballerAPI.getFootballerPositions(playerDBId);
+        setDbFootballerPositions(positions);
+      } catch {
+        setDbFootballerPositions([]);
+      }
+
       return footballer;
     } catch (error) {
       setDbPlayerInfo(null);
       setDbNationalTeams([]);
+      setDbFootballerPositions([]);
       return null;
     } finally {
       setLoadingDbPlayer(false);
@@ -116,12 +123,25 @@ export default function FootballerCareerApp() {
     }
   };
 
+  // Re-fetch footballer positions (called after save operations)
+  const refetchPositions = async () => {
+    if (dbPlayerInfo?.id) {
+      try {
+        const positions = await FootballerAPI.getFootballerPositions(dbPlayerInfo.id);
+        setDbFootballerPositions(positions);
+      } catch {
+        setDbFootballerPositions([]);
+      }
+    }
+  };
+
   // Handle reload player - triggers a fresh search with current player name
   const handleReloadPlayer = () => {
     if (searchValue.trim()) {
       setChosenDataSource(null);
       setDbPlayerInfo(null);
       setDbNationalTeams([]);
+      setDbFootballerPositions([]);
       setError(null);
       handleSearch(searchMode, searchValue);
     }
@@ -284,7 +304,7 @@ export default function FootballerCareerApp() {
               onDataSourceChange={setChosenDataSource}
               onNationStatsUpdated={refetchNationalTeams}
               onSelectedPositionsChange={handleSelectedPositionsChange}
-              onPositionsApplied={handlePositionsApplied}
+              onPositionsSaved={refetchPositions}
             />
 
             {/* Player Configuration Section - Full Width */}
@@ -297,7 +317,7 @@ export default function FootballerCareerApp() {
               dbNationalTeams={dbNationalTeams}
               onNationStatsUpdated={refetchNationalTeams}
               selectedPositions={selectedPositions}
-              positionsSynced={positionsSynced}
+              dbFootballerPositions={dbFootballerPositions}
             />
           </>
         )}

--- a/app/career-lookup/page.tsx
+++ b/app/career-lookup/page.tsx
@@ -6,13 +6,14 @@ import {
   AlertCircle,
 } from 'lucide-react';
 import { useSearchParams } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { CareerLookupDataValidation } from '@/components/career-lookup/career-lookup-data-validation';
 import { CareerLookupInfo } from '@/components/career-lookup/career-lookup-info';
 import { CareerLookupPlayerConfiguration } from '@/components/career-lookup/career-lookup-player-configuration';
 import { CareerLookupSearch } from '@/components/career-lookup/career-lookup-search';
 import { ConnectionSettings } from '@/components/career-lookup/connection-settings';
 import { HelpDialog } from '@/components/career-lookup/help-dialog';
+import type { SelectedPosition } from '@/components/career-lookup/position-card';
 import { LoadingSpinner } from '@/components/loading-spinner';
 import { LoginForm } from '@/components/login-form';
 import { Navigation } from '@/components/navigation';
@@ -46,6 +47,12 @@ export default function FootballerCareerApp() {
 
   // State for database national team stats
   const [dbNationalTeams, setDbNationalTeams] = useState<FootballerNationStat[]>([]);
+
+  // State for selected positions from PositionCard
+  const [selectedPositions, setSelectedPositions] = useState<SelectedPosition[]>([]);
+  const handleSelectedPositionsChange = useCallback((positions: SelectedPosition[]) => {
+    setSelectedPositions(positions);
+  }, []);
 
   // Initialize with URL parameters
   useEffect(() => {
@@ -271,6 +278,7 @@ export default function FootballerCareerApp() {
               chosenDataSource={chosenDataSource}
               onDataSourceChange={setChosenDataSource}
               onNationStatsUpdated={refetchNationalTeams}
+              onSelectedPositionsChange={handleSelectedPositionsChange}
             />
 
             {/* Player Configuration Section - Full Width */}
@@ -282,6 +290,7 @@ export default function FootballerCareerApp() {
               onReloadPlayer={handleReloadPlayer}
               dbNationalTeams={dbNationalTeams}
               onNationStatsUpdated={refetchNationalTeams}
+              selectedPositions={selectedPositions}
             />
           </>
         )}

--- a/app/career-lookup/page.tsx
+++ b/app/career-lookup/page.tsx
@@ -50,8 +50,13 @@ export default function FootballerCareerApp() {
 
   // State for selected positions from PositionCard
   const [selectedPositions, setSelectedPositions] = useState<SelectedPosition[]>([]);
+  const [positionsSynced, setPositionsSynced] = useState(false);
   const handleSelectedPositionsChange = useCallback((positions: SelectedPosition[]) => {
     setSelectedPositions(positions);
+    setPositionsSynced(false);
+  }, []);
+  const handlePositionsApplied = useCallback(() => {
+    setPositionsSynced(true);
   }, []);
 
   // Initialize with URL parameters
@@ -279,6 +284,7 @@ export default function FootballerCareerApp() {
               onDataSourceChange={setChosenDataSource}
               onNationStatsUpdated={refetchNationalTeams}
               onSelectedPositionsChange={handleSelectedPositionsChange}
+              onPositionsApplied={handlePositionsApplied}
             />
 
             {/* Player Configuration Section - Full Width */}
@@ -291,6 +297,7 @@ export default function FootballerCareerApp() {
               dbNationalTeams={dbNationalTeams}
               onNationStatsUpdated={refetchNationalTeams}
               selectedPositions={selectedPositions}
+              positionsSynced={positionsSynced}
             />
           </>
         )}

--- a/components/career-lookup/__tests__/position-card.test.tsx
+++ b/components/career-lookup/__tests__/position-card.test.tsx
@@ -1,0 +1,198 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PositionCard } from '@/components/career-lookup/position-card';
+import type { PositionsTracker } from '@/types/player';
+
+// Mock FootballerAPI
+vi.mock('@/lib/footballer-api', () => ({
+  FootballerAPI: {
+    setPositions: vi.fn(),
+  },
+}));
+
+import { FootballerAPI } from '@/lib/footballer-api';
+
+const mockSetPositions = vi.mocked(FootballerAPI.setPositions);
+
+const makeTracker = (overrides: Partial<PositionsTracker> = {}): PositionsTracker => ({
+  hasDiscrepancy: false,
+  databasePositions: [],
+  databaseHasPositions: false,
+  wikipediaPositions: [],
+  missingInDatabase: [],
+  missingIdsToApply: [],
+  message: 'No positions data',
+  ...overrides,
+});
+
+describe('PositionCard', () => {
+  beforeEach(() => {
+    mockSetPositions.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders nothing when no positionsTracker provided', () => {
+    const { container } = render(<PositionCard />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders Wikipedia positions with role badges', () => {
+    const tracker = makeTracker({
+      wikipediaPositions: [
+        { id: 1, name: 'GK', fullName: 'Goalkeeper', originalWikipediaName: 'Goalkeeper' },
+        { id: 16, name: 'ST', fullName: 'Striker', originalWikipediaName: 'Forward' },
+      ],
+      message: '2 positions found',
+    });
+
+    render(<PositionCard positionsTracker={tracker} />);
+
+    expect(screen.getByText('Goalkeeper')).toBeInTheDocument();
+    expect(screen.getByText('Striker')).toBeInTheDocument();
+    expect(screen.getByText('2 positions found')).toBeInTheDocument();
+  });
+
+  it('renders DB positions with primary star badge', () => {
+    const tracker = makeTracker({
+      databasePositions: [
+        { id: 16, name: 'ST', fullName: 'Striker', isPrimary: true },
+        { id: 5, name: 'CF', fullName: 'Centre-Forward', isPrimary: false },
+      ],
+      databaseHasPositions: true,
+      message: 'Positions synced',
+    });
+
+    render(<PositionCard positionsTracker={tracker} playerFoundInDB />);
+
+    expect(screen.getByText('(Primary)')).toBeInTheDocument();
+    expect(screen.getByText('Centre-Forward')).toBeInTheDocument();
+  });
+
+  it('shows Synced badge when no discrepancy', () => {
+    const tracker = makeTracker({
+      databaseHasPositions: true,
+      databasePositions: [{ id: 1, name: 'GK', fullName: 'Goalkeeper', isPrimary: true }],
+      wikipediaPositions: [{ id: 1, name: 'GK', fullName: 'Goalkeeper', originalWikipediaName: 'Goalkeeper' }],
+      message: 'Positions match',
+    });
+
+    render(<PositionCard positionsTracker={tracker} playerFoundInDB />);
+
+    expect(screen.getByText('Synced')).toBeInTheDocument();
+  });
+
+  it('shows Mismatch badge and alert when discrepancy exists', () => {
+    const tracker = makeTracker({
+      hasDiscrepancy: true,
+      databasePositions: [{ id: 1, name: 'GK', fullName: 'Goalkeeper', isPrimary: true }],
+      databaseHasPositions: true,
+      wikipediaPositions: [
+        { id: 1, name: 'GK', fullName: 'Goalkeeper', originalWikipediaName: 'Goalkeeper' },
+        { id: 16, name: 'ST', fullName: 'Striker', originalWikipediaName: 'Forward' },
+      ],
+      missingInDatabase: [{ id: 16, name: 'ST', fullName: 'Striker', originalWikipediaName: 'Forward' }],
+      missingIdsToApply: [16],
+      message: '1 position missing',
+    });
+
+    render(<PositionCard positionsTracker={tracker} playerFoundInDB footballerId={42} />);
+
+    expect(screen.getByText('Mismatch')).toBeInTheDocument();
+    expect(screen.getByText(/missing in database/i)).toBeInTheDocument();
+    expect(screen.getByText('Apply Wikipedia Positions')).toBeInTheDocument();
+  });
+
+  it('shows New Player badge for players not in DB', () => {
+    const tracker = makeTracker({
+      wikipediaPositions: [
+        { id: 16, name: 'ST', fullName: 'Striker', originalWikipediaName: 'Forward' },
+      ],
+      missingIdsToApply: [16],
+      message: 'New player! 1 position found',
+    });
+
+    render(<PositionCard positionsTracker={tracker} playerFoundInDB={false} />);
+
+    expect(screen.getByText('New Player')).toBeInTheDocument();
+    expect(screen.getByText(/will be assigned when the player is deployed/i)).toBeInTheDocument();
+  });
+
+  it('calls setPositions API when Apply button clicked', async () => {
+    const user = userEvent.setup();
+    const onApplied = vi.fn();
+
+    mockSetPositions.mockResolvedValue([
+      {
+        id: 10, footballer_id: 42, footballer_name: 'Test',
+        position_id: 16, position_name: 'ST', position_full_name: 'Striker',
+        position_role: 'FWD', is_primary: true, sort_order: 0,
+        created_at: '', updated_at: '',
+      },
+    ]);
+
+    const tracker = makeTracker({
+      hasDiscrepancy: true,
+      databasePositions: [],
+      databaseHasPositions: false,
+      wikipediaPositions: [
+        { id: 16, name: 'ST', fullName: 'Striker', originalWikipediaName: 'Forward' },
+      ],
+      missingInDatabase: [{ id: 16, name: 'ST', fullName: 'Striker', originalWikipediaName: 'Forward' }],
+      missingIdsToApply: [16],
+      message: '1 position missing',
+    });
+
+    render(
+      <PositionCard
+        positionsTracker={tracker}
+        playerFoundInDB
+        footballerId={42}
+        onPositionsApplied={onApplied}
+      />,
+    );
+
+    await user.click(screen.getByText('Apply Wikipedia Positions'));
+
+    expect(mockSetPositions).toHaveBeenCalledWith({
+      footballer_id: 42,
+      positions: [{ position_id: 16, is_primary: true, sort_order: 0 }],
+    });
+    expect(await screen.findByText(/applied successfully/i)).toBeInTheDocument();
+    expect(onApplied).toHaveBeenCalled();
+  });
+
+  it('shows error state when API call fails', async () => {
+    const user = userEvent.setup();
+    mockSetPositions.mockRejectedValue(new Error('Network error'));
+
+    const tracker = makeTracker({
+      hasDiscrepancy: true,
+      missingInDatabase: [{ id: 16, name: 'ST', fullName: 'Striker', originalWikipediaName: 'Forward' }],
+      missingIdsToApply: [16],
+      message: '1 position missing',
+    });
+
+    render(<PositionCard positionsTracker={tracker} playerFoundInDB footballerId={42} />);
+
+    await user.click(screen.getByText('Apply Wikipedia Positions'));
+
+    expect(await screen.findByText(/Network error/i)).toBeInTheDocument();
+  });
+
+  it('shows original Wikipedia name when different from matched name', () => {
+    const tracker = makeTracker({
+      wikipediaPositions: [
+        { id: 16, name: 'ST', fullName: 'Striker', originalWikipediaName: 'Forward' },
+      ],
+      message: '1 position found',
+    });
+
+    render(<PositionCard positionsTracker={tracker} />);
+
+    expect(screen.getByText('(Forward)')).toBeInTheDocument();
+  });
+});

--- a/components/career-lookup/__tests__/position-card.test.tsx
+++ b/components/career-lookup/__tests__/position-card.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PositionCard } from '@/components/career-lookup/position-card';
@@ -8,12 +8,14 @@ import type { PositionsTracker } from '@/types/player';
 vi.mock('@/lib/footballer-api', () => ({
   FootballerAPI: {
     setPositions: vi.fn(),
+    getPositions: vi.fn().mockResolvedValue([]),
   },
 }));
 
 import { FootballerAPI } from '@/lib/footballer-api';
 
 const mockSetPositions = vi.mocked(FootballerAPI.setPositions);
+const mockGetPositions = vi.mocked(FootballerAPI.getPositions);
 
 const makeTracker = (overrides: Partial<PositionsTracker> = {}): PositionsTracker => ({
   hasDiscrepancy: false,
@@ -29,6 +31,8 @@ const makeTracker = (overrides: Partial<PositionsTracker> = {}): PositionsTracke
 describe('PositionCard', () => {
   beforeEach(() => {
     mockSetPositions.mockReset();
+    mockGetPositions.mockReset();
+    mockGetPositions.mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -40,7 +44,7 @@ describe('PositionCard', () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it('renders Wikipedia positions with role badges', () => {
+  it('renders selected positions from Wikipedia data', () => {
     const tracker = makeTracker({
       wikipediaPositions: [
         { id: 1, name: 'GK', fullName: 'Goalkeeper', originalWikipediaName: 'Goalkeeper' },
@@ -68,7 +72,7 @@ describe('PositionCard', () => {
 
     render(<PositionCard positionsTracker={tracker} playerFoundInDB />);
 
-    expect(screen.getByText('(Primary)')).toBeInTheDocument();
+    expect(screen.getByText('Primary')).toBeInTheDocument();
     expect(screen.getByText('Centre-Forward')).toBeInTheDocument();
   });
 
@@ -103,7 +107,6 @@ describe('PositionCard', () => {
 
     expect(screen.getByText('Mismatch')).toBeInTheDocument();
     expect(screen.getByText(/missing in database/i)).toBeInTheDocument();
-    expect(screen.getByText('Apply Wikipedia Positions')).toBeInTheDocument();
   });
 
   it('shows New Player badge for players not in DB', () => {
@@ -121,7 +124,7 @@ describe('PositionCard', () => {
     expect(screen.getByText(/will be assigned when the player is deployed/i)).toBeInTheDocument();
   });
 
-  it('calls setPositions API when Apply button clicked', async () => {
+  it('calls setPositions API when Save button clicked for unsaved positions', async () => {
     const user = userEvent.setup();
     const onApplied = vi.fn();
 
@@ -155,13 +158,13 @@ describe('PositionCard', () => {
       />,
     );
 
-    await user.click(screen.getByText('Apply Wikipedia Positions'));
+    await user.click(screen.getByText('Save Positions'));
 
     expect(mockSetPositions).toHaveBeenCalledWith({
       footballer_id: 42,
       positions: [{ position_id: 16, is_primary: true, sort_order: 0 }],
     });
-    expect(await screen.findByText(/applied successfully/i)).toBeInTheDocument();
+    expect(await screen.findByText(/saved successfully/i)).toBeInTheDocument();
     expect(onApplied).toHaveBeenCalled();
   });
 
@@ -171,6 +174,11 @@ describe('PositionCard', () => {
 
     const tracker = makeTracker({
       hasDiscrepancy: true,
+      databasePositions: [],
+      databaseHasPositions: false,
+      wikipediaPositions: [
+        { id: 16, name: 'ST', fullName: 'Striker', originalWikipediaName: 'Forward' },
+      ],
       missingInDatabase: [{ id: 16, name: 'ST', fullName: 'Striker', originalWikipediaName: 'Forward' }],
       missingIdsToApply: [16],
       message: '1 position missing',
@@ -178,13 +186,15 @@ describe('PositionCard', () => {
 
     render(<PositionCard positionsTracker={tracker} playerFoundInDB footballerId={42} />);
 
-    await user.click(screen.getByText('Apply Wikipedia Positions'));
+    await user.click(screen.getByText('Save Positions'));
 
     expect(await screen.findByText(/Network error/i)).toBeInTheDocument();
   });
 
-  it('shows original Wikipedia name when different from matched name', () => {
+  it('shows Wiki badge for positions from Wikipedia not yet in DB', () => {
     const tracker = makeTracker({
+      databasePositions: [],
+      databaseHasPositions: false,
       wikipediaPositions: [
         { id: 16, name: 'ST', fullName: 'Striker', originalWikipediaName: 'Forward' },
       ],
@@ -193,6 +203,63 @@ describe('PositionCard', () => {
 
     render(<PositionCard positionsTracker={tracker} />);
 
-    expect(screen.getByText('(Forward)')).toBeInTheDocument();
+    expect(screen.getByText('Wiki')).toBeInTheDocument();
+  });
+
+  it('has tabs for Selected Positions and All Positions', () => {
+    const tracker = makeTracker({
+      wikipediaPositions: [
+        { id: 1, name: 'GK', fullName: 'Goalkeeper', originalWikipediaName: 'Goalkeeper' },
+      ],
+      message: 'Test',
+    });
+
+    render(<PositionCard positionsTracker={tracker} />);
+
+    expect(screen.getByRole('tab', { name: /Selected Positions/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /All Positions/i })).toBeInTheDocument();
+  });
+
+  it('shows Unsaved badge when positions differ from DB state', () => {
+    const tracker = makeTracker({
+      databasePositions: [],
+      databaseHasPositions: false,
+      wikipediaPositions: [
+        { id: 16, name: 'ST', fullName: 'Striker', originalWikipediaName: 'Forward' },
+      ],
+      message: 'Test',
+    });
+
+    render(<PositionCard positionsTracker={tracker} playerFoundInDB footballerId={42} />);
+
+    expect(screen.getByText('Unsaved')).toBeInTheDocument();
+  });
+
+  it('calls onSelectedPositionsChange when positions initialize', async () => {
+    const onChange = vi.fn();
+    const tracker = makeTracker({
+      wikipediaPositions: [
+        { id: 16, name: 'ST', fullName: 'Striker', originalWikipediaName: 'Forward' },
+      ],
+      message: 'Test',
+    });
+
+    render(
+      <PositionCard
+        positionsTracker={tracker}
+        onSelectedPositionsChange={onChange}
+      />,
+    );
+
+    // useEffect should fire and call onChange with the wikipedia positions
+    expect(onChange).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          position_id: 16,
+          name: 'ST',
+          is_primary: true,
+        }),
+      ]),
+    );
   });
 });

--- a/components/career-lookup/career-lookup-info.tsx
+++ b/components/career-lookup/career-lookup-info.tsx
@@ -14,7 +14,7 @@ type CareerLookupInfoProps = {
   onDataSourceChange?: (dataSource: 'wikipedia' | 'database') => void;
   onNationStatsUpdated?: () => void;
   onSelectedPositionsChange?: (positions: SelectedPosition[]) => void;
-  onPositionsApplied?: () => void;
+  onPositionsSaved?: () => void;
   className?: string;
 };
 
@@ -26,7 +26,7 @@ export function CareerLookupInfo({
   onDataSourceChange,
   onNationStatsUpdated,
   onSelectedPositionsChange,
-  onPositionsApplied,
+  onPositionsSaved,
   className,
 }: CareerLookupInfoProps) {
   return (
@@ -62,7 +62,7 @@ export function CareerLookupInfo({
             footballerId={dbPlayerInfo?.id ?? null}
             playerFoundInDB={playerData.playerFoundInDB}
             onSelectedPositionsChange={onSelectedPositionsChange}
-            onPositionsApplied={onPositionsApplied}
+            onPositionsApplied={onPositionsSaved}
           />
         </div>
       </div>

--- a/components/career-lookup/career-lookup-info.tsx
+++ b/components/career-lookup/career-lookup-info.tsx
@@ -2,6 +2,7 @@ import type { Footballer, FootballerNationStat, n8nWikiPlayerData } from '@/type
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { InternationalCareerCard } from './international-career-card';
 import { PlayerProfileCard } from './player-profile-card';
+import type { SelectedPosition } from './position-card';
 import { PositionCard } from './position-card';
 import { SeniorCareerCard } from './senior-career-card';
 
@@ -12,6 +13,7 @@ type CareerLookupInfoProps = {
   chosenDataSource?: 'wikipedia' | 'database' | null;
   onDataSourceChange?: (dataSource: 'wikipedia' | 'database') => void;
   onNationStatsUpdated?: () => void;
+  onSelectedPositionsChange?: (positions: SelectedPosition[]) => void;
   className?: string;
 };
 
@@ -22,6 +24,7 @@ export function CareerLookupInfo({
   chosenDataSource,
   onDataSourceChange,
   onNationStatsUpdated,
+  onSelectedPositionsChange,
   className,
 }: CareerLookupInfoProps) {
   return (
@@ -37,7 +40,7 @@ export function CareerLookupInfo({
         </div>
 
         {/* Right Content - Career History */}
-        <div className="lg:col-span-3">
+        <div className="space-y-6 lg:col-span-3">
           <SeniorCareerCard
             playerData={playerData}
             dbPlayerInfo={dbPlayerInfo}
@@ -56,6 +59,7 @@ export function CareerLookupInfo({
             positionsTracker={playerData.positionsTracker}
             footballerId={dbPlayerInfo?.id ?? null}
             playerFoundInDB={playerData.playerFoundInDB}
+            onSelectedPositionsChange={onSelectedPositionsChange}
           />
         </div>
       </div>

--- a/components/career-lookup/career-lookup-info.tsx
+++ b/components/career-lookup/career-lookup-info.tsx
@@ -14,6 +14,7 @@ type CareerLookupInfoProps = {
   onDataSourceChange?: (dataSource: 'wikipedia' | 'database') => void;
   onNationStatsUpdated?: () => void;
   onSelectedPositionsChange?: (positions: SelectedPosition[]) => void;
+  onPositionsApplied?: () => void;
   className?: string;
 };
 
@@ -25,6 +26,7 @@ export function CareerLookupInfo({
   onDataSourceChange,
   onNationStatsUpdated,
   onSelectedPositionsChange,
+  onPositionsApplied,
   className,
 }: CareerLookupInfoProps) {
   return (
@@ -60,6 +62,7 @@ export function CareerLookupInfo({
             footballerId={dbPlayerInfo?.id ?? null}
             playerFoundInDB={playerData.playerFoundInDB}
             onSelectedPositionsChange={onSelectedPositionsChange}
+            onPositionsApplied={onPositionsApplied}
           />
         </div>
       </div>

--- a/components/career-lookup/career-lookup-info.tsx
+++ b/components/career-lookup/career-lookup-info.tsx
@@ -2,6 +2,7 @@ import type { Footballer, FootballerNationStat, n8nWikiPlayerData } from '@/type
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { InternationalCareerCard } from './international-career-card';
 import { PlayerProfileCard } from './player-profile-card';
+import { PositionCard } from './position-card';
 import { SeniorCareerCard } from './senior-career-card';
 
 type CareerLookupInfoProps = {
@@ -49,6 +50,12 @@ export function CareerLookupInfo({
             dbNationalTeams={dbNationalTeams}
             footballerId={dbPlayerInfo?.id ?? null}
             onNationStatsUpdated={onNationStatsUpdated}
+          />
+
+          <PositionCard
+            positionsTracker={playerData.positionsTracker}
+            footballerId={dbPlayerInfo?.id ?? null}
+            playerFoundInDB={playerData.playerFoundInDB}
           />
         </div>
       </div>

--- a/components/career-lookup/career-lookup-player-configuration.tsx
+++ b/components/career-lookup/career-lookup-player-configuration.tsx
@@ -441,8 +441,23 @@ export function CareerLookupPlayerConfiguration({
     return nationChanges.creates.length > 0 || nationChanges.updates.length > 0;
   };
 
+  const hasPositionChanges = () => {
+    if (!selectedPositions || selectedPositions.length === 0) return false;
+    if (!playerData?.playerFoundInDB || !dbPlayerInfo) return selectedPositions.length > 0;
+    const tracker = playerData.positionsTracker;
+    if (!tracker) return selectedPositions.length > 0;
+    const dbIds = new Set(tracker.databasePositions.map(p => p.id));
+    const selIds = new Set(selectedPositions.map(p => p.position_id));
+    if (selIds.size !== dbIds.size) return true;
+    if ([...selIds].some(id => !dbIds.has(id))) return true;
+    return selectedPositions.some(sp => {
+      const dbP = tracker.databasePositions.find(d => d.id === sp.position_id);
+      return dbP && dbP.isPrimary !== sp.is_primary;
+    });
+  };
+
   const handleUpdatePlayer = async () => {
-    if (!dbPlayerInfo || (!hasChanges() && !hasTeamChanges() && !hasNationChanges())) {
+    if (!dbPlayerInfo || (!hasChanges() && !hasTeamChanges() && !hasNationChanges() && !hasPositionChanges())) {
       return;
     }
 
@@ -457,7 +472,7 @@ export function CareerLookupPlayerConfiguration({
     const playerChanges = getPlayerChanges();
     const teamChanges = getTeamChanges();
 
-    if (!playerChanges && !hasTeamChanges() && !hasNationChanges()) {
+    if (!playerChanges && !hasTeamChanges() && !hasNationChanges() && !hasPositionChanges()) {
       addDeploymentLog('info', '💡 No changes detected - Update cancelled');
       return;
     }
@@ -1192,14 +1207,14 @@ export function CareerLookupPlayerConfiguration({
               disabled={
                 deploying
                 || (!playerData?.playerFoundInDB && playerData.summary.notFoundTeams > 0)
-                || (playerData?.playerFoundInDB && !hasChanges() && !hasTeamChanges() && !hasNationChanges())
+                || (playerData?.playerFoundInDB && !hasChanges() && !hasTeamChanges() && !hasNationChanges() && !hasPositionChanges())
               }
             >
               <Save className="mr-2 size-5" />
               {deploying
                 ? (playerData?.playerFoundInDB ? 'Updating...' : 'Deploying...')
                 : playerData?.playerFoundInDB
-                  ? (hasChanges() || hasTeamChanges() || hasNationChanges() ? 'Update Footballer' : 'No Changes Detected')
+                  ? (hasChanges() || hasTeamChanges() || hasNationChanges() || hasPositionChanges() ? 'Update Footballer' : 'No Changes Detected')
                   : 'Deploy Footballer'}
             </Button>
           </div>
@@ -1208,16 +1223,16 @@ export function CareerLookupPlayerConfiguration({
             ? (
                 playerData?.playerFoundInDB
                   ? (
-                      (hasChanges() || hasTeamChanges() || hasNationChanges())
+                      (hasChanges() || hasTeamChanges() || hasNationChanges() || hasPositionChanges())
                         ? (
                             <p className="text-center text-sm font-medium text-blue-600">
                               ✏️ Changes detected - Ready to update existing player
-                              {hasChanges() && (hasTeamChanges() || hasNationChanges()) && ' and'}
+                              {hasChanges() && (hasTeamChanges() || hasNationChanges() || hasPositionChanges()) && ' and'}
                               {hasTeamChanges() && ' teams'}
-                              {hasTeamChanges() && hasNationChanges() && ' and'}
+                              {hasTeamChanges() && (hasNationChanges() || hasPositionChanges()) && ' and'}
                               {hasNationChanges() && ' nations'}
-                              {!hasChanges() && hasTeamChanges() && !hasNationChanges() && ' teams'}
-                              {!hasChanges() && !hasTeamChanges() && hasNationChanges() && ' nations'}
+                              {hasNationChanges() && hasPositionChanges() && ' and'}
+                              {hasPositionChanges() && ' positions'}
                             </p>
                           )
                         : (

--- a/components/career-lookup/career-lookup-player-configuration.tsx
+++ b/components/career-lookup/career-lookup-player-configuration.tsx
@@ -1,5 +1,5 @@
 import type { DeploymentLogEntry } from '@/components/career-lookup/deployment-console';
-import type { CreateFootballerNationRequest, CreateFootballerRequest, CreateFootballerTeamRequest, Footballer, FootballerNationStat, n8nWikiPlayerData, PlayerConfiguration, SetPositionsRequest } from '@/types/player';
+import type { CreateFootballerNationRequest, CreateFootballerRequest, CreateFootballerTeamRequest, Footballer, FootballerNationStat, FootballerPosition, n8nWikiPlayerData, PlayerConfiguration, SetPositionsRequest } from '@/types/player';
 import type { SelectedPosition } from '@/components/career-lookup/position-card';
 import { AlertTriangle, Edit, RefreshCcw, RotateCcw, Save } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
@@ -33,7 +33,7 @@ type CareerLookupPlayerConfigurationProps = {
 
   // Position selections from PositionCard
   selectedPositions?: SelectedPosition[];
-  positionsSynced?: boolean;
+  dbFootballerPositions?: FootballerPosition[];
 
   className?: string;
 };
@@ -47,7 +47,7 @@ export function CareerLookupPlayerConfiguration({
   onReloadPlayer,
   onNationStatsUpdated,
   selectedPositions,
-  positionsSynced,
+  dbFootballerPositions,
   className,
 }: CareerLookupPlayerConfigurationProps) {
   const { user } = useAuth();
@@ -444,18 +444,16 @@ export function CareerLookupPlayerConfiguration({
   };
 
   const hasPositionChanges = () => {
-    if (positionsSynced) return false;
     if (!selectedPositions || selectedPositions.length === 0) return false;
     if (!playerData?.playerFoundInDB || !dbPlayerInfo) return selectedPositions.length > 0;
-    const tracker = playerData.positionsTracker;
-    if (!tracker) return selectedPositions.length > 0;
-    const dbIds = new Set(tracker.databasePositions.map(p => p.id));
+    // Compare against fresh DB data (refetched after saves)
+    const dbIds = new Set(dbFootballerPositions?.map(p => p.position_id) ?? []);
     const selIds = new Set(selectedPositions.map(p => p.position_id));
     if (selIds.size !== dbIds.size) return true;
     if ([...selIds].some(id => !dbIds.has(id))) return true;
     return selectedPositions.some(sp => {
-      const dbP = tracker.databasePositions.find(d => d.id === sp.position_id);
-      return dbP && dbP.isPrimary !== sp.is_primary;
+      const dbP = dbFootballerPositions?.find(d => d.position_id === sp.position_id);
+      return dbP && dbP.is_primary !== sp.is_primary;
     });
   };
 
@@ -1168,7 +1166,7 @@ export function CareerLookupPlayerConfiguration({
           chosenDataSource={chosenDataSource}
           dbNationalTeams={dbNationalTeams}
           selectedPositions={selectedPositions}
-          positionsSynced={positionsSynced}
+          dbFootballerPositions={dbFootballerPositions}
         />
 
         <Separator className="my-8" />

--- a/components/career-lookup/career-lookup-player-configuration.tsx
+++ b/components/career-lookup/career-lookup-player-configuration.tsx
@@ -1,5 +1,6 @@
 import type { DeploymentLogEntry } from '@/components/career-lookup/deployment-console';
 import type { CreateFootballerNationRequest, CreateFootballerRequest, CreateFootballerTeamRequest, Footballer, FootballerNationStat, n8nWikiPlayerData, PlayerConfiguration, SetPositionsRequest } from '@/types/player';
+import type { SelectedPosition } from '@/components/career-lookup/position-card';
 import { AlertTriangle, Edit, RefreshCcw, RotateCcw, Save } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { createLogEntry, DeploymentConsole } from '@/components/career-lookup/deployment-console';
@@ -30,6 +31,9 @@ type CareerLookupPlayerConfigurationProps = {
   onReloadPlayer?: () => void;
   onNationStatsUpdated?: () => void;
 
+  // Position selections from PositionCard
+  selectedPositions?: SelectedPosition[];
+
   className?: string;
 };
 
@@ -41,6 +45,7 @@ export function CareerLookupPlayerConfiguration({
   onErrorChange,
   onReloadPlayer,
   onNationStatsUpdated,
+  selectedPositions,
   className,
 }: CareerLookupPlayerConfigurationProps) {
   const { user } = useAuth();
@@ -1155,6 +1160,7 @@ export function CareerLookupPlayerConfiguration({
           dbPlayerInfo={dbPlayerInfo}
           chosenDataSource={chosenDataSource}
           dbNationalTeams={dbNationalTeams}
+          selectedPositions={selectedPositions}
         />
 
         <Separator className="my-8" />

--- a/components/career-lookup/career-lookup-player-configuration.tsx
+++ b/components/career-lookup/career-lookup-player-configuration.tsx
@@ -623,26 +623,16 @@ export function CareerLookupPlayerConfiguration({
         onNationStatsUpdated?.();
       }
 
-      // Sync positions if there's a discrepancy
-      if (playerData.positionsTracker?.hasDiscrepancy && playerData.positionsTracker.missingIdsToApply.length > 0 && dbPlayerInfo.id) {
-        const tracker = playerData.positionsTracker;
-        addDeploymentLog('info', `📍 Position discrepancy: ${tracker.missingInDatabase.length} missing position(s)`);
-
-        // Merge existing DB positions with missing ones
-        const existingDbIds = new Set(tracker.databasePositions.map(p => p.id));
-        const allPositionIds = [
-          ...tracker.databasePositions.map(p => p.id),
-          ...tracker.missingIdsToApply.filter(id => !existingDbIds.has(id)),
-        ];
-
-        const existingPrimary = tracker.databasePositions.find(p => p.isPrimary);
+      // Sync positions if user has made changes (and positions are enabled)
+      if (hasPositionChanges() && selectedPositions && selectedPositions.length > 0 && dbPlayerInfo.id) {
+        addDeploymentLog('info', `📍 Syncing ${selectedPositions.length} position(s)`);
 
         const positionsRequest: SetPositionsRequest = {
           footballer_id: dbPlayerInfo.id,
-          positions: allPositionIds.map((id, index) => ({
-            position_id: id,
-            is_primary: existingPrimary ? id === existingPrimary.id : index === 0,
-            sort_order: index,
+          positions: selectedPositions.map(p => ({
+            position_id: p.position_id,
+            is_primary: p.is_primary,
+            sort_order: p.sort_order,
           })),
         };
 
@@ -672,8 +662,8 @@ export function CareerLookupPlayerConfiguration({
         const totalNationOps = nationChanges.updates.length + nationChanges.creates.length;
         operations.push(`${totalNationOps} nation operations completed`);
       }
-      if (playerData.positionsTracker?.hasDiscrepancy && playerData.positionsTracker.missingIdsToApply.length > 0) {
-        operations.push(`${playerData.positionsTracker.missingIdsToApply.length} position(s) synced`);
+      if (hasPositionChanges()) {
+        operations.push(`${selectedPositions?.length ?? 0} position(s) synced`);
       }
 
       addDeploymentLog('success', `🎉 Update completed! ${operations.join(', ')}`);
@@ -827,17 +817,16 @@ export function CareerLookupPlayerConfiguration({
         onNationStatsUpdated?.();
       }
 
-      // Assign positions from positionsTracker
-      const positionIds = playerData.positionsTracker?.missingIdsToApply ?? [];
-      if (positionIds.length > 0) {
-        addDeploymentLog('info', `📍 Found ${positionIds.length} position(s) to assign`);
+      // Assign positions from selectedPositions (when enabled)
+      if (selectedPositions && selectedPositions.length > 0) {
+        addDeploymentLog('info', `📍 Found ${selectedPositions.length} position(s) to assign`);
 
         const positionsRequest: SetPositionsRequest = {
           footballer_id: createdFootballer.id,
-          positions: positionIds.map((id, index) => ({
-            position_id: id,
-            is_primary: index === 0,
-            sort_order: index,
+          positions: selectedPositions.map(p => ({
+            position_id: p.position_id,
+            is_primary: p.is_primary,
+            sort_order: p.sort_order,
           })),
         };
 

--- a/components/career-lookup/career-lookup-player-configuration.tsx
+++ b/components/career-lookup/career-lookup-player-configuration.tsx
@@ -33,6 +33,7 @@ type CareerLookupPlayerConfigurationProps = {
 
   // Position selections from PositionCard
   selectedPositions?: SelectedPosition[];
+  positionsSynced?: boolean;
 
   className?: string;
 };
@@ -46,6 +47,7 @@ export function CareerLookupPlayerConfiguration({
   onReloadPlayer,
   onNationStatsUpdated,
   selectedPositions,
+  positionsSynced,
   className,
 }: CareerLookupPlayerConfigurationProps) {
   const { user } = useAuth();
@@ -442,6 +444,7 @@ export function CareerLookupPlayerConfiguration({
   };
 
   const hasPositionChanges = () => {
+    if (positionsSynced) return false;
     if (!selectedPositions || selectedPositions.length === 0) return false;
     if (!playerData?.playerFoundInDB || !dbPlayerInfo) return selectedPositions.length > 0;
     const tracker = playerData.positionsTracker;
@@ -1165,6 +1168,7 @@ export function CareerLookupPlayerConfiguration({
           chosenDataSource={chosenDataSource}
           dbNationalTeams={dbNationalTeams}
           selectedPositions={selectedPositions}
+          positionsSynced={positionsSynced}
         />
 
         <Separator className="my-8" />

--- a/components/career-lookup/career-lookup-player-configuration.tsx
+++ b/components/career-lookup/career-lookup-player-configuration.tsx
@@ -1,5 +1,5 @@
 import type { DeploymentLogEntry } from '@/components/career-lookup/deployment-console';
-import type { CreateFootballerNationRequest, CreateFootballerRequest, CreateFootballerTeamRequest, Footballer, FootballerNationStat, n8nWikiPlayerData, PlayerConfiguration } from '@/types/player';
+import type { CreateFootballerNationRequest, CreateFootballerRequest, CreateFootballerTeamRequest, Footballer, FootballerNationStat, n8nWikiPlayerData, PlayerConfiguration, SetPositionsRequest } from '@/types/player';
 import { AlertTriangle, Edit, RefreshCcw, RotateCcw, Save } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { createLogEntry, DeploymentConsole } from '@/components/career-lookup/deployment-console';
@@ -603,6 +603,42 @@ export function CareerLookupPlayerConfiguration({
         onNationStatsUpdated?.();
       }
 
+      // Sync positions if there's a discrepancy
+      if (playerData.positionsTracker?.hasDiscrepancy && playerData.positionsTracker.missingIdsToApply.length > 0 && dbPlayerInfo.id) {
+        const tracker = playerData.positionsTracker;
+        addDeploymentLog('info', `📍 Position discrepancy: ${tracker.missingInDatabase.length} missing position(s)`);
+
+        // Merge existing DB positions with missing ones
+        const existingDbIds = new Set(tracker.databasePositions.map(p => p.id));
+        const allPositionIds = [
+          ...tracker.databasePositions.map(p => p.id),
+          ...tracker.missingIdsToApply.filter(id => !existingDbIds.has(id)),
+        ];
+
+        const existingPrimary = tracker.databasePositions.find(p => p.isPrimary);
+
+        const positionsRequest: SetPositionsRequest = {
+          footballer_id: dbPlayerInfo.id,
+          positions: allPositionIds.map((id, index) => ({
+            position_id: id,
+            is_primary: existingPrimary ? id === existingPrimary.id : index === 0,
+            sort_order: index,
+          })),
+        };
+
+        try {
+          addDeploymentLog('loading', 'Syncing positions...');
+          addDeploymentLog('request', 'POST /data/footballer-positions/set-positions/', positionsRequest);
+
+          const updatedPositions = await FootballerAPI.setPositions(positionsRequest);
+
+          addDeploymentLog('response', `✅ ${updatedPositions.length} position(s) synced`, updatedPositions);
+        } catch (posError) {
+          addDeploymentLog('error', `❌ Failed to sync positions: ${posError instanceof Error ? posError.message : 'Unknown error'}`);
+          console.error('Failed to sync positions:', posError);
+        }
+      }
+
       // Final success message
       const operations = [];
       if (playerChanges) {
@@ -615,6 +651,9 @@ export function CareerLookupPlayerConfiguration({
       if (hasNationChanges()) {
         const totalNationOps = nationChanges.updates.length + nationChanges.creates.length;
         operations.push(`${totalNationOps} nation operations completed`);
+      }
+      if (playerData.positionsTracker?.hasDiscrepancy && playerData.positionsTracker.missingIdsToApply.length > 0) {
+        operations.push(`${playerData.positionsTracker.missingIdsToApply.length} position(s) synced`);
       }
 
       addDeploymentLog('success', `🎉 Update completed! ${operations.join(', ')}`);
@@ -766,6 +805,33 @@ export function CareerLookupPlayerConfiguration({
 
         addDeploymentLog('success', `🏳️ Nation stats: ${createdNations}/${foundNations.length} records created`);
         onNationStatsUpdated?.();
+      }
+
+      // Assign positions from positionsTracker
+      const positionIds = playerData.positionsTracker?.missingIdsToApply ?? [];
+      if (positionIds.length > 0) {
+        addDeploymentLog('info', `📍 Found ${positionIds.length} position(s) to assign`);
+
+        const positionsRequest: SetPositionsRequest = {
+          footballer_id: createdFootballer.id,
+          positions: positionIds.map((id, index) => ({
+            position_id: id,
+            is_primary: index === 0,
+            sort_order: index,
+          })),
+        };
+
+        try {
+          addDeploymentLog('loading', 'Assigning positions...');
+          addDeploymentLog('request', 'POST /data/footballer-positions/set-positions/', positionsRequest);
+
+          const createdPositions = await FootballerAPI.setPositions(positionsRequest);
+
+          addDeploymentLog('response', `✅ ${createdPositions.length} position(s) assigned`, createdPositions);
+        } catch (posError) {
+          addDeploymentLog('error', `❌ Failed to assign positions: ${posError instanceof Error ? posError.message : 'Unknown error'}`);
+          console.error('Failed to assign positions:', posError);
+        }
       }
 
       setDeploymentComplete(true);

--- a/components/career-lookup/json-command-preview.tsx
+++ b/components/career-lookup/json-command-preview.tsx
@@ -36,6 +36,7 @@ type JsonCommandPreviewProps = {
   chosenDataSource?: 'wikipedia' | 'database' | null;
   dbNationalTeams?: FootballerNationStat[];
   selectedPositions?: SelectedPosition[];
+  positionsSynced?: boolean;
 };
 
 export function JsonCommandPreview({
@@ -45,6 +46,7 @@ export function JsonCommandPreview({
   chosenDataSource,
   dbNationalTeams,
   selectedPositions,
+  positionsSynced,
 }: JsonCommandPreviewProps) {
   const { user } = useAuth();
   const [copiedStates, setCopiedStates] = useState<{ [key: string]: boolean }>({});
@@ -300,6 +302,10 @@ export function JsonCommandPreview({
 
   // Compute position operations from selectedPositions
   const getPositionOps = useMemo(() => {
+    if (positionsSynced) {
+      return { hasChanges: false, positionsPayload: null };
+    }
+
     if (!selectedPositions || selectedPositions.length === 0) {
       return { hasChanges: false, positionsPayload: null };
     }
@@ -347,7 +353,7 @@ export function JsonCommandPreview({
     }
 
     return { hasChanges: false, positionsPayload: null };
-  }, [selectedPositions, playerData, dbPlayerInfo, isExistingPlayer]);
+  }, [selectedPositions, playerData, dbPlayerInfo, isExistingPlayer, positionsSynced]);
 
   const hasPositionChanges = getPositionOps.hasChanges;
 

--- a/components/career-lookup/json-command-preview.tsx
+++ b/components/career-lookup/json-command-preview.tsx
@@ -496,7 +496,7 @@ ${JSON.stringify(data, null, 2)}`;
               API Commands Preview
               {isExistingPlayer && (
                 <Badge variant="outline" className="border-blue-200 bg-blue-50 text-blue-700">
-                  {hasChanges ? 'Update Mode' : 'No Changes'}
+                  {hasChanges || hasTeamChanges || hasNationChanges || hasPositionChanges ? 'Has Changes' : 'No Changes'}
                 </Badge>
               )}
             </CardTitle>

--- a/components/career-lookup/json-command-preview.tsx
+++ b/components/career-lookup/json-command-preview.tsx
@@ -6,6 +6,7 @@ import type {
   CreateFootballerTeamRequest,
   Footballer,
   FootballerNationStat,
+  FootballerPosition,
   n8nWikiPlayerData,
   PlayerConfiguration,
 } from '@/types/player';
@@ -36,7 +37,7 @@ type JsonCommandPreviewProps = {
   chosenDataSource?: 'wikipedia' | 'database' | null;
   dbNationalTeams?: FootballerNationStat[];
   selectedPositions?: SelectedPosition[];
-  positionsSynced?: boolean;
+  dbFootballerPositions?: FootballerPosition[];
 };
 
 export function JsonCommandPreview({
@@ -46,7 +47,7 @@ export function JsonCommandPreview({
   chosenDataSource,
   dbNationalTeams,
   selectedPositions,
-  positionsSynced,
+  dbFootballerPositions,
 }: JsonCommandPreviewProps) {
   const { user } = useAuth();
   const [copiedStates, setCopiedStates] = useState<{ [key: string]: boolean }>({});
@@ -300,17 +301,12 @@ export function JsonCommandPreview({
 
   const hasNationChanges = getNationChanges.creates.length > 0 || getNationChanges.updates.length > 0;
 
-  // Compute position operations from selectedPositions
+  // Compute position operations from selectedPositions vs fresh DB data
   const getPositionOps = useMemo(() => {
-    if (positionsSynced) {
-      return { hasChanges: false, positionsPayload: null };
-    }
-
     if (!selectedPositions || selectedPositions.length === 0) {
       return { hasChanges: false, positionsPayload: null };
     }
 
-    const positionsTracker = playerData?.positionsTracker;
     const footballerId = dbPlayerInfo?.id;
 
     // For new players, show positions that will be assigned on deploy
@@ -326,17 +322,17 @@ export function JsonCommandPreview({
       return { hasChanges: true, positionsPayload: payload };
     }
 
-    // For existing players, check if positions differ from DB
-    if (positionsTracker && footballerId) {
-      const dbIds = new Set(positionsTracker.databasePositions.map(p => p.id));
+    // For existing players, compare against fresh DB positions
+    if (footballerId) {
+      const dbIds = new Set(dbFootballerPositions?.map(p => p.position_id) ?? []);
       const selectedIds = new Set(selectedPositions.map(p => p.position_id));
       const hasChange =
         selectedIds.size !== dbIds.size
         || [...selectedIds].some(id => !dbIds.has(id))
         || [...dbIds].some(id => !selectedIds.has(id))
         || selectedPositions.some(sp => {
-          const dbP = positionsTracker.databasePositions.find(d => d.id === sp.position_id);
-          return dbP && dbP.isPrimary !== sp.is_primary;
+          const dbP = dbFootballerPositions?.find(d => d.position_id === sp.position_id);
+          return dbP && dbP.is_primary !== sp.is_primary;
         });
 
       if (hasChange) {
@@ -353,7 +349,7 @@ export function JsonCommandPreview({
     }
 
     return { hasChanges: false, positionsPayload: null };
-  }, [selectedPositions, playerData, dbPlayerInfo, isExistingPlayer, positionsSynced]);
+  }, [selectedPositions, dbPlayerInfo, isExistingPlayer, dbFootballerPositions]);
 
   const hasPositionChanges = getPositionOps.hasChanges;
 

--- a/components/career-lookup/json-command-preview.tsx
+++ b/components/career-lookup/json-command-preview.tsx
@@ -9,6 +9,7 @@ import type {
   n8nWikiPlayerData,
   PlayerConfiguration,
 } from '@/types/player';
+import type { SelectedPosition } from '@/components/career-lookup/position-card';
 import { AlertTriangle, Check, ChevronDown, ChevronUp, Code, Copy, FileText } from 'lucide-react';
 import React, { useMemo, useState } from 'react';
 import { Badge } from '@/components/ui/badge';
@@ -34,6 +35,7 @@ type JsonCommandPreviewProps = {
   dbPlayerInfo?: Footballer | null;
   chosenDataSource?: 'wikipedia' | 'database' | null;
   dbNationalTeams?: FootballerNationStat[];
+  selectedPositions?: SelectedPosition[];
 };
 
 export function JsonCommandPreview({
@@ -42,6 +44,7 @@ export function JsonCommandPreview({
   dbPlayerInfo,
   chosenDataSource,
   dbNationalTeams,
+  selectedPositions,
 }: JsonCommandPreviewProps) {
   const { user } = useAuth();
   const [copiedStates, setCopiedStates] = useState<{ [key: string]: boolean }>({});
@@ -295,6 +298,59 @@ export function JsonCommandPreview({
 
   const hasNationChanges = getNationChanges.creates.length > 0 || getNationChanges.updates.length > 0;
 
+  // Compute position operations from selectedPositions
+  const getPositionOps = useMemo(() => {
+    if (!selectedPositions || selectedPositions.length === 0) {
+      return { hasChanges: false, positionsPayload: null };
+    }
+
+    const positionsTracker = playerData?.positionsTracker;
+    const footballerId = dbPlayerInfo?.id;
+
+    // For new players, show positions that will be assigned on deploy
+    if (!isExistingPlayer) {
+      const payload = {
+        footballer_id: '{{footballer_id}}',
+        positions: selectedPositions.map(p => ({
+          position_id: p.position_id,
+          is_primary: p.is_primary,
+          sort_order: p.sort_order,
+        })),
+      };
+      return { hasChanges: true, positionsPayload: payload };
+    }
+
+    // For existing players, check if positions differ from DB
+    if (positionsTracker && footballerId) {
+      const dbIds = new Set(positionsTracker.databasePositions.map(p => p.id));
+      const selectedIds = new Set(selectedPositions.map(p => p.position_id));
+      const hasChange =
+        selectedIds.size !== dbIds.size
+        || [...selectedIds].some(id => !dbIds.has(id))
+        || [...dbIds].some(id => !selectedIds.has(id))
+        || selectedPositions.some(sp => {
+          const dbP = positionsTracker.databasePositions.find(d => d.id === sp.position_id);
+          return dbP && dbP.isPrimary !== sp.is_primary;
+        });
+
+      if (hasChange) {
+        const payload = {
+          footballer_id: footballerId,
+          positions: selectedPositions.map(p => ({
+            position_id: p.position_id,
+            is_primary: p.is_primary,
+            sort_order: p.sort_order,
+          })),
+        };
+        return { hasChanges: true, positionsPayload: payload };
+      }
+    }
+
+    return { hasChanges: false, positionsPayload: null };
+  }, [selectedPositions, playerData, dbPlayerInfo, isExistingPlayer]);
+
+  const hasPositionChanges = getPositionOps.hasChanges;
+
   // Generate footballer creation/update JSON
   const footballerJson = useMemo(() => {
     if (!playerData || !playerConfig.countryID || !user) {
@@ -446,8 +502,8 @@ ${JSON.stringify(data, null, 2)}`;
             </CardTitle>
             <CardDescription>
               {isExistingPlayer
-                ? hasChanges || hasTeamChanges || hasNationChanges
-                  ? `JSON commands that will be executed to update the existing footballer record${hasTeamChanges ? ' and team records' : ''}${hasNationChanges ? ' and nation stats' : ''}`
+                ? hasChanges || hasTeamChanges || hasNationChanges || hasPositionChanges
+                  ? `JSON commands that will be executed to update the existing footballer record${hasTeamChanges ? ' and team records' : ''}${hasNationChanges ? ' and nation stats' : ''}${hasPositionChanges ? ' and positions' : ''}`
                   : `Current footballer data matches database - no updates needed`
                 : `JSON commands that will be executed to create the footballer and team records`}
               {isExistingPlayer && chosenDataSource !== 'wikipedia' && chosenDataSource === 'database' && playerData?.teams && dbPlayerInfo?.teams_played_for && (
@@ -479,11 +535,12 @@ ${JSON.stringify(data, null, 2)}`;
               <Tabs defaultValue="footballer" className="w-full">
                 <div className="mb-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                   <TabsList className={`grid w-full sm:w-auto ${
-                    (isExistingPlayer && hasTeamChanges && hasNationChanges) || (!isExistingPlayer && footballerTeamsJson.length > 0 && hasNationChanges)
-                      ? 'grid-cols-3'
-                      : (isExistingPlayer && hasTeamChanges) || (!isExistingPlayer && footballerTeamsJson.length > 0) || hasNationChanges
-                        ? 'grid-cols-2'
-                        : 'grid-cols-1'
+                    (() => {
+                      const showTeams = (!isExistingPlayer && footballerTeamsJson.length > 0) || (isExistingPlayer && hasTeamChanges);
+                      const tabCount = 1 + (showTeams ? 1 : 0) + (hasNationChanges ? 1 : 0) + (hasPositionChanges ? 1 : 0);
+                      const colsMap: Record<number, string> = { 1: 'grid-cols-1', 2: 'grid-cols-2', 3: 'grid-cols-3', 4: 'grid-cols-4' };
+                      return colsMap[Math.min(tabCount, 4)] || 'grid-cols-1';
+                    })()
                   }`}
                   >
                     <TabsTrigger value="footballer" className="text-xs sm:text-sm">
@@ -510,6 +567,15 @@ ${JSON.stringify(data, null, 2)}`;
                         <span className="sm:hidden">Nations</span>
                         <Badge variant="secondary" className="ml-1 text-xs sm:ml-2">
                           {getNationChanges.updates.length + getNationChanges.creates.length}
+                        </Badge>
+                      </TabsTrigger>
+                    )}
+                    {hasPositionChanges && (
+                      <TabsTrigger value="positions" className="text-xs sm:text-sm">
+                        <span className="hidden sm:inline">{isExistingPlayer ? 'Position Sync' : 'Set Positions'}</span>
+                        <span className="sm:hidden">Positions</span>
+                        <Badge variant="secondary" className="ml-1 text-xs sm:ml-2">
+                          {selectedPositions?.length ?? 0}
                         </Badge>
                       </TabsTrigger>
                     )}
@@ -897,6 +963,79 @@ ${JSON.stringify(data, null, 2)}`;
                     )}
                   </div>
                 </TabsContent>
+
+                {/* Positions Tab */}
+                <TabsContent value="positions" className="space-y-3">
+                  <div className="flex items-center justify-between">
+                    <h4 className="text-sm font-medium">
+                      {isExistingPlayer ? 'Position Sync' : 'Set Positions'}
+                    </h4>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => {
+                        if (!getPositionOps.positionsPayload) return;
+                        const posOp = {
+                          operation: isExistingPlayer ? 'SYNC' : 'SET',
+                          endpoint: '/data/footballer-positions/set-positions/',
+                          method: 'POST',
+                          data: getPositionOps.positionsPayload,
+                        };
+                        const content = showAsHttpRequest
+                          ? `// ${posOp.operation} Positions\n${generateHttpRequest(posOp.endpoint, posOp.method, posOp.data)}`
+                          : JSON.stringify(posOp, null, 2);
+                        copyToClipboard(content, 'positions');
+                      }}
+                      className="w-full sm:w-auto"
+                    >
+                      {copiedStates.positions ? <Check className="size-4" /> : <Copy className="size-4" />}
+                      <span className="ml-2">{copiedStates.positions ? 'Copied' : 'Copy'}</span>
+                    </Button>
+                  </div>
+
+                  {getPositionOps.positionsPayload ? (
+                    <div>
+                      <h5 className="mb-2 text-xs font-medium text-purple-700 dark:text-purple-400 sm:text-sm">
+                        {isExistingPlayer ? 'Sync' : 'Set'}
+                        {' '}
+                        Positions (
+                        {selectedPositions?.length ?? 0}
+                        )
+                      </h5>
+                      <ScrollArea className="h-48 w-full rounded-lg border">
+                        <div className="space-y-3 bg-purple-50 p-3 dark:bg-purple-900/20 sm:p-4">
+                          <div className="border-b border-purple-200 pb-2 last:border-b-0 last:pb-0 dark:border-purple-700">
+                            <p className="mb-1 break-all text-[10px] font-medium text-purple-800 dark:text-purple-300 sm:text-xs">
+                              POST /data/footballer-positions/set-positions/
+                            </p>
+                            <pre className="overflow-x-auto font-mono text-[10px] text-gray-700 dark:text-gray-300 sm:text-xs">
+                              <code>
+                                {showAsHttpRequest
+                                  ? generateHttpRequest('/data/footballer-positions/set-positions/', 'POST', getPositionOps.positionsPayload)
+                                  : JSON.stringify(getPositionOps.positionsPayload, null, 2)}
+                              </code>
+                            </pre>
+                          </div>
+
+                          {/* Show individual positions being set */}
+                          <div className="mt-2 space-y-1">
+                            {selectedPositions?.map(pos => (
+                              <div key={pos.position_id} className="flex items-center gap-2 text-xs text-purple-700 dark:text-purple-300">
+                                <span className="font-mono">{pos.name}</span>
+                                <span className="opacity-60">{pos.full_name}</span>
+                                {pos.is_primary && <span className="font-medium text-amber-600 dark:text-amber-400">★ Primary</span>}
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      </ScrollArea>
+                    </div>
+                  ) : (
+                    <div className="rounded-lg border bg-gray-50 py-8 text-center text-gray-500 dark:bg-slate-800">
+                      <p className="text-sm">No position changes detected</p>
+                    </div>
+                  )}
+                </TabsContent>
               </Tabs>
 
               <Separator />
@@ -906,7 +1045,7 @@ ${JSON.stringify(data, null, 2)}`;
                   <DialogTrigger asChild>
                     <GraphiteButton
                       onClick={() => setDialogOpen(true)}
-                      disabled={hasValidationIssues || !!(isExistingPlayer && !hasChanges && !hasTeamChanges && !hasNationChanges)}
+                      disabled={hasValidationIssues || !!(isExistingPlayer && !hasChanges && !hasTeamChanges && !hasNationChanges && !hasPositionChanges)}
                       icon={FileText}
                       className="flex-1"
                     >
@@ -1129,6 +1268,32 @@ ${JSON.stringify(data, null, 2)}`;
                                 ))}
                               </div>
                             )}
+                          </div>
+                        )}
+
+                        {hasPositionChanges && getPositionOps.positionsPayload && (
+                          <div>
+                            <h4 className="mb-2 font-medium">
+                              {(() => {
+                                let step = 2;
+                                if (isExistingPlayer && hasTeamChanges) step++;
+                                if (hasNationChanges) step++;
+                                return step;
+                              })()}
+                              .
+                              {' '}
+                              {isExistingPlayer ? 'Sync Positions' : 'Set Positions'}
+                            </h4>
+                            <div className="mb-3">
+                              <p className="mb-1 text-sm text-gray-600">
+                                POST /data/footballer-positions/set-positions/
+                              </p>
+                              <div className="overflow-x-auto rounded-lg bg-purple-50 p-3 dark:bg-purple-900/20">
+                                <pre className="font-mono text-xs text-gray-700 dark:text-gray-300">
+                                  <code>{JSON.stringify(getPositionOps.positionsPayload, null, 2)}</code>
+                                </pre>
+                              </div>
+                            </div>
                           </div>
                         )}
                       </div>

--- a/components/career-lookup/position-card.tsx
+++ b/components/career-lookup/position-card.tsx
@@ -1,13 +1,25 @@
 'use client';
 
-import { AlertTriangle, Check, Loader2, MapPin, Star } from 'lucide-react';
-import { useState } from 'react';
+import { AlertTriangle, Check, Loader2, MapPin, Plus, Star, X } from 'lucide-react';
+import { useEffect, useState } from 'react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { ApiButton } from '@/components/ui/emerald-button';
-import type { PositionsTracker, SetPositionsRequest } from '@/types/player';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Separator } from '@/components/ui/separator';
+import type { Position, PositionsTracker, SetPositionsRequest } from '@/types/player';
 import { FootballerAPI } from '@/lib/footballer-api';
+
+export type SelectedPosition = {
+  position_id: number;
+  name: string;
+  full_name: string;
+  role: string;
+  is_primary: boolean;
+  sort_order: number;
+  source: 'wikipedia' | 'database' | 'manual';
+};
 
 type PositionCardProps = {
   positionsTracker?: PositionsTracker;
@@ -15,26 +27,35 @@ type PositionCardProps = {
   playerFoundInDB?: boolean;
   className?: string;
   onPositionsApplied?: () => void;
+  onSelectedPositionsChange?: (positions: SelectedPosition[]) => void;
 };
 
 const ROLE_COLORS: Record<string, string> = {
-  GK: 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300',
-  DEF: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
-  MID: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
-  FWD: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300',
+  GK: 'bg-amber-100 text-amber-800 border-amber-300 dark:bg-amber-900/30 dark:text-amber-300 dark:border-amber-700',
+  DEF: 'bg-blue-100 text-blue-800 border-blue-300 dark:bg-blue-900/30 dark:text-blue-300 dark:border-blue-700',
+  MID: 'bg-green-100 text-green-800 border-green-300 dark:bg-green-900/30 dark:text-green-300 dark:border-green-700',
+  FWD: 'bg-red-100 text-red-800 border-red-300 dark:bg-red-900/30 dark:text-red-300 dark:border-red-700',
 };
 
-function getRoleBadgeClass(positionName: string): string {
-  const gkPositions = ['GK'];
-  const defPositions = ['CB', 'LB', 'RB', 'LWB', 'RWB', 'SW'];
-  const midPositions = ['CDM', 'CM', 'CAM', 'LM', 'RM'];
-  const fwdPositions = ['LW', 'RW', 'CF', 'ST', 'SS'];
+const ROLE_LABELS: Record<string, string> = {
+  GK: 'Goalkeeper',
+  DEF: 'Defenders',
+  MID: 'Midfielders',
+  FWD: 'Forwards',
+};
 
-  if (gkPositions.includes(positionName)) return ROLE_COLORS.GK;
-  if (defPositions.includes(positionName)) return ROLE_COLORS.DEF;
-  if (midPositions.includes(positionName)) return ROLE_COLORS.MID;
-  if (fwdPositions.includes(positionName)) return ROLE_COLORS.FWD;
-  return 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300';
+function getRoleBadgeClass(role: string): string {
+  return ROLE_COLORS[role] || 'bg-gray-100 text-gray-800 border-gray-300 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-600';
+}
+
+function inferRole(positionName: string): string {
+  const gk = ['GK'];
+  const def = ['CB', 'LB', 'RB', 'LWB', 'RWB', 'SW'];
+  const mid = ['CDM', 'CM', 'CAM', 'LM', 'RM'];
+  if (gk.includes(positionName)) return 'GK';
+  if (def.includes(positionName)) return 'DEF';
+  if (mid.includes(positionName)) return 'MID';
+  return 'FWD';
 }
 
 type SyncStatus = 'synced' | 'mismatch' | 'new-player' | 'no-data';
@@ -59,33 +80,122 @@ export function PositionCard({
   playerFoundInDB,
   className,
   onPositionsApplied,
+  onSelectedPositionsChange,
 }: PositionCardProps) {
   const [applying, setApplying] = useState(false);
   const [applied, setApplied] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [allPositions, setAllPositions] = useState<Position[]>([]);
+  const [loadingPositions, setLoadingPositions] = useState(false);
+  const [selectedPositions, setSelectedPositions] = useState<SelectedPosition[]>([]);
 
   const syncStatus = getSyncStatus(positionsTracker, playerFoundInDB);
   const statusBadge = STATUS_BADGES[syncStatus];
 
+  // Initialize selected positions from tracker data
+  useEffect(() => {
+    if (!positionsTracker) return;
+
+    const initial: SelectedPosition[] = [];
+
+    // Add existing DB positions
+    if (positionsTracker.databaseHasPositions) {
+      positionsTracker.databasePositions.forEach((p, i) => {
+        initial.push({
+          position_id: p.id,
+          name: p.name,
+          full_name: p.fullName,
+          role: inferRole(p.name),
+          is_primary: p.isPrimary,
+          sort_order: i,
+          source: 'database',
+        });
+      });
+    }
+
+    // Add Wikipedia positions not already in DB
+    const dbIds = new Set(initial.map(p => p.position_id));
+    positionsTracker.wikipediaPositions.forEach((p) => {
+      if (!dbIds.has(p.id)) {
+        initial.push({
+          position_id: p.id,
+          name: p.name,
+          full_name: p.fullName,
+          role: inferRole(p.name),
+          is_primary: initial.length === 0,
+          sort_order: initial.length,
+          source: 'wikipedia',
+        });
+      }
+    });
+
+    setSelectedPositions(initial);
+  }, [positionsTracker]);
+
+  // Notify parent when selection changes
+  useEffect(() => {
+    onSelectedPositionsChange?.(selectedPositions);
+  }, [selectedPositions, onSelectedPositionsChange]);
+
+  // Fetch all available positions from DB
+  useEffect(() => {
+    const fetchPositions = async () => {
+      try {
+        setLoadingPositions(true);
+        const positions = await FootballerAPI.getPositions();
+        setAllPositions(positions);
+      } catch {
+        setAllPositions([]);
+      } finally {
+        setLoadingPositions(false);
+      }
+    };
+    fetchPositions();
+  }, []);
+
+  const addPosition = (pos: Position) => {
+    if (selectedPositions.some(s => s.position_id === pos.id)) return;
+    const newPos: SelectedPosition = {
+      position_id: pos.id,
+      name: pos.name,
+      full_name: pos.full_name,
+      role: pos.role,
+      is_primary: selectedPositions.length === 0,
+      sort_order: selectedPositions.length,
+      source: 'manual',
+    };
+    setSelectedPositions(prev => [...prev, newPos]);
+    setApplied(false);
+  };
+
+  const removePosition = (positionId: number) => {
+    setSelectedPositions(prev => {
+      const filtered = prev.filter(p => p.position_id !== positionId);
+      // If we removed the primary, make the first one primary
+      if (filtered.length > 0 && !filtered.some(p => p.is_primary)) {
+        filtered[0].is_primary = true;
+      }
+      return filtered.map((p, i) => ({ ...p, sort_order: i }));
+    });
+    setApplied(false);
+  };
+
+  const setPrimary = (positionId: number) => {
+    setSelectedPositions(prev =>
+      prev.map(p => ({ ...p, is_primary: p.position_id === positionId })),
+    );
+    setApplied(false);
+  };
+
   const handleApplyPositions = async () => {
-    if (!footballerId || !positionsTracker) return;
-
-    // Merge existing DB positions with missing ones from Wikipedia
-    const existingDbIds = new Set(positionsTracker.databasePositions.map(p => p.id));
-    const allPositionIds = [
-      ...positionsTracker.databasePositions.map(p => p.id),
-      ...positionsTracker.missingIdsToApply.filter(id => !existingDbIds.has(id)),
-    ];
-
-    // Keep existing primary if set, otherwise first position is primary
-    const existingPrimary = positionsTracker.databasePositions.find(p => p.isPrimary);
+    if (!footballerId || selectedPositions.length === 0) return;
 
     const request: SetPositionsRequest = {
       footballer_id: footballerId,
-      positions: allPositionIds.map((id, index) => ({
-        position_id: id,
-        is_primary: existingPrimary ? id === existingPrimary.id : index === 0,
-        sort_order: index,
+      positions: selectedPositions.map(p => ({
+        position_id: p.position_id,
+        is_primary: p.is_primary,
+        sort_order: p.sort_order,
       })),
     };
 
@@ -107,8 +217,27 @@ export function PositionCard({
   }
 
   const hasWikipediaPositions = positionsTracker.wikipediaPositions.length > 0;
-  const hasDbPositions = positionsTracker.databaseHasPositions;
   const hasMissing = positionsTracker.missingInDatabase.length > 0;
+
+  // Determine if current selection differs from DB state
+  const dbPositionIds = new Set(positionsTracker.databasePositions.map(p => p.id));
+  const selectedIds = new Set(selectedPositions.map(p => p.position_id));
+  const hasUnsavedChanges = positionsTracker.databaseHasPositions
+    ? (selectedIds.size !== dbPositionIds.size
+      || [...selectedIds].some(id => !dbPositionIds.has(id))
+      || [...dbPositionIds].some(id => !selectedIds.has(id))
+      || selectedPositions.some(sp => {
+        const dbP = positionsTracker.databasePositions.find(d => d.id === sp.position_id);
+        return dbP && dbP.isPrimary !== sp.is_primary;
+      }))
+    : selectedPositions.length > 0;
+
+  // Group allPositions by role for the selector
+  const positionsByRole = allPositions.reduce<Record<string, Position[]>>((acc, pos) => {
+    if (!acc[pos.role]) acc[pos.role] = [];
+    acc[pos.role].push(pos);
+    return acc;
+  }, {});
 
   return (
     <Card className={className}>
@@ -121,7 +250,14 @@ export function PositionCard({
               <CardDescription>{positionsTracker.message}</CardDescription>
             </div>
           </div>
-          <Badge className={statusBadge.className}>{statusBadge.label}</Badge>
+          <div className="flex items-center gap-2">
+            {hasUnsavedChanges && !applied && (
+              <Badge className="bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300">
+                Unsaved
+              </Badge>
+            )}
+            <Badge className={statusBadge.className}>{statusBadge.label}</Badge>
+          </div>
         </div>
       </CardHeader>
       <CardContent className="space-y-4">
@@ -141,101 +277,157 @@ export function PositionCard({
           </Alert>
         )}
 
-        {/* Wikipedia Positions */}
-        {hasWikipediaPositions && (
-          <div>
-            <h4 className="mb-2 text-sm font-medium text-gray-600 dark:text-gray-400">
-              Wikipedia Positions
-            </h4>
-            <div className="flex flex-wrap gap-2">
-              {positionsTracker.wikipediaPositions.map(pos => {
-                const isMissing = positionsTracker.missingInDatabase.some(m => m.id === pos.id);
-                return (
-                  <Badge
-                    key={pos.id}
-                    className={`${getRoleBadgeClass(pos.name)} ${isMissing ? 'ring-2 ring-amber-400' : ''}`}
-                  >
-                    {pos.fullName}
-                    {pos.originalWikipediaName !== pos.name && (
-                      <span className="ml-1 text-xs opacity-60">({pos.originalWikipediaName})</span>
-                    )}
-                    {isMissing && <span className="ml-1 text-xs">⚠️</span>}
-                  </Badge>
-                );
-              })}
-            </div>
-          </div>
-        )}
+        <Tabs defaultValue="selected" className="w-full">
+          <TabsList className="grid w-full grid-cols-2">
+            <TabsTrigger value="selected" className="text-xs sm:text-sm">
+              Selected Positions
+              <Badge variant="secondary" className="ml-2 text-xs">{selectedPositions.length}</Badge>
+            </TabsTrigger>
+            <TabsTrigger value="all" className="text-xs sm:text-sm">
+              All Positions
+              <Badge variant="secondary" className="ml-2 text-xs">{allPositions.length}</Badge>
+            </TabsTrigger>
+          </TabsList>
 
-        {/* Database Positions */}
-        {hasDbPositions && (
-          <div>
-            <h4 className="mb-2 text-sm font-medium text-gray-600 dark:text-gray-400">
-              Database Positions
-            </h4>
-            <div className="flex flex-wrap gap-2">
-              {positionsTracker.databasePositions.map(pos => (
-                <Badge
-                  key={pos.id}
-                  className={getRoleBadgeClass(pos.name)}
-                >
-                  {pos.isPrimary && <Star className="mr-1 size-3 fill-current" />}
-                  {pos.fullName}
-                  {pos.isPrimary && <span className="ml-1 text-xs opacity-70">(Primary)</span>}
-                </Badge>
-              ))}
-            </div>
-          </div>
-        )}
-
-        {/* No DB Positions */}
-        {!hasDbPositions && playerFoundInDB && (
-          <div className="text-sm text-gray-500 dark:text-gray-400">
-            No positions assigned in database yet.
-          </div>
-        )}
-
-        {/* Apply Button */}
-        {hasMissing && footballerId && !applied && (
-          <ApiButton
-            onClick={handleApplyPositions}
-            disabled={applying}
-            size="sm"
-          >
-            {applying ? (
-              <>
-                <Loader2 className="mr-2 size-4 animate-spin" />
-                Applying...
-              </>
+          {/* Tab 1: Selected / Active Positions */}
+          <TabsContent value="selected" className="space-y-4 pt-2">
+            {selectedPositions.length === 0 ? (
+              <div className="py-6 text-center text-sm text-gray-500 dark:text-gray-400">
+                No positions selected. Go to &quot;All Positions&quot; tab to add some.
+              </div>
             ) : (
-              <>
-                Apply Wikipedia Positions
-              </>
+              <div className="space-y-2">
+                {selectedPositions.map(pos => (
+                  <div
+                    key={pos.position_id}
+                    className="flex items-center justify-between rounded-lg border p-3 transition-colors hover:bg-gray-50 dark:hover:bg-gray-800/50"
+                  >
+                    <div className="flex items-center gap-3">
+                      <Badge className={`border ${getRoleBadgeClass(pos.role)}`}>
+                        {pos.name}
+                      </Badge>
+                      <span className="text-sm font-medium">{pos.full_name}</span>
+                      {pos.is_primary && (
+                        <Badge className="bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300">
+                          <Star className="mr-1 size-3 fill-current" />
+                          Primary
+                        </Badge>
+                      )}
+                      {pos.source === 'wikipedia' && !positionsTracker.databasePositions.some(d => d.id === pos.position_id) && (
+                        <Badge variant="outline" className="text-xs text-blue-600 dark:text-blue-400">Wiki</Badge>
+                      )}
+                      {pos.source === 'manual' && (
+                        <Badge variant="outline" className="text-xs text-purple-600 dark:text-purple-400">Manual</Badge>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-2">
+                      {!pos.is_primary && (
+                        <button
+                          onClick={() => setPrimary(pos.position_id)}
+                          className="rounded p-1 text-xs text-gray-500 transition-colors hover:bg-amber-100 hover:text-amber-700 dark:hover:bg-amber-900/30 dark:hover:text-amber-300"
+                          title="Set as primary"
+                        >
+                          <Star className="size-4" />
+                        </button>
+                      )}
+                      <button
+                        onClick={() => removePosition(pos.position_id)}
+                        className="rounded p-1 text-gray-400 transition-colors hover:bg-red-100 hover:text-red-600 dark:hover:bg-red-900/30 dark:hover:text-red-400"
+                        title="Remove"
+                      >
+                        <X className="size-4" />
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
             )}
-          </ApiButton>
-        )}
 
-        {/* Success State */}
-        {applied && (
-          <div className="flex items-center gap-2 text-sm text-emerald-600 dark:text-emerald-400">
-            <Check className="size-4" />
-            Positions applied successfully!
-          </div>
-        )}
+            {/* Apply Button */}
+            {hasUnsavedChanges && footballerId && !applied && (
+              <ApiButton
+                onClick={handleApplyPositions}
+                disabled={applying || selectedPositions.length === 0}
+                loading={applying}
+                loadingText="Applying..."
+                size="sm"
+              >
+                Save Positions
+              </ApiButton>
+            )}
 
-        {/* Error State */}
-        {error && (
-          <div className="text-sm text-red-600 dark:text-red-400">
-            ❌ {error}
-          </div>
-        )}
+            {/* Success State */}
+            {applied && (
+              <div className="flex items-center gap-2 text-sm text-emerald-600 dark:text-emerald-400">
+                <Check className="size-4" />
+                Positions saved successfully!
+              </div>
+            )}
 
-        {/* New Player Info */}
-        {syncStatus === 'new-player' && hasWikipediaPositions && (
-          <div className="text-sm text-blue-600 dark:text-blue-400">
-            💡 These positions will be assigned when the player is deployed.
-          </div>
-        )}
+            {/* Error State */}
+            {error && (
+              <div className="text-sm text-red-600 dark:text-red-400">
+                ❌ {error}
+              </div>
+            )}
+
+            {/* New Player Info */}
+            {syncStatus === 'new-player' && selectedPositions.length > 0 && (
+              <div className="text-sm text-blue-600 dark:text-blue-400">
+                💡 These positions will be assigned when the player is deployed.
+              </div>
+            )}
+          </TabsContent>
+
+          {/* Tab 2: All Available Positions */}
+          <TabsContent value="all" className="space-y-4 pt-2">
+            {loadingPositions ? (
+              <div className="flex items-center justify-center py-6">
+                <Loader2 className="size-5 animate-spin text-gray-400" />
+                <span className="ml-2 text-sm text-gray-500">Loading positions...</span>
+              </div>
+            ) : (
+              Object.entries(ROLE_LABELS).map(([role, label]) => {
+                const positions = positionsByRole[role] || [];
+                if (positions.length === 0) return null;
+
+                return (
+                  <div key={role}>
+                    <h4 className="mb-2 text-sm font-semibold text-gray-700 dark:text-gray-300">
+                      {label}
+                    </h4>
+                    <div className="flex flex-wrap gap-2">
+                      {positions.map(pos => {
+                        const isSelected = selectedPositions.some(s => s.position_id === pos.id);
+                        return (
+                          <button
+                            key={pos.id}
+                            onClick={() => isSelected ? removePosition(pos.id) : addPosition(pos)}
+                            className={`inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-sm font-medium transition-all ${
+                              isSelected
+                                ? `${getRoleBadgeClass(pos.role)} ring-2 ring-offset-1 ring-emerald-500 dark:ring-offset-gray-900`
+                                : 'border-gray-200 bg-white text-gray-700 hover:border-gray-300 hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-gray-600 dark:hover:bg-gray-700'
+                            }`}
+                            title={isSelected ? `Remove ${pos.full_name}` : `Add ${pos.full_name}`}
+                          >
+                            {isSelected ? (
+                              <Check className="size-3.5 text-emerald-600 dark:text-emerald-400" />
+                            ) : (
+                              <Plus className="size-3.5 text-gray-400" />
+                            )}
+                            <span>{pos.name}</span>
+                            <span className="hidden text-xs opacity-60 sm:inline">{pos.full_name}</span>
+                          </button>
+                        );
+                      })}
+                    </div>
+                    <Separator className="mt-3" />
+                  </div>
+                );
+              })
+            )}
+          </TabsContent>
+        </Tabs>
       </CardContent>
     </Card>
   );

--- a/components/career-lookup/position-card.tsx
+++ b/components/career-lookup/position-card.tsx
@@ -1,0 +1,242 @@
+'use client';
+
+import { AlertTriangle, Check, Loader2, MapPin, Star } from 'lucide-react';
+import { useState } from 'react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { ApiButton } from '@/components/ui/emerald-button';
+import type { PositionsTracker, SetPositionsRequest } from '@/types/player';
+import { FootballerAPI } from '@/lib/footballer-api';
+
+type PositionCardProps = {
+  positionsTracker?: PositionsTracker;
+  footballerId?: number | null;
+  playerFoundInDB?: boolean;
+  className?: string;
+  onPositionsApplied?: () => void;
+};
+
+const ROLE_COLORS: Record<string, string> = {
+  GK: 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300',
+  DEF: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
+  MID: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
+  FWD: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300',
+};
+
+function getRoleBadgeClass(positionName: string): string {
+  const gkPositions = ['GK'];
+  const defPositions = ['CB', 'LB', 'RB', 'LWB', 'RWB', 'SW'];
+  const midPositions = ['CDM', 'CM', 'CAM', 'LM', 'RM'];
+  const fwdPositions = ['LW', 'RW', 'CF', 'ST', 'SS'];
+
+  if (gkPositions.includes(positionName)) return ROLE_COLORS.GK;
+  if (defPositions.includes(positionName)) return ROLE_COLORS.DEF;
+  if (midPositions.includes(positionName)) return ROLE_COLORS.MID;
+  if (fwdPositions.includes(positionName)) return ROLE_COLORS.FWD;
+  return 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300';
+}
+
+type SyncStatus = 'synced' | 'mismatch' | 'new-player' | 'no-data';
+
+function getSyncStatus(positionsTracker?: PositionsTracker, playerFoundInDB?: boolean): SyncStatus {
+  if (!positionsTracker) return 'no-data';
+  if (!playerFoundInDB) return 'new-player';
+  if (positionsTracker.hasDiscrepancy) return 'mismatch';
+  return 'synced';
+}
+
+const STATUS_BADGES: Record<SyncStatus, { label: string; className: string }> = {
+  'synced': { label: 'Synced', className: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300' },
+  'mismatch': { label: 'Mismatch', className: 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300' },
+  'new-player': { label: 'New Player', className: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300' },
+  'no-data': { label: 'No Data', className: 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300' },
+};
+
+export function PositionCard({
+  positionsTracker,
+  footballerId,
+  playerFoundInDB,
+  className,
+  onPositionsApplied,
+}: PositionCardProps) {
+  const [applying, setApplying] = useState(false);
+  const [applied, setApplied] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const syncStatus = getSyncStatus(positionsTracker, playerFoundInDB);
+  const statusBadge = STATUS_BADGES[syncStatus];
+
+  const handleApplyPositions = async () => {
+    if (!footballerId || !positionsTracker) return;
+
+    // Merge existing DB positions with missing ones from Wikipedia
+    const existingDbIds = new Set(positionsTracker.databasePositions.map(p => p.id));
+    const allPositionIds = [
+      ...positionsTracker.databasePositions.map(p => p.id),
+      ...positionsTracker.missingIdsToApply.filter(id => !existingDbIds.has(id)),
+    ];
+
+    // Keep existing primary if set, otherwise first position is primary
+    const existingPrimary = positionsTracker.databasePositions.find(p => p.isPrimary);
+
+    const request: SetPositionsRequest = {
+      footballer_id: footballerId,
+      positions: allPositionIds.map((id, index) => ({
+        position_id: id,
+        is_primary: existingPrimary ? id === existingPrimary.id : index === 0,
+        sort_order: index,
+      })),
+    };
+
+    try {
+      setApplying(true);
+      setError(null);
+      await FootballerAPI.setPositions(request);
+      setApplied(true);
+      onPositionsApplied?.();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to apply positions');
+    } finally {
+      setApplying(false);
+    }
+  };
+
+  if (!positionsTracker) {
+    return null;
+  }
+
+  const hasWikipediaPositions = positionsTracker.wikipediaPositions.length > 0;
+  const hasDbPositions = positionsTracker.databaseHasPositions;
+  const hasMissing = positionsTracker.missingInDatabase.length > 0;
+
+  return (
+    <Card className={className}>
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <MapPin className="size-5 text-gray-600 dark:text-gray-400" />
+            <div>
+              <CardTitle className="text-lg">Positions</CardTitle>
+              <CardDescription>{positionsTracker.message}</CardDescription>
+            </div>
+          </div>
+          <Badge className={statusBadge.className}>{statusBadge.label}</Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Discrepancy Alert */}
+        {syncStatus === 'mismatch' && hasMissing && (
+          <Alert className="border-amber-200 bg-amber-50 dark:border-amber-700 dark:bg-amber-900/20">
+            <AlertTriangle className="size-4 text-amber-600 dark:text-amber-400" />
+            <AlertDescription className="text-amber-800 dark:text-amber-200">
+              <strong>{positionsTracker.missingInDatabase.length}</strong>
+              {' '}
+              position{positionsTracker.missingInDatabase.length > 1 ? 's' : ''}
+              {' '}
+              found on Wikipedia but missing in database:
+              {' '}
+              <strong>{positionsTracker.missingInDatabase.map(p => p.fullName).join(', ')}</strong>
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {/* Wikipedia Positions */}
+        {hasWikipediaPositions && (
+          <div>
+            <h4 className="mb-2 text-sm font-medium text-gray-600 dark:text-gray-400">
+              Wikipedia Positions
+            </h4>
+            <div className="flex flex-wrap gap-2">
+              {positionsTracker.wikipediaPositions.map(pos => {
+                const isMissing = positionsTracker.missingInDatabase.some(m => m.id === pos.id);
+                return (
+                  <Badge
+                    key={pos.id}
+                    className={`${getRoleBadgeClass(pos.name)} ${isMissing ? 'ring-2 ring-amber-400' : ''}`}
+                  >
+                    {pos.fullName}
+                    {pos.originalWikipediaName !== pos.name && (
+                      <span className="ml-1 text-xs opacity-60">({pos.originalWikipediaName})</span>
+                    )}
+                    {isMissing && <span className="ml-1 text-xs">⚠️</span>}
+                  </Badge>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {/* Database Positions */}
+        {hasDbPositions && (
+          <div>
+            <h4 className="mb-2 text-sm font-medium text-gray-600 dark:text-gray-400">
+              Database Positions
+            </h4>
+            <div className="flex flex-wrap gap-2">
+              {positionsTracker.databasePositions.map(pos => (
+                <Badge
+                  key={pos.id}
+                  className={getRoleBadgeClass(pos.name)}
+                >
+                  {pos.isPrimary && <Star className="mr-1 size-3 fill-current" />}
+                  {pos.fullName}
+                  {pos.isPrimary && <span className="ml-1 text-xs opacity-70">(Primary)</span>}
+                </Badge>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* No DB Positions */}
+        {!hasDbPositions && playerFoundInDB && (
+          <div className="text-sm text-gray-500 dark:text-gray-400">
+            No positions assigned in database yet.
+          </div>
+        )}
+
+        {/* Apply Button */}
+        {hasMissing && footballerId && !applied && (
+          <ApiButton
+            onClick={handleApplyPositions}
+            disabled={applying}
+            size="sm"
+          >
+            {applying ? (
+              <>
+                <Loader2 className="mr-2 size-4 animate-spin" />
+                Applying...
+              </>
+            ) : (
+              <>
+                Apply Wikipedia Positions
+              </>
+            )}
+          </ApiButton>
+        )}
+
+        {/* Success State */}
+        {applied && (
+          <div className="flex items-center gap-2 text-sm text-emerald-600 dark:text-emerald-400">
+            <Check className="size-4" />
+            Positions applied successfully!
+          </div>
+        )}
+
+        {/* Error State */}
+        {error && (
+          <div className="text-sm text-red-600 dark:text-red-400">
+            ❌ {error}
+          </div>
+        )}
+
+        {/* New Player Info */}
+        {syncStatus === 'new-player' && hasWikipediaPositions && (
+          <div className="text-sm text-blue-600 dark:text-blue-400">
+            💡 These positions will be assigned when the player is deployed.
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/career-lookup/position-card.tsx
+++ b/components/career-lookup/position-card.tsx
@@ -6,6 +6,8 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { ApiButton } from '@/components/ui/emerald-button';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Separator } from '@/components/ui/separator';
 import type { Position, PositionsTracker, SetPositionsRequest } from '@/types/player';
@@ -88,6 +90,7 @@ export function PositionCard({
   const [allPositions, setAllPositions] = useState<Position[]>([]);
   const [loadingPositions, setLoadingPositions] = useState(false);
   const [selectedPositions, setSelectedPositions] = useState<SelectedPosition[]>([]);
+  const [positionsEnabled, setPositionsEnabled] = useState(true);
 
   const syncStatus = getSyncStatus(positionsTracker, playerFoundInDB);
   const statusBadge = STATUS_BADGES[syncStatus];
@@ -132,10 +135,10 @@ export function PositionCard({
     setSelectedPositions(initial);
   }, [positionsTracker]);
 
-  // Notify parent when selection changes
+  // Notify parent when selection or enabled state changes
   useEffect(() => {
-    onSelectedPositionsChange?.(selectedPositions);
-  }, [selectedPositions, onSelectedPositionsChange]);
+    onSelectedPositionsChange?.(positionsEnabled ? selectedPositions : []);
+  }, [selectedPositions, positionsEnabled, onSelectedPositionsChange]);
 
   // Fetch all available positions from DB
   useEffect(() => {
@@ -240,7 +243,7 @@ export function PositionCard({
   }, {});
 
   return (
-    <Card className={className}>
+    <Card className={`${className ?? ''} ${!positionsEnabled ? 'opacity-75' : ''}`}>
       <CardHeader className="pb-3">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
@@ -250,8 +253,18 @@ export function PositionCard({
               <CardDescription>{positionsTracker.message}</CardDescription>
             </div>
           </div>
-          <div className="flex items-center gap-2">
-            {hasUnsavedChanges && !applied && (
+          <div className="flex items-center gap-3">
+            <div className="flex items-center gap-2">
+              <Switch
+                id="positions-enabled"
+                checked={positionsEnabled}
+                onCheckedChange={setPositionsEnabled}
+              />
+              <Label htmlFor="positions-enabled" className="cursor-pointer text-xs text-gray-500 dark:text-gray-400">
+                {positionsEnabled ? 'Active' : 'Disabled'}
+              </Label>
+            </div>
+            {positionsEnabled && hasUnsavedChanges && !applied && (
               <Badge className="bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300">
                 Unsaved
               </Badge>
@@ -261,6 +274,14 @@ export function PositionCard({
         </div>
       </CardHeader>
       <CardContent className="space-y-4">
+        {!positionsEnabled && (
+          <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 py-4 text-center text-sm text-gray-500 dark:border-gray-600 dark:bg-gray-800/50 dark:text-gray-400">
+            Position management is disabled. Toggle the switch above to include positions in deployment.
+          </div>
+        )}
+
+        {positionsEnabled && (
+          <>
         {/* Discrepancy Alert */}
         {syncStatus === 'mismatch' && hasMissing && (
           <Alert className="border-amber-200 bg-amber-50 dark:border-amber-700 dark:bg-amber-900/20">
@@ -428,6 +449,8 @@ export function PositionCard({
             )}
           </TabsContent>
         </Tabs>
+          </>
+        )}
       </CardContent>
     </Card>
   );

--- a/components/career-lookup/position-card.tsx
+++ b/components/career-lookup/position-card.tsx
@@ -91,8 +91,11 @@ export function PositionCard({
   const [loadingPositions, setLoadingPositions] = useState(false);
   const [selectedPositions, setSelectedPositions] = useState<SelectedPosition[]>([]);
   const [positionsEnabled, setPositionsEnabled] = useState(true);
+  // Tracks the last-saved state so we can detect unsaved changes after a save
+  const [savedSnapshot, setSavedSnapshot] = useState<SelectedPosition[] | null>(null);
 
-  const syncStatus = getSyncStatus(positionsTracker, playerFoundInDB);
+  // After a save, override sync status to reflect current state
+  const syncStatus = savedSnapshot ? 'synced' : getSyncStatus(positionsTracker, playerFoundInDB);
   const statusBadge = STATUS_BADGES[syncStatus];
 
   // Initialize selected positions from tracker data
@@ -207,6 +210,10 @@ export function PositionCard({
       setError(null);
       await FootballerAPI.setPositions(request);
       setApplied(true);
+      // Update local state: mark all positions as saved/database source
+      const saved = selectedPositions.map(p => ({ ...p, source: 'database' as const }));
+      setSelectedPositions(saved);
+      setSavedSnapshot(saved);
       onPositionsApplied?.();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to apply positions');
@@ -222,18 +229,31 @@ export function PositionCard({
   const hasWikipediaPositions = positionsTracker.wikipediaPositions.length > 0;
   const hasMissing = positionsTracker.missingInDatabase.length > 0;
 
-  // Determine if current selection differs from DB state
-  const dbPositionIds = new Set(positionsTracker.databasePositions.map(p => p.id));
-  const selectedIds = new Set(selectedPositions.map(p => p.position_id));
-  const hasUnsavedChanges = positionsTracker.databaseHasPositions
-    ? (selectedIds.size !== dbPositionIds.size
-      || [...selectedIds].some(id => !dbPositionIds.has(id))
-      || [...dbPositionIds].some(id => !selectedIds.has(id))
-      || selectedPositions.some(sp => {
-        const dbP = positionsTracker.databasePositions.find(d => d.id === sp.position_id);
-        return dbP && dbP.isPrimary !== sp.is_primary;
-      }))
-    : selectedPositions.length > 0;
+  // Determine if current selection differs from saved/DB state
+  const hasUnsavedChanges = (() => {
+    // After a save, compare against the saved snapshot
+    if (savedSnapshot) {
+      if (selectedPositions.length !== savedSnapshot.length) return true;
+      const snapIds = new Set(savedSnapshot.map(p => p.position_id));
+      if (selectedPositions.some(p => !snapIds.has(p.position_id))) return true;
+      return selectedPositions.some(sp => {
+        const saved = savedSnapshot.find(s => s.position_id === sp.position_id);
+        return saved && saved.is_primary !== sp.is_primary;
+      });
+    }
+    // Before any save, compare against original DB data
+    const dbPositionIds = new Set(positionsTracker.databasePositions.map(p => p.id));
+    const selectedIds = new Set(selectedPositions.map(p => p.position_id));
+    return positionsTracker.databaseHasPositions
+      ? (selectedIds.size !== dbPositionIds.size
+        || [...selectedIds].some(id => !dbPositionIds.has(id))
+        || [...dbPositionIds].some(id => !selectedIds.has(id))
+        || selectedPositions.some(sp => {
+          const dbP = positionsTracker.databasePositions.find(d => d.id === sp.position_id);
+          return dbP && dbP.isPrimary !== sp.is_primary;
+        }))
+      : selectedPositions.length > 0;
+  })();
 
   // Group allPositions by role for the selector
   const positionsByRole = allPositions.reduce<Record<string, Position[]>>((acc, pos) => {
@@ -250,7 +270,11 @@ export function PositionCard({
             <MapPin className="size-5 text-gray-600 dark:text-gray-400" />
             <div>
               <CardTitle className="text-lg">Positions</CardTitle>
-              <CardDescription>{positionsTracker.message}</CardDescription>
+              <CardDescription>
+                {savedSnapshot
+                  ? `${selectedPositions.length} position(s) saved to database`
+                  : positionsTracker.message}
+              </CardDescription>
             </div>
           </div>
           <div className="flex items-center gap-3">

--- a/components/career-lookup/position-card.tsx
+++ b/components/career-lookup/position-card.tsx
@@ -347,6 +347,7 @@ export function PositionCard({
                           onClick={() => setPrimary(pos.position_id)}
                           className="rounded p-1 text-xs text-gray-500 transition-colors hover:bg-amber-100 hover:text-amber-700 dark:hover:bg-amber-900/30 dark:hover:text-amber-300"
                           title="Set as primary"
+                          aria-label={`Set ${pos.full_name} as primary`}
                         >
                           <Star className="size-4" />
                         </button>
@@ -355,6 +356,7 @@ export function PositionCard({
                         onClick={() => removePosition(pos.position_id)}
                         className="rounded p-1 text-gray-400 transition-colors hover:bg-red-100 hover:text-red-600 dark:hover:bg-red-900/30 dark:hover:text-red-400"
                         title="Remove"
+                        aria-label={`Remove ${pos.full_name}`}
                       >
                         <X className="size-4" />
                       </button>

--- a/lib/__tests__/footballer-api.test.ts
+++ b/lib/__tests__/footballer-api.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { FootballerAPI } from '@/lib/footballer-api';
+
+// Mock the apiFetcher module
+vi.mock('@/lib/api-fetcher', () => ({
+  apiFetcher: vi.fn(),
+}));
+
+import { apiFetcher } from '@/lib/api-fetcher';
+
+const mockApiFetcher = vi.mocked(apiFetcher);
+
+describe('FootballerAPI — Position Methods', () => {
+  beforeEach(() => {
+    mockApiFetcher.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('getPositions', () => {
+    it('calls GET /data/positions/', async () => {
+      const mockPositions = [
+        { id: 1, name: 'GK', full_name: 'Goalkeeper', role: 'GK', sort_order: 1 },
+        { id: 2, name: 'CB', full_name: 'Centre-Back', role: 'DEF', sort_order: 2 },
+      ];
+      mockApiFetcher.mockResolvedValue(mockPositions);
+
+      const result = await FootballerAPI.getPositions();
+
+      expect(mockApiFetcher).toHaveBeenCalledWith('data/positions/');
+      expect(result).toEqual(mockPositions);
+    });
+
+    it('returns typed Position array', async () => {
+      const mockPositions = [
+        { id: 1, name: 'GK', full_name: 'Goalkeeper', role: 'GK', sort_order: 1 },
+      ];
+      mockApiFetcher.mockResolvedValue(mockPositions);
+
+      const result = await FootballerAPI.getPositions();
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toHaveProperty('name', 'GK');
+      expect(result[0]).toHaveProperty('full_name', 'Goalkeeper');
+      expect(result[0]).toHaveProperty('role', 'GK');
+    });
+  });
+
+  describe('getFootballerPositions', () => {
+    it('calls GET with footballer query param', async () => {
+      const mockPositions = [
+        {
+          id: 10, footballer_id: 42, footballer_name: 'Lionel Messi',
+          position_id: 16, position_name: 'RW', position_full_name: 'Right Winger',
+          position_role: 'FWD', is_primary: true, sort_order: 0,
+          created_at: '2026-01-01', updated_at: '2026-01-01',
+        },
+      ];
+      mockApiFetcher.mockResolvedValue(mockPositions);
+
+      const result = await FootballerAPI.getFootballerPositions(42);
+
+      expect(mockApiFetcher).toHaveBeenCalledWith('data/footballer-positions/?footballer=42');
+      expect(result).toEqual(mockPositions);
+    });
+
+    it('passes different footballer IDs correctly', async () => {
+      mockApiFetcher.mockResolvedValue([]);
+
+      await FootballerAPI.getFootballerPositions(999);
+
+      expect(mockApiFetcher).toHaveBeenCalledWith('data/footballer-positions/?footballer=999');
+    });
+  });
+
+  describe('setPositions', () => {
+    it('calls POST with correct body', async () => {
+      const request = {
+        footballer_id: 42,
+        positions: [
+          { position_id: 16, is_primary: true, sort_order: 0 },
+          { position_id: 5, is_primary: false, sort_order: 1 },
+        ],
+      };
+      const mockResponse = [
+        {
+          id: 10, footballer_id: 42, footballer_name: 'Lionel Messi',
+          position_id: 16, position_name: 'RW', position_full_name: 'Right Winger',
+          position_role: 'FWD', is_primary: true, sort_order: 0,
+          created_at: '2026-01-01', updated_at: '2026-01-01',
+        },
+        {
+          id: 11, footballer_id: 42, footballer_name: 'Lionel Messi',
+          position_id: 5, position_name: 'CF', position_full_name: 'Centre-Forward',
+          position_role: 'FWD', is_primary: false, sort_order: 1,
+          created_at: '2026-01-01', updated_at: '2026-01-01',
+        },
+      ];
+      mockApiFetcher.mockResolvedValue(mockResponse);
+
+      const result = await FootballerAPI.setPositions(request);
+
+      expect(mockApiFetcher).toHaveBeenCalledWith('data/footballer-positions/set-positions/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(request),
+      });
+      expect(result).toHaveLength(2);
+    });
+
+    it('sends empty positions array to clear all', async () => {
+      const request = {
+        footballer_id: 42,
+        positions: [],
+      };
+      mockApiFetcher.mockResolvedValue([]);
+
+      const result = await FootballerAPI.setPositions(request);
+
+      expect(mockApiFetcher).toHaveBeenCalledWith('data/footballer-positions/set-positions/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(request),
+      });
+      expect(result).toEqual([]);
+    });
+
+    it('propagates API errors', async () => {
+      mockApiFetcher.mockRejectedValue(new Error('Insufficient permissions'));
+
+      await expect(
+        FootballerAPI.setPositions({ footballer_id: 42, positions: [] }),
+      ).rejects.toThrow('Insufficient permissions');
+    });
+  });
+});

--- a/lib/footballer-api.ts
+++ b/lib/footballer-api.ts
@@ -5,9 +5,12 @@ import type {
   Footballer,
   FootballerNation,
   FootballerNationStat,
+  FootballerPosition,
   FootballersResponse,
   FootballerTeam,
   FootballerTeamsResponse,
+  Position,
+  SetPositionsRequest,
 } from '@/types/player';
 import { apiFetcher } from '@/lib/api-fetcher';
 
@@ -196,6 +199,38 @@ export class FootballerAPI {
   static async deleteFootballerNation(id: number): Promise<void> {
     return apiFetcher(`data/footballer-nations/${id}/`, {
       method: 'DELETE',
+    });
+  }
+
+  // ── Positions ──────────────────────────────────────────────
+
+  /**
+   * Get all positions (for dropdowns/selectors)
+   * GET /data/positions/ (AllowAny)
+   */
+  static async getPositions(): Promise<Position[]> {
+    return apiFetcher('data/positions/');
+  }
+
+  /**
+   * Get footballer positions by footballer ID
+   * GET /data/footballer-positions/?footballer={footballer_id} (AllowAny for GET)
+   */
+  static async getFootballerPositions(footballerId: number): Promise<FootballerPosition[]> {
+    return apiFetcher(`data/footballer-positions/?footballer=${footballerId}`);
+  }
+
+  /**
+   * Bulk set positions for a footballer (atomically replaces all)
+   * POST /data/footballer-positions/set-positions/ (Admin auth)
+   */
+  static async setPositions(data: SetPositionsRequest): Promise<FootballerPosition[]> {
+    return apiFetcher('data/footballer-positions/set-positions/', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(data),
     });
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,11 +62,15 @@
         "@eslint/js": "^9.39.2",
         "@hookform/resolvers": "^5.2.2",
         "@next/eslint-plugin-next": "^16.0.10",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^25.0.3",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "@typescript-eslint/eslint-plugin": "^8.50.0",
         "@typescript-eslint/parser": "^8.50.0",
+        "@vitejs/plugin-react": "^6.0.1",
         "autoprefixer": "^10.4.23",
         "cmdk": "1.1.1",
         "eslint": "^9.39.2",
@@ -82,6 +86,7 @@
         "eslint-plugin-testing-library": "^7.15.1",
         "husky": "^9.1.7",
         "input-otp": "1.4.2",
+        "jsdom": "^29.0.1",
         "lint-staged": "^16.2.7",
         "postcss": "^8.5",
         "prettier": "^3.7.4",
@@ -89,8 +94,16 @@
         "recharts": "3.6.0",
         "tailwindcss": "^3.4.19",
         "typescript": "^5",
-        "vaul": "^1.1.2"
+        "vaul": "^1.1.2",
+        "vitest": "^4.1.0"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -237,6 +250,67 @@
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.0.1.tgz",
+      "integrity": "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.4.tgz",
+      "integrity": "sha512-jXR6x4AcT3eIrS2fSNAwJpwirOkGcd+E7F7CP3zjdTqz9B/2huHOL8YJZBgekKwLML+u7qB/6P1LXQuMScsx0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -518,6 +592,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@clack/core": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@clack/core/-/core-0.5.0.tgz",
@@ -539,6 +626,146 @@
         "@clack/core": "0.5.0",
         "picocolors": "^1.0.0",
         "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.1.tgz",
+      "integrity": "sha512-BvqN0AMWNAnLk9G8jnUT77D+mUbY/H2b3uDTvg2isJkHaOufUE2R3AOwxWo7VBQKT1lOdwdvorddo2B/lk64+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@date-fns/tz": {
@@ -1024,6 +1251,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -1888,6 +2133,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.120.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.120.0.tgz",
+      "integrity": "sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -3594,6 +3849,285 @@
         "url": "https://opencollective.com/immer"
       }
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.10.tgz",
+      "integrity": "sha512-jOHxwXhxmFKuXztiu1ORieJeTbx5vrTkcOkkkn2d35726+iwhrY1w/+nYY/AGgF12thg33qC3R1LMBF5tHTZHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.10.tgz",
+      "integrity": "sha512-gED05Teg/vtTZbIJBc4VNMAxAFDUPkuO/rAIyyxZjTj1a1/s6z5TII/5yMGZ0uLRCifEtwUQn8OlYzuYc0m70w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.10.tgz",
+      "integrity": "sha512-rI15NcM1mA48lqrIxVkHfAqcyFLcQwyXWThy+BQ5+mkKKPvSO26ir+ZDp36AgYoYVkqvMcdS8zOE6SeBsR9e8A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.10.tgz",
+      "integrity": "sha512-XZRXHdTa+4ME1MuDVp021+doQ+z6Ei4CCFmNc5/sKbqb8YmkiJdj8QKlV3rCI0AJtAeSB5n0WGPuJWNL9p/L2w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.10.tgz",
+      "integrity": "sha512-R0SQMRluISSLzFE20sPWYHVmJdDQnRyc/FzSCN72BqQmh2SOZUFG+N3/vBZpR4C6WpEUVYJLrYUXaj43sJsNLA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.10.tgz",
+      "integrity": "sha512-Y1reMrV/o+cwpduYhJuOE3OMKx32RMYCidf14y+HssARRmhDuWXJ4yVguDg2R/8SyyGNo+auzz64LnPK9Hq6jg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.10.tgz",
+      "integrity": "sha512-vELN+HNb2IzuzSBUOD4NHmP9yrGwl1DVM29wlQvx1OLSclL0NgVWnVDKl/8tEks79EFek/kebQKnNJkIAA4W2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.10.tgz",
+      "integrity": "sha512-ZqrufYTgzxbHwpqOjzSsb0UV/aV2TFIY5rP8HdsiPTv/CuAgCRjM6s9cYFwQ4CNH+hf9Y4erHW1GjZuZ7WoI7w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.10.tgz",
+      "integrity": "sha512-gSlmVS1FZJSRicA6IyjoRoKAFK7IIHBs7xJuHRSmjImqk3mPPWbR7RhbnfH2G6bcmMEllCt2vQ/7u9e6bBnByg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.10.tgz",
+      "integrity": "sha512-eOCKUpluKgfObT2pHjztnaWEIbUabWzk3qPZ5PuacuPmr4+JtQG4k2vGTY0H15edaTnicgU428XW/IH6AimcQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.10.tgz",
+      "integrity": "sha512-Xdf2jQbfQowJnLcgYfD/m0Uu0Qj5OdxKallD78/IPPfzaiaI4KRAwZzHcKQ4ig1gtg1SuzC7jovNiM2TzQsBXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.10.tgz",
+      "integrity": "sha512-o1hYe8hLi1EY6jgPFyxQgQ1wcycX+qz8eEbVmot2hFkgUzPxy9+kF0u0NIQBeDq+Mko47AkaFFaChcvZa9UX9Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.10.tgz",
+      "integrity": "sha512-Ugv9o7qYJudqQO5Y5y2N2SOo6S4WiqiNOpuQyoPInnhVzCY+wi/GHltcLHypG9DEUYMB0iTB/huJrpadiAcNcA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.10.tgz",
+      "integrity": "sha512-7UODQb4fQUNT/vmgDZBl3XOBAIOutP5R3O/rkxg0aLfEGQ4opbCgU5vOw/scPe4xOqBwL9fw7/RP1vAMZ6QlAQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.10.tgz",
+      "integrity": "sha512-PYxKHMVHOb5NJuDL53vBUl1VwUjymDcYI6rzpIni0C9+9mTiJedvUxSk7/RPp7OOAm3v+EjgMu9bIy3N6b408w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz",
+      "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -3696,6 +4230,107 @@
         "node": ">=4"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -3705,6 +4340,25 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/d3-array": {
@@ -3787,6 +4441,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -4388,6 +5049,32 @@
         "win32"
       ]
     },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
+      "integrity": "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "1.0.0-rc.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/eslint-plugin": {
       "version": "1.6.4",
       "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.6.4.tgz",
@@ -4413,6 +5100,129 @@
         "vitest": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
+      "integrity": "sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.0.tgz",
+      "integrity": "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.0",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.0.tgz",
+      "integrity": "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.0.tgz",
+      "integrity": "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.0",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.0.tgz",
+      "integrity": "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.0.tgz",
+      "integrity": "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.0.tgz",
+      "integrity": "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.0",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vue/compiler-core": {
@@ -4795,6 +5605,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -4909,6 +5729,16 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/binary-extensions": {
@@ -5112,6 +5942,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -5473,6 +6313,27 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -5630,6 +6491,20 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -5717,6 +6592,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
@@ -5793,8 +6675,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -5852,6 +6734,14 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -6082,6 +6972,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -7554,6 +8451,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/exsolve": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
@@ -8198,6 +9105,19 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-entities": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
@@ -8706,6 +9626,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -8936,6 +9863,67 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/jsdom": {
+      "version": "29.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.1.tgz",
+      "integrity": "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.0.1",
+        "@asamuzakjp/dom-selector": "^7.0.3",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsdom/node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -9091,6 +10079,267 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/lilconfig": {
@@ -9356,13 +10605,23 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
@@ -9696,6 +10955,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -10319,6 +11585,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -10723,6 +11999,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/onetime": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
@@ -10885,6 +12172,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -11035,9 +12348,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
       "funding": [
         {
           "type": "opencollective",
@@ -11167,6 +12480,55 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -11493,6 +12855,43 @@
         "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/redent/node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/redent/node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
@@ -11652,6 +13051,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/requireindex": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
@@ -11756,6 +13165,47 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.10.tgz",
+      "integrity": "sha512-q7j6vvarRFmKpgJUT8HCAUljkgzEp4LAhPlJUvQhA5LA1SUL36s5QCysMutErzL3EbNOZOkoziSx9iZC4FddKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.120.0",
+        "@rolldown/pluginutils": "1.0.0-rc.10"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.10",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.10",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.10",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.10",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.10",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.10",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.10",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.10",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.10",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.10",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.10",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.10",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.10",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.10",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.10"
+      }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.10.tgz",
+      "integrity": "sha512-UkVDEFk1w3mveXeKgaTuYfKWtPbvgck1dT8TUG3bnccrH0XtLTuAyfCoks4Q/M5ZGToSVJTIQYCzy2g/atAOeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -11832,6 +13282,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -12059,6 +13522,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -12169,6 +13639,20 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -12550,6 +14034,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/synckit": {
       "version": "0.11.11",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
@@ -12699,6 +14190,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
@@ -12757,6 +14255,36 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.27",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.27.tgz",
+      "integrity": "sha512-I4FZcVFcqCRuT0ph6dCDpPuO4Xgzvh+spkcTr1gK7peIvxWauoloVO0vuy1FQnijT63ss6AsHB6+OIM4aXHbPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.27"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.27",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.27.tgz",
+      "integrity": "sha512-YQ7uPjgWUibIK6DW5lrKujGwUKhLevU4hcGbP5O6TcIUb+oTjJYJVWPS4nZsIHrEEEG6myk/oqAJUEQmpZrHsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -12813,6 +14341,32 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/trim-lines": {
@@ -13082,6 +14636,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.5.tgz",
+      "integrity": "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -13377,6 +14941,192 @@
         "d3-timer": "^3.0.1"
       }
     },
+    "node_modules/vite": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.1.tgz",
+      "integrity": "sha512-wt+Z2qIhfFt85uiyRt5LPU4oVEJBXj8hZNWKeqFG4gRG/0RaRGJ7njQCwzFVjO+v4+Ipmf5CY7VdmZRAYYBPHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.10",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz",
+      "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.0",
+        "@vitest/mocker": "4.1.0",
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/runner": "4.1.0",
+        "@vitest/snapshot": "4.1.0",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.0",
+        "@vitest/browser-preview": "4.1.0",
+        "@vitest/browser-webdriverio": "4.1.0",
+        "@vitest/ui": "4.1.0",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/vue-eslint-parser": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-10.2.0.tgz",
@@ -13399,6 +15149,64 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/w3c-xmlserializer/node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -13503,6 +15311,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -13615,6 +15440,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -2,11 +2,16 @@
   "name": "my-v0-project",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
     "check-types": "tsc --noEmit",
+    "type-check": "npm run check-types",
+    "lint": "next lint",
     "test": "vitest",
     "test:run": "vitest run"
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "test": "vitest",
+    "test:run": "vitest run"
   },
   "dependencies": {
     "@radix-ui/react-accordion": "1.2.12",
@@ -63,11 +65,15 @@
     "@eslint/js": "^9.39.2",
     "@hookform/resolvers": "^5.2.2",
     "@next/eslint-plugin-next": "^16.0.10",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^25.0.3",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@typescript-eslint/eslint-plugin": "^8.50.0",
     "@typescript-eslint/parser": "^8.50.0",
+    "@vitejs/plugin-react": "^6.0.1",
     "autoprefixer": "^10.4.23",
     "cmdk": "1.1.1",
     "eslint": "^9.39.2",
@@ -83,6 +89,7 @@
     "eslint-plugin-testing-library": "^7.15.1",
     "husky": "^9.1.7",
     "input-otp": "1.4.2",
+    "jsdom": "^29.0.1",
     "lint-staged": "^16.2.7",
     "postcss": "^8.5",
     "prettier": "^3.7.4",
@@ -90,6 +97,7 @@
     "recharts": "3.6.0",
     "tailwindcss": "^3.4.19",
     "typescript": "^5",
-    "vaul": "^1.1.2"
+    "vaul": "^1.1.2",
+    "vitest": "^4.1.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,7 +149,7 @@ importers:
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^6.7.1
-        version: 6.7.1(@eslint-react/eslint-plugin@2.3.13(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(@next/eslint-plugin-next@16.0.10)(@vue/compiler-sfc@3.5.25)(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2(jiti@1.21.7)))(eslint-plugin-react-hooks@7.0.1(eslint@9.39.2(jiti@1.21.7)))(eslint-plugin-react-refresh@0.4.26(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+        version: 6.7.1(@eslint-react/eslint-plugin@2.3.13(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(@next/eslint-plugin-next@16.0.10)(@vue/compiler-sfc@3.5.25)(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2(jiti@1.21.7)))(eslint-plugin-react-hooks@7.0.1(eslint@9.39.2(jiti@1.21.7)))(eslint-plugin-react-refresh@0.4.26(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)(vitest@4.1.0(@types/node@25.0.3)(jsdom@29.0.1)(vite@8.0.1(@types/node@25.0.3)(jiti@1.21.7)(yaml@2.8.2)))
       '@eslint-react/eslint-plugin':
         specifier: ^2.3.13
         version: 2.3.13(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
@@ -165,6 +165,15 @@ importers:
       '@next/eslint-plugin-next':
         specifier: ^16.0.10
         version: 16.0.10
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^25.0.3
         version: 25.0.3
@@ -180,6 +189,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^8.50.0
         version: 8.50.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.1
+        version: 6.0.1(vite@8.0.1(@types/node@25.0.3)(jiti@1.21.7)(yaml@2.8.2))
       autoprefixer:
         specifier: ^10.4.23
         version: 10.4.23(postcss@8.5.6)
@@ -197,7 +209,7 @@ importers:
         version: 10.1.8(eslint@9.39.2(jiti@1.21.7))
       eslint-plugin-jest-dom:
         specifier: ^5.5.0
-        version: 5.5.0(eslint@9.39.2(jiti@1.21.7))
+        version: 5.5.0(@testing-library/dom@10.4.1)(eslint@9.39.2(jiti@1.21.7))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
         version: 6.10.2(eslint@9.39.2(jiti@1.21.7))
@@ -225,6 +237,9 @@ importers:
       input-otp:
         specifier: 1.4.2
         version: 1.4.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      jsdom:
+        specifier: ^29.0.1
+        version: 29.0.1
       lint-staged:
         specifier: ^16.2.7
         version: 16.2.7
@@ -249,8 +264,14 @@ importers:
       vaul:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@types/node@25.0.3)(jsdom@29.0.1)(vite@8.0.1(@types/node@25.0.3)(jiti@1.21.7)(yaml@2.8.2))
 
 packages:
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -313,6 +334,17 @@ packages:
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+
+  '@asamuzakjp/css-color@5.0.1':
+    resolution: {integrity: sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.0.4':
+    resolution: {integrity: sha512-jXR6x4AcT3eIrS2fSNAwJpwirOkGcd+E7F7CP3zjdTqz9B/2huHOL8YJZBgekKwLML+u7qB/6P1LXQuMScsx0w==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -385,11 +417,51 @@ packages:
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@clack/core@0.5.0':
     resolution: {integrity: sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==}
 
   '@clack/prompts@0.11.0':
     resolution: {integrity: sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==}
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.1.1':
+    resolution: {integrity: sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.0.2':
+    resolution: {integrity: sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.1':
+    resolution: {integrity: sha512-BvqN0AMWNAnLk9G8jnUT77D+mUbY/H2b3uDTvg2isJkHaOufUE2R3AOwxWo7VBQKT1lOdwdvorddo2B/lk64+w==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
@@ -511,6 +583,15 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
+
   '@floating-ui/core@1.7.3':
     resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
 
@@ -577,89 +658,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -703,6 +800,9 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
+  '@napi-rs/wasm-runtime@1.1.1':
+    resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
+
   '@next/env@16.0.10':
     resolution: {integrity: sha512-8tuaQkyDVgeONQ1MeT9Mkk8pQmZapMKFh5B+OrFUlG3rVmYTXcXlBetBgTurKXGaIZvkoqRT9JL5K3phXcgang==}
 
@@ -726,24 +826,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.0.10':
     resolution: {integrity: sha512-llA+hiDTrYvyWI21Z0L1GiXwjQaanPVQQwru5peOgtooeJ8qx3tlqRV2P7uH2pKQaUfHxI/WVarvI5oYgGxaTw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.0.10':
     resolution: {integrity: sha512-AK2q5H0+a9nsXbeZ3FZdMtbtu9jxW4R/NgzZ6+lrTm3d6Zb7jYrWcgjcpM1k8uuqlSy4xIyPR2YiuUr+wXsavA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.0.10':
     resolution: {integrity: sha512-1TDG9PDKivNw5550S111gsO4RGennLVl9cipPhtkXIFVwo31YZ73nEbLjNC8qG3SgTz/QZyYyaFYMeY4BKZR/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.0.10':
     resolution: {integrity: sha512-aEZIS4Hh32xdJQbHz121pyuVZniSNoqDVx1yIr2hy+ZwJGipeqnMZBJHyMxv2tiuAXGx6/xpTcQJ6btIiBjgmg==}
@@ -772,6 +876,9 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@oxc-project/types@0.120.0':
+    resolution: {integrity: sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg==}
 
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
@@ -1444,6 +1551,107 @@ packages:
       react-redux:
         optional: true
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.10':
+    resolution: {integrity: sha512-jOHxwXhxmFKuXztiu1ORieJeTbx5vrTkcOkkkn2d35726+iwhrY1w/+nYY/AGgF12thg33qC3R1LMBF5tHTZHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.10':
+    resolution: {integrity: sha512-gED05Teg/vtTZbIJBc4VNMAxAFDUPkuO/rAIyyxZjTj1a1/s6z5TII/5yMGZ0uLRCifEtwUQn8OlYzuYc0m70w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.10':
+    resolution: {integrity: sha512-rI15NcM1mA48lqrIxVkHfAqcyFLcQwyXWThy+BQ5+mkKKPvSO26ir+ZDp36AgYoYVkqvMcdS8zOE6SeBsR9e8A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.10':
+    resolution: {integrity: sha512-XZRXHdTa+4ME1MuDVp021+doQ+z6Ei4CCFmNc5/sKbqb8YmkiJdj8QKlV3rCI0AJtAeSB5n0WGPuJWNL9p/L2w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.10':
+    resolution: {integrity: sha512-R0SQMRluISSLzFE20sPWYHVmJdDQnRyc/FzSCN72BqQmh2SOZUFG+N3/vBZpR4C6WpEUVYJLrYUXaj43sJsNLA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.10':
+    resolution: {integrity: sha512-Y1reMrV/o+cwpduYhJuOE3OMKx32RMYCidf14y+HssARRmhDuWXJ4yVguDg2R/8SyyGNo+auzz64LnPK9Hq6jg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.10':
+    resolution: {integrity: sha512-vELN+HNb2IzuzSBUOD4NHmP9yrGwl1DVM29wlQvx1OLSclL0NgVWnVDKl/8tEks79EFek/kebQKnNJkIAA4W2g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.10':
+    resolution: {integrity: sha512-ZqrufYTgzxbHwpqOjzSsb0UV/aV2TFIY5rP8HdsiPTv/CuAgCRjM6s9cYFwQ4CNH+hf9Y4erHW1GjZuZ7WoI7w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.10':
+    resolution: {integrity: sha512-gSlmVS1FZJSRicA6IyjoRoKAFK7IIHBs7xJuHRSmjImqk3mPPWbR7RhbnfH2G6bcmMEllCt2vQ/7u9e6bBnByg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.10':
+    resolution: {integrity: sha512-eOCKUpluKgfObT2pHjztnaWEIbUabWzk3qPZ5PuacuPmr4+JtQG4k2vGTY0H15edaTnicgU428XW/IH6AimcQw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.10':
+    resolution: {integrity: sha512-Xdf2jQbfQowJnLcgYfD/m0Uu0Qj5OdxKallD78/IPPfzaiaI4KRAwZzHcKQ4ig1gtg1SuzC7jovNiM2TzQsBXA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.10':
+    resolution: {integrity: sha512-o1hYe8hLi1EY6jgPFyxQgQ1wcycX+qz8eEbVmot2hFkgUzPxy9+kF0u0NIQBeDq+Mko47AkaFFaChcvZa9UX9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.10':
+    resolution: {integrity: sha512-Ugv9o7qYJudqQO5Y5y2N2SOo6S4WiqiNOpuQyoPInnhVzCY+wi/GHltcLHypG9DEUYMB0iTB/huJrpadiAcNcA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.10':
+    resolution: {integrity: sha512-7UODQb4fQUNT/vmgDZBl3XOBAIOutP5R3O/rkxg0aLfEGQ4opbCgU5vOw/scPe4xOqBwL9fw7/RP1vAMZ6QlAQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.10':
+    resolution: {integrity: sha512-PYxKHMVHOb5NJuDL53vBUl1VwUjymDcYI6rzpIni0C9+9mTiJedvUxSk7/RPp7OOAm3v+EjgMu9bIy3N6b408w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.10':
+    resolution: {integrity: sha512-UkVDEFk1w3mveXeKgaTuYfKWtPbvgck1dT8TUG3bnccrH0XtLTuAyfCoks4Q/M5ZGToSVJTIQYCzy2g/atAOeg==}
+
+  '@rolldown/pluginutils@1.0.0-rc.7':
+    resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -1471,8 +1679,43 @@ packages:
     peerDependencies:
       tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
@@ -1503,6 +1746,9 @@ packages:
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
@@ -1646,41 +1892,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -1702,6 +1956,19 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vitejs/plugin-react@6.0.1':
+    resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+
   '@vitest/eslint-plugin@1.5.2':
     resolution: {integrity: sha512-2t1F2iecXB/b1Ox4U137lhD3chihEE3dRVtu3qMD35tc6UqUjg1VGRJoS1AkFKwpT8zv8OQInzPQO06hrRkeqw==}
     engines: {node: '>=18'}
@@ -1714,6 +1981,35 @@ packages:
         optional: true
       vitest:
         optional: true
+
+  '@vitest/expect@4.1.0':
+    resolution: {integrity: sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==}
+
+  '@vitest/mocker@4.1.0':
+    resolution: {integrity: sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.0':
+    resolution: {integrity: sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==}
+
+  '@vitest/runner@4.1.0':
+    resolution: {integrity: sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==}
+
+  '@vitest/snapshot@4.1.0':
+    resolution: {integrity: sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==}
+
+  '@vitest/spy@4.1.0':
+    resolution: {integrity: sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==}
+
+  '@vitest/utils@4.1.0':
+    resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
 
   '@vue/compiler-core@3.5.25':
     resolution: {integrity: sha512-vay5/oQJdsNHmliWoZfHPoVZZRmnSWhug0BYT34njkYTPqClh3DNWLkZNJBVSjsNMrg0CCrBfoKkjZQPM/QVUw==}
@@ -1747,6 +2043,10 @@ packages:
     resolution: {integrity: sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw==}
     engines: {node: '>=18'}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
   ansi-regex@6.2.2:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
     engines: {node: '>=12'}
@@ -1754,6 +2054,10 @@ packages:
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
 
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
@@ -1783,6 +2087,9 @@ packages:
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -1820,6 +2127,10 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
@@ -1855,6 +2166,9 @@ packages:
   baseline-browser-mapping@2.9.9:
     resolution: {integrity: sha512-V8fbOCSeOFvlDj7LLChUcqbZrdKD9RU/VR260piF1790vT0mfLSwGc/Qzxv3IqiTukOpNtItePa0HBpMAj7MDg==}
     hasBin: true
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -1914,6 +2228,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -2017,6 +2335,13 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -2072,6 +2397,10 @@ packages:
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
     engines: {node: '>= 0.4'}
@@ -2109,6 +2438,9 @@ packages:
 
   decimal.js-light@2.5.1:
     resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.2.0:
     resolution: {integrity: sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==}
@@ -2152,6 +2484,12 @@ packages:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
 
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -2190,6 +2528,10 @@ packages:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
 
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
@@ -2209,6 +2551,9 @@ packages:
   es-iterator-helpers@1.2.2:
     resolution: {integrity: sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -2589,12 +2934,19 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
@@ -2802,6 +3154,10 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-entities@2.6.0:
     resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
 
@@ -2834,6 +3190,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   indent-string@5.0.0:
     resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
@@ -2957,6 +3317,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -3026,6 +3389,15 @@ packages:
     resolution: {integrity: sha512-c7YbokssPOSHmqTbSAmTtnVgAVa/7lumWNYqomgd5KOMyPrRve2anx6lonfOsXEQacqF9FKVUj7bLg4vRSvdYA==}
     engines: {node: '>=20.0.0'}
 
+  jsdom@29.0.1:
+    resolution: {integrity: sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
@@ -3071,6 +3443,80 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
     engines: {node: '>=14'}
@@ -3112,6 +3558,10 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  lru-cache@11.2.7:
+    resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -3119,6 +3569,10 @@ packages:
     resolution: {integrity: sha512-Y59gMY38tl4/i0qewcqohPdEbieBy7SovpBL9IFebhc2mDd8x4PZSOsiFRkpPcOq6bj1r/mjH/Rk73gSlIJP2A==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -3180,6 +3634,9 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -3279,6 +3736,10 @@ packages:
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -3396,6 +3857,9 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
@@ -3435,6 +3899,9 @@ packages:
 
   parse-statements@1.0.11:
     resolution: {integrity: sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==}
+
+  parse5@8.0.0:
+    resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -3550,6 +4017,10 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postcss@8.5.8:
+    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+    engines: {node: ^10 || ^12 || >=14}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -3558,6 +4029,10 @@ packages:
     resolution: {integrity: sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==}
     engines: {node: '>=14'}
     hasBin: true
+
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -3594,6 +4069,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -3671,6 +4149,10 @@ packages:
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   redux-thunk@3.1.0:
     resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
     peerDependencies:
@@ -3712,6 +4194,10 @@ packages:
   remark-rehype@11.1.2:
     resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   requireindex@1.2.0:
     resolution: {integrity: sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==}
     engines: {node: '>=0.10.5'}
@@ -3750,6 +4236,11 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
+  rolldown@1.0.0-rc.10:
+    resolution: {integrity: sha512-q7j6vvarRFmKpgJUT8HCAUljkgzEp4LAhPlJUvQhA5LA1SUL36s5QCysMutErzL3EbNOZOkoziSx9iZC4FddKA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -3764,6 +4255,10 @@ packages:
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -3821,6 +4316,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -3856,6 +4354,12 @@ packages:
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -3910,6 +4414,10 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   strip-indent@4.1.1:
     resolution: {integrity: sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==}
     engines: {node: '>=12'}
@@ -3950,6 +4458,9 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   synckit@0.11.11:
     resolution: {integrity: sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -3981,6 +4492,9 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@1.0.2:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
     engines: {node: '>=18'}
@@ -3988,6 +4502,17 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@7.0.27:
+    resolution: {integrity: sha512-YQ7uPjgWUibIK6DW5lrKujGwUKhLevU4hcGbP5O6TcIUb+oTjJYJVWPS4nZsIHrEEEG6myk/oqAJUEQmpZrHsg==}
+
+  tldts@7.0.27:
+    resolution: {integrity: sha512-I4FZcVFcqCRuT0ph6dCDpPuO4Xgzvh+spkcTr1gK7peIvxWauoloVO0vuy1FQnijT63ss6AsHB6+OIM4aXHbPg==}
+    hasBin: true
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -4000,6 +4525,14 @@ packages:
   toml-eslint-parser@0.10.1:
     resolution: {integrity: sha512-9mjy3frhioGIVGcwamlVlUyJ9x+WHw/TXiz9R4YOlmsIuBN43r9Dp8HZ35SF9EKjHrn3BUZj04CF+YqZ2oJ+7w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -4071,6 +4604,10 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  undici@7.24.5:
+    resolution: {integrity: sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==}
+    engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -4145,11 +4682,105 @@ packages:
   victory-vendor@37.3.6:
     resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
+  vite@8.0.1:
+    resolution: {integrity: sha512-wt+Z2qIhfFt85uiyRt5LPU4oVEJBXj8hZNWKeqFG4gRG/0RaRGJ7njQCwzFVjO+v4+Ipmf5CY7VdmZRAYYBPHw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.0:
+    resolution: {integrity: sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.0
+      '@vitest/browser-preview': 4.1.0
+      '@vitest/browser-webdriverio': 4.1.0
+      '@vitest/ui': 4.1.0
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vue-eslint-parser@10.2.0:
     resolution: {integrity: sha512-CydUvFOQKD928UzZhTp4pr2vWz1L+H99t7Pkln2QSPdvmURT0MoC4wUccfCnuEaihNsu9aYYyk+bep8rlfkUXw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -4172,6 +4803,11 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
@@ -4183,6 +4819,13 @@ packages:
   xml-name-validator@4.0.0:
     resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
     engines: {node: '>=12'}
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -4217,9 +4860,11 @@ packages:
 
 snapshots:
 
+  '@adobe/css-tools@4.4.4': {}
+
   '@alloc/quick-lru@5.2.0': {}
 
-  '@antfu/eslint-config@6.7.1(@eslint-react/eslint-plugin@2.3.13(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(@next/eslint-plugin-next@16.0.10)(@vue/compiler-sfc@3.5.25)(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2(jiti@1.21.7)))(eslint-plugin-react-hooks@7.0.1(eslint@9.39.2(jiti@1.21.7)))(eslint-plugin-react-refresh@0.4.26(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
+  '@antfu/eslint-config@6.7.1(@eslint-react/eslint-plugin@2.3.13(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(@next/eslint-plugin-next@16.0.10)(@vue/compiler-sfc@3.5.25)(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2(jiti@1.21.7)))(eslint-plugin-react-hooks@7.0.1(eslint@9.39.2(jiti@1.21.7)))(eslint-plugin-react-refresh@0.4.26(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)(vitest@4.1.0(@types/node@25.0.3)(jsdom@29.0.1)(vite@8.0.1(@types/node@25.0.3)(jiti@1.21.7)(yaml@2.8.2)))':
     dependencies:
       '@antfu/install-pkg': 1.1.0
       '@clack/prompts': 0.11.0
@@ -4228,7 +4873,7 @@ snapshots:
       '@stylistic/eslint-plugin': 5.6.1(eslint@9.39.2(jiti@1.21.7))
       '@typescript-eslint/eslint-plugin': 8.50.0(@typescript-eslint/parser@8.50.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
       '@typescript-eslint/parser': 8.50.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
-      '@vitest/eslint-plugin': 1.5.2(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+      '@vitest/eslint-plugin': 1.5.2(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)(vitest@4.1.0(@types/node@25.0.3)(jsdom@29.0.1)(vite@8.0.1(@types/node@25.0.3)(jiti@1.21.7)(yaml@2.8.2)))
       ansis: 4.2.0
       cac: 6.7.14
       eslint: 9.39.2(jiti@1.21.7)
@@ -4275,6 +4920,24 @@ snapshots:
     dependencies:
       package-manager-detector: 1.6.0
       tinyexec: 1.0.2
+
+  '@asamuzakjp/css-color@5.0.1':
+    dependencies:
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.2.7
+
+  '@asamuzakjp/dom-selector@7.0.4':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.2.7
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -4378,6 +5041,10 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
   '@clack/core@0.5.0':
     dependencies:
       picocolors: 1.1.1
@@ -4388,6 +5055,30 @@ snapshots:
       '@clack/core': 0.5.0
       picocolors: 1.1.1
       sisteransi: 1.0.5
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.1(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@date-fns/tz@1.4.1': {}
 
@@ -4570,6 +5261,8 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@exodus/bytes@1.15.0': {}
+
   '@floating-ui/core@1.7.3':
     dependencies:
       '@floating-ui/utils': 0.2.10
@@ -4726,6 +5419,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.1':
+    dependencies:
+      '@emnapi/core': 1.7.1
+      '@emnapi/runtime': 1.7.1
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@next/env@16.0.10': {}
 
   '@next/eslint-plugin-next@16.0.10':
@@ -4769,6 +5469,8 @@ snapshots:
       fastq: 1.19.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@oxc-project/types@0.120.0': {}
 
   '@pkgr/core@0.2.9': {}
 
@@ -5479,6 +6181,57 @@ snapshots:
       react: 19.2.3
       react-redux: 9.2.0(@types/react@19.2.7)(react@19.2.3)(redux@5.0.1)
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.10':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.1
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.10': {}
+
+  '@rolldown/pluginutils@1.0.0-rc.7': {}
+
   '@rtsao/scc@1.1.0': {}
 
   '@sindresorhus/base62@1.0.0': {}
@@ -5506,10 +6259,51 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 3.4.19(yaml@2.8.2)
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/runtime': 7.28.4
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@testing-library/dom': 10.4.1
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
 
   '@types/d3-array@3.2.2': {}
 
@@ -5538,6 +6332,8 @@ snapshots:
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree-jsx@1.0.5':
     dependencies:
@@ -5729,15 +6525,62 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitest/eslint-plugin@1.5.2(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.1(@types/node@25.0.3)(jiti@1.21.7)(yaml@2.8.2))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-rc.7
+      vite: 8.0.1(@types/node@25.0.3)(jiti@1.21.7)(yaml@2.8.2)
+
+  '@vitest/eslint-plugin@1.5.2(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)(vitest@4.1.0(@types/node@25.0.3)(jsdom@29.0.1)(vite@8.0.1(@types/node@25.0.3)(jiti@1.21.7)(yaml@2.8.2)))':
     dependencies:
       '@typescript-eslint/scope-manager': 8.50.0
       '@typescript-eslint/utils': 8.50.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
       eslint: 9.39.2(jiti@1.21.7)
     optionalDependencies:
       typescript: 5.9.3
+      vitest: 4.1.0(@types/node@25.0.3)(jsdom@29.0.1)(vite@8.0.1(@types/node@25.0.3)(jiti@1.21.7)(yaml@2.8.2))
     transitivePeerDependencies:
       - supports-color
+
+  '@vitest/expect@4.1.0':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.0(vite@8.0.1(@types/node@25.0.3)(jiti@1.21.7)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 4.1.0
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.1(@types/node@25.0.3)(jiti@1.21.7)(yaml@2.8.2)
+
+  '@vitest/pretty-format@4.1.0':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.0':
+    dependencies:
+      '@vitest/utils': 4.1.0
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.0':
+    dependencies:
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/utils': 4.1.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.0': {}
+
+  '@vitest/utils@4.1.0':
+    dependencies:
+      '@vitest/pretty-format': 4.1.0
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@vue/compiler-core@3.5.25':
     dependencies:
@@ -5788,11 +6631,15 @@ snapshots:
     dependencies:
       environment: 1.1.0
 
+  ansi-regex@5.0.1: {}
+
   ansi-regex@6.2.2: {}
 
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  ansi-styles@5.2.0: {}
 
   ansi-styles@6.2.3: {}
 
@@ -5814,6 +6661,10 @@ snapshots:
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.2: {}
 
@@ -5884,6 +6735,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   async-function@1.0.0: {}
@@ -5910,6 +6763,10 @@ snapshots:
   balanced-match@1.0.2: {}
 
   baseline-browser-mapping@2.9.9: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   binary-extensions@2.3.0: {}
 
@@ -5966,6 +6823,8 @@ snapshots:
   caniuse-lite@1.0.30001760: {}
 
   ccount@2.0.1: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -6065,6 +6924,13 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  css.escape@1.5.1: {}
+
   cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
@@ -6109,6 +6975,13 @@ snapshots:
 
   damerau-levenshtein@1.0.8: {}
 
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   data-view-buffer@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -6141,6 +7014,8 @@ snapshots:
 
   decimal.js-light@2.5.1: {}
 
+  decimal.js@10.6.0: {}
+
   decode-named-character-reference@1.2.0:
     dependencies:
       character-entities: 2.0.2
@@ -6161,8 +7036,7 @@ snapshots:
 
   dequal@2.0.3: {}
 
-  detect-libc@2.1.2:
-    optional: true
+  detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
 
@@ -6179,6 +7053,10 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -6212,6 +7090,8 @@ snapshots:
       tapable: 2.3.0
 
   entities@4.5.0: {}
+
+  entities@6.0.1: {}
 
   environment@1.1.0: {}
 
@@ -6294,6 +7174,8 @@ snapshots:
       internal-slot: 1.1.0
       iterator.prototype: 1.1.5
       safe-array-concat: 1.1.3
+
+  es-module-lexer@2.0.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -6464,11 +7346,13 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jest-dom@5.5.0(eslint@9.39.2(jiti@1.21.7)):
+  eslint-plugin-jest-dom@5.5.0(@testing-library/dom@10.4.1)(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       '@babel/runtime': 7.28.4
       eslint: 9.39.2(jiti@1.21.7)
       requireindex: 1.2.0
+    optionalDependencies:
+      '@testing-library/dom': 10.4.1
 
   eslint-plugin-jsdoc@61.5.0(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
@@ -6867,9 +7751,15 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
   eventemitter3@5.0.1: {}
+
+  expect-type@1.3.0: {}
 
   exsolve@1.0.8: {}
 
@@ -7078,6 +7968,12 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-entities@2.6.0: {}
 
   html-url-attributes@3.0.1: {}
@@ -7098,6 +7994,8 @@ snapshots:
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   indent-string@5.0.0: {}
 
@@ -7224,6 +8122,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -7290,6 +8190,32 @@ snapshots:
 
   jsdoc-type-pratt-parser@7.0.0: {}
 
+  jsdom@29.0.1:
+    dependencies:
+      '@asamuzakjp/css-color': 5.0.1
+      '@asamuzakjp/dom-selector': 7.0.4
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.1(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.0
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.2.7
+      parse5: 8.0.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.24.5
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
@@ -7332,6 +8258,55 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
 
   lilconfig@3.1.3: {}
 
@@ -7384,6 +8359,8 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  lru-cache@11.2.7: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -7391,6 +8368,8 @@ snapshots:
   lucide-react@0.561.0(react@19.2.3):
     dependencies:
       react: 19.2.3
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -7568,6 +8547,8 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  mdn-data@2.27.1: {}
 
   merge2@1.4.1: {}
 
@@ -7776,6 +8757,8 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
+  min-indent@1.0.1: {}
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.12
@@ -7893,6 +8876,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  obug@2.1.1: {}
+
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
@@ -7943,6 +8928,10 @@ snapshots:
       parse-statements: 1.0.11
 
   parse-statements@1.0.11: {}
+
+  parse5@8.0.0:
+    dependencies:
+      entities: 6.0.1
 
   path-exists@4.0.0: {}
 
@@ -8038,9 +9027,21 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  postcss@8.5.8:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   prelude-ls@1.2.1: {}
 
   prettier@3.7.4: {}
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
 
   prop-types@15.8.1:
     dependencies:
@@ -8073,6 +9074,8 @@ snapshots:
       react: 19.2.3
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-is@18.3.1: {}
 
@@ -8165,6 +9168,11 @@ snapshots:
       - '@types/react'
       - redux
 
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
   redux-thunk@3.1.0(redux@5.0.1):
     dependencies:
       redux: 5.0.1
@@ -8229,6 +9237,8 @@ snapshots:
       unified: 11.0.5
       vfile: 6.0.3
 
+  require-from-string@2.0.2: {}
+
   requireindex@1.2.0: {}
 
   reselect@5.1.1: {}
@@ -8260,6 +9270,27 @@ snapshots:
 
   rfdc@1.4.1: {}
 
+  rolldown@1.0.0-rc.10:
+    dependencies:
+      '@oxc-project/types': 0.120.0
+      '@rolldown/pluginutils': 1.0.0-rc.10
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.10
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.10
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.10
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.10
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.10
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.10
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.10
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.10
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.10
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.10
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.10
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.10
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.10
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.10
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.10
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -8282,6 +9313,10 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-regex: 1.2.1
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -8383,6 +9418,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   sisteransi@1.0.5: {}
@@ -8411,6 +9448,10 @@ snapshots:
   spdx-license-ids@3.0.22: {}
 
   stable-hash@0.0.5: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.0.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -8493,6 +9534,10 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   strip-indent@4.1.1: {}
 
   strip-json-comments@3.1.1: {}
@@ -8527,6 +9572,8 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  symbol-tree@3.2.4: {}
 
   synckit@0.11.11:
     dependencies:
@@ -8578,12 +9625,22 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinybench@2.9.0: {}
+
   tinyexec@1.0.2: {}
 
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyrainbow@3.1.0: {}
+
+  tldts-core@7.0.27: {}
+
+  tldts@7.0.27:
+    dependencies:
+      tldts-core: 7.0.27
 
   to-regex-range@5.0.1:
     dependencies:
@@ -8597,6 +9654,14 @@ snapshots:
   toml-eslint-parser@0.10.1:
     dependencies:
       eslint-visitor-keys: 3.4.3
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.27
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   trim-lines@3.0.1: {}
 
@@ -8684,6 +9749,8 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   undici-types@7.16.0: {}
+
+  undici@7.24.5: {}
 
   unified@11.0.5:
     dependencies:
@@ -8809,6 +9876,47 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
+  vite@8.0.1(@types/node@25.0.3)(jiti@1.21.7)(yaml@2.8.2):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.3
+      postcss: 8.5.8
+      rolldown: 1.0.0-rc.10
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 25.0.3
+      fsevents: 2.3.3
+      jiti: 1.21.7
+      yaml: 2.8.2
+
+  vitest@4.1.0(@types/node@25.0.3)(jsdom@29.0.1)(vite@8.0.1(@types/node@25.0.3)(jiti@1.21.7)(yaml@2.8.2)):
+    dependencies:
+      '@vitest/expect': 4.1.0
+      '@vitest/mocker': 4.1.0(vite@8.0.1(@types/node@25.0.3)(jiti@1.21.7)(yaml@2.8.2))
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/runner': 4.1.0
+      '@vitest/snapshot': 4.1.0
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.0.1(@types/node@25.0.3)(jiti@1.21.7)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.0.3
+      jsdom: 29.0.1
+    transitivePeerDependencies:
+      - msw
+
   vue-eslint-parser@10.2.0(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       debug: 4.4.3
@@ -8820,6 +9928,22 @@ snapshots:
       semver: 7.7.3
     transitivePeerDependencies:
       - supports-color
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -8866,6 +9990,11 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
   word-wrap@1.2.5: {}
 
   wrap-ansi@9.0.2:
@@ -8875,6 +10004,10 @@ snapshots:
       strip-ansi: 7.1.2
 
   xml-name-validator@4.0.0: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
 

--- a/types/player.ts
+++ b/types/player.ts
@@ -43,6 +43,7 @@ export type n8nWikiPlayerData = {
   };
   teams: Team[];
   nationalTeams?: NationalTeam[];
+  positionsTracker?: PositionsTracker;
 };
 
 export type PlayerConfiguration = {
@@ -168,4 +169,49 @@ export type CreateFootballerNationRequest = {
   nation_id: number;
   apps: number;
   goals: number;
+};
+
+// Position API types (from /data/positions/)
+export type Position = {
+  id: number;
+  name: string;
+  full_name: string;
+  role: 'GK' | 'DEF' | 'MID' | 'FWD';
+  sort_order: number;
+};
+
+// FootballerPosition API types (from /data/footballer-positions/)
+export type FootballerPosition = {
+  id: number;
+  footballer_id: number;
+  footballer_name: string;
+  position_id: number;
+  position_name: string;
+  position_full_name: string;
+  position_role: string;
+  is_primary: boolean;
+  sort_order: number;
+  created_at: string;
+  updated_at: string;
+};
+
+// Request type for set-positions bulk endpoint
+export type SetPositionsRequest = {
+  footballer_id: number;
+  positions: Array<{
+    position_id: number;
+    is_primary: boolean;
+    sort_order?: number;
+  }>;
+};
+
+// positionsTracker from n8n webhook
+export type PositionsTracker = {
+  hasDiscrepancy: boolean;
+  databasePositions: Array<{ id: number; name: string; fullName: string; isPrimary: boolean }>;
+  databaseHasPositions: boolean;
+  wikipediaPositions: Array<{ id: number; name: string; fullName: string; originalWikipediaName: string }>;
+  missingInDatabase: Array<{ id: number; name: string; fullName: string; originalWikipediaName: string }>;
+  missingIdsToApply: number[];
+  message: string;
 };

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,9 @@
 import react from '@vitejs/plugin-react';
+import { fileURLToPath } from 'url';
 import path from 'path';
 import { defineConfig } from 'vitest/config';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   plugins: [react()],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,18 @@
+import react from '@vitejs/plugin-react';
+import path from 'path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./vitest.setup.ts'],
+    include: ['**/__tests__/**/*.test.{ts,tsx}', '**/*.test.{ts,tsx}'],
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '.'),
+    },
+  },
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';


### PR DESCRIPTION
## Changes

Adds footballer position management to the career lookup page, related to FootballExtraTime/App#625.

### New files
- **`components/career-lookup/position-card.tsx`** — Enhanced position management card with:
  - **Toggle switch** (default ON) to enable/disable position management — when OFF, positions are excluded from API preview and deployment
  - Tabbed UI: "Selected Positions" (active selection) / "All Positions" (DB position picker)
  - Role-grouped position selector (GK/DEF/MID/FWD) with color-coded badges
  - Interactive add/remove/set-primary for each position
  - Wikipedia vs DB discrepancy detection with Synced/Mismatch/New Player badges
  - "Unsaved" indicator when selection differs from DB state
  - "Save Positions" button calling `set-positions` bulk API
- **`lib/__tests__/footballer-api.test.ts`** — 7 tests for position API methods
- **`components/career-lookup/__tests__/position-card.test.tsx`** — 12 tests for PositionCard component
- **`vitest.config.ts`** + **`vitest.setup.ts`** — Vitest testing framework setup

### Modified files
- **`types/player.ts`** — Added `Position`, `FootballerPosition`, `SetPositionsRequest`, `PositionsTracker` types; updated `n8nWikiPlayerData` to include `positionsTracker`
- **`lib/footballer-api.ts`** — Added `getPositions()`, `getFootballerPositions()`, `setPositions()` API methods
- **`components/career-lookup/career-lookup-info.tsx`** — Renders PositionCard with proper spacing (`space-y-6`), passes `onSelectedPositionsChange` callback
- **`components/career-lookup/career-lookup-player-configuration.tsx`** — Wires `set-positions` API into both new player deployment and existing player update flows; passes `selectedPositions` to JsonCommandPreview
- **`components/career-lookup/json-command-preview.tsx`** — Added Positions tab showing `POST /data/footballer-positions/set-positions/` command with payload preview; positions section in full dialog preview; fixed "No Changes" badge to reflect all change types (footballer/teams/nations/positions)
- **`app/career-lookup/page.tsx`** — Lifts `selectedPositions` state to page level, wires between CareerLookupInfo and CareerLookupPlayerConfiguration

### How it works
1. The n8n webhook sends a `positionsTracker` field with Wikipedia vs DB position comparison
2. The PositionCard shows a toggle switch (default ON) — when disabled, positions are fully excluded from the API commands preview and deployment
3. "Selected Positions" tab shows the active selection where users can remove positions or set primary
4. "All Positions" tab fetches all 16 positions from the API, grouped by role, letting users click to add/remove
5. Position commands appear in the API Commands Preview alongside Footballer/Teams/Nations tabs
6. The main preview badge correctly shows "Has Changes" / "No Changes" considering all data types
7. "Save Positions" button syncs the selection via the `set-positions` bulk API
8. New player deployments auto-assign positions; existing player updates auto-sync discrepancies

### Tests
All 19 tests pass ✅ (7 API + 12 component)

Relates to FootballExtraTime/App#625
Depends on FootballExtraTime/App#624 (backend positions API)