### PR TITLE
feat(user-hub): read-only User Hub — favourites analytics + user list/detail (Phase 1)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -54,7 +54,7 @@ export default function DashboardPage() {
     router.push('/team-players');
   };
   const navigateToUserHub = () => {
-    router.push('/user-hub/analytics');
+    router.push('/user-hub');
   };
 
   return (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,7 +22,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { useAuth } from '@/lib/auth';
 
 export default function DashboardPage() {
-  const { user, isLoading, isAuthenticated } = useAuth();
+  const { isLoading, isAuthenticated } = useAuth();
   const router = useRouter();
 
   // Show loading spinner while checking authentication
@@ -52,6 +52,9 @@ export default function DashboardPage() {
   };
   const navigateToTeamPlayers = () => {
     router.push('/team-players');
+  };
+  const navigateToUserHub = () => {
+    router.push('/user-hub/analytics');
   };
 
   return (
@@ -196,24 +199,23 @@ export default function DashboardPage() {
             </CardContent>
           </Card>
 
-          <Card className="opacity-60 transition-shadow duration-200 hover:shadow-lg">
+          <Card className="transition-shadow duration-200 hover:shadow-lg">
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
                 <Users className="size-5 text-orange-600" />
-                User Management
+                User Hub
               </CardTitle>
               <CardDescription>
-                Manage user accounts and permissions
+                Favourites analytics and user profiles (read-only)
               </CardDescription>
             </CardHeader>
             <CardContent>
               <Button
-                disabled
-                className="w-full"
-                variant="outline"
+                onClick={navigateToUserHub}
+                className="w-full border-emerald-500 bg-gradient-to-r from-emerald-500 to-green-600 text-white shadow-lg transition-all duration-200 hover:border-emerald-600 hover:from-emerald-600 hover:to-green-700 hover:shadow-xl"
               >
-                <Users className="mr-2 size-4" />
-                Coming Soon
+                <BarChart3 className="mr-2 size-4" />
+                Open User Hub
               </Button>
             </CardContent>
           </Card>

--- a/app/user-hub/analytics/page.tsx
+++ b/app/user-hub/analytics/page.tsx
@@ -8,6 +8,7 @@ import { Navigation } from '@/components/navigation';
 import { Button } from '@/components/ui/button';
 import { AdminGate } from '@/components/user-hub/AdminGate';
 import { AnalyticsSkeleton } from '@/components/user-hub/AnalyticsSkeleton';
+import { FavouriteInsights } from '@/components/user-hub/FavouriteInsights';
 import { FavouritesUsageSummary } from '@/components/user-hub/FavouritesUsageSummary';
 import { GamePopularityChart } from '@/components/user-hub/GamePopularityChart';
 import { UserHubNav } from '@/components/user-hub/UserHubNav';
@@ -72,6 +73,7 @@ export default function UserHubAnalyticsPage() {
                       gamePopularity={data.game_popularity}
                       onGameSelect={slug => router.push(`/user-hub/users?favourite_game=${encodeURIComponent(slug)}`)}
                     />
+                    <FavouriteInsights data={data} />
                   </>
                 )}
               </>

--- a/app/user-hub/analytics/page.tsx
+++ b/app/user-hub/analytics/page.tsx
@@ -1,11 +1,13 @@
 'use client';
 
 import { BarChart3 } from 'lucide-react';
+import { useRouter } from 'next/navigation';
 import { LoadingSpinner } from '@/components/loading-spinner';
 import { LoginForm } from '@/components/login-form';
 import { Navigation } from '@/components/navigation';
 import { Button } from '@/components/ui/button';
 import { AdminGate } from '@/components/user-hub/AdminGate';
+import { AnalyticsSkeleton } from '@/components/user-hub/AnalyticsSkeleton';
 import { FavouritesUsageSummary } from '@/components/user-hub/FavouritesUsageSummary';
 import { GamePopularityChart } from '@/components/user-hub/GamePopularityChart';
 import { UserHubNav } from '@/components/user-hub/UserHubNav';
@@ -14,6 +16,7 @@ import { useAuth } from '@/lib/auth';
 
 export default function UserHubAnalyticsPage() {
   const { isLoading, isAuthenticated, user } = useAuth();
+  const router = useRouter();
   const { data, isLoading: dataLoading, error, notDeployed, refetch } = useFavouritesUsage(
     isAuthenticated && !!user?.is_superuser,
   );
@@ -27,7 +30,7 @@ export default function UserHubAnalyticsPage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-green-50 to-blue-50 p-4 dark:from-slate-800 dark:to-emerald-900/30">
-      <div className="mx-auto max-w-5xl space-y-6">
+      <div className="mx-auto max-w-7xl space-y-6">
         <Navigation />
 
         <div className="space-y-2 text-center">
@@ -37,7 +40,7 @@ export default function UserHubAnalyticsPage() {
             Favourites Analytics
           </h1>
           <p className="text-gray-600 dark:text-gray-300">
-            How many users have set favourite games, and which games are most favourited.
+            Favourites adoption metrics. Click a game bar to see who favourited it.
           </p>
         </div>
 
@@ -48,7 +51,7 @@ export default function UserHubAnalyticsPage() {
           : (
               <>
                 <UserHubNav />
-                {dataLoading && <p className="text-center text-sm text-gray-500">Loading analytics…</p>}
+                {dataLoading && <AnalyticsSkeleton />}
 
                 {error && (
                   <div
@@ -65,7 +68,10 @@ export default function UserHubAnalyticsPage() {
                 {data && !notDeployed && (
                   <>
                     <FavouritesUsageSummary data={data} />
-                    <GamePopularityChart gamePopularity={data.game_popularity} />
+                    <GamePopularityChart
+                      gamePopularity={data.game_popularity}
+                      onGameSelect={slug => router.push(`/user-hub/users?favourite_game=${encodeURIComponent(slug)}`)}
+                    />
                   </>
                 )}
               </>

--- a/app/user-hub/analytics/page.tsx
+++ b/app/user-hub/analytics/page.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button';
 import { AdminGate } from '@/components/user-hub/AdminGate';
 import { FavouritesUsageSummary } from '@/components/user-hub/FavouritesUsageSummary';
 import { GamePopularityChart } from '@/components/user-hub/GamePopularityChart';
+import { UserHubNav } from '@/components/user-hub/UserHubNav';
 import { useFavouritesUsage } from '@/hooks/use-favourites-usage';
 import { useAuth } from '@/lib/auth';
 
@@ -46,6 +47,7 @@ export default function UserHubAnalyticsPage() {
             )
           : (
               <>
+                <UserHubNav />
                 {dataLoading && <p className="text-center text-sm text-gray-500">Loading analytics…</p>}
 
                 {error && (

--- a/app/user-hub/analytics/page.tsx
+++ b/app/user-hub/analytics/page.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { BarChart3 } from 'lucide-react';
+import { LoadingSpinner } from '@/components/loading-spinner';
+import { LoginForm } from '@/components/login-form';
+import { Navigation } from '@/components/navigation';
+import { Button } from '@/components/ui/button';
+import { AdminGate } from '@/components/user-hub/AdminGate';
+import { FavouritesUsageSummary } from '@/components/user-hub/FavouritesUsageSummary';
+import { GamePopularityChart } from '@/components/user-hub/GamePopularityChart';
+import { useFavouritesUsage } from '@/hooks/use-favourites-usage';
+import { useAuth } from '@/lib/auth';
+
+export default function UserHubAnalyticsPage() {
+  const { isLoading, isAuthenticated, user } = useAuth();
+  const { data, isLoading: dataLoading, error, notDeployed, refetch } = useFavouritesUsage(
+    isAuthenticated && !!user?.is_superuser,
+  );
+
+  if (isLoading) {
+    return <LoadingSpinner message="Authenticating" subtitle="Verifying staff access..." />;
+  }
+  if (!isAuthenticated) {
+    return <LoginForm />;
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-green-50 to-blue-50 p-4 dark:from-slate-800 dark:to-emerald-900/30">
+      <div className="mx-auto max-w-5xl space-y-6">
+        <Navigation />
+
+        <div className="space-y-2 text-center">
+          <h1 className="flex items-center justify-center gap-2 text-3xl font-bold text-gray-900 dark:text-white">
+            <BarChart3 className="size-7 text-emerald-600" />
+            {' '}
+            Favourites Analytics
+          </h1>
+          <p className="text-gray-600 dark:text-gray-300">
+            How many users have set favourite games, and which games are most favourited.
+          </p>
+        </div>
+
+        {!user?.is_superuser
+          ? (
+              <AdminGate />
+            )
+          : (
+              <>
+                {dataLoading && <p className="text-center text-sm text-gray-500">Loading analytics…</p>}
+
+                {error && (
+                  <div
+                    role="alert"
+                    className="whitespace-pre-line rounded-md border border-amber-300 bg-amber-50 p-4 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-200"
+                  >
+                    {error}
+                    <div className="mt-3">
+                      <Button size="sm" variant="outline" onClick={refetch}>Retry</Button>
+                    </div>
+                  </div>
+                )}
+
+                {data && !notDeployed && (
+                  <>
+                    <FavouritesUsageSummary data={data} />
+                    <GamePopularityChart gamePopularity={data.game_popularity} />
+                  </>
+                )}
+              </>
+            )}
+      </div>
+    </div>
+  );
+}

--- a/app/user-hub/page.tsx
+++ b/app/user-hub/page.tsx
@@ -22,18 +22,18 @@ type HubOption = {
 
 const OPTIONS: HubOption[] = [
   {
-    title: 'Favourites Analytics',
-    description: 'Adoption of favourite games and which games are most favourited.',
-    icon: <BarChart3 className="size-5 text-emerald-600" />,
-    href: '/user-hub/analytics',
-    cta: 'Open analytics',
-  },
-  {
     title: 'Users',
     description: 'Search and filter users; open a profile to view favourites and status. Read-only.',
     icon: <Users className="size-5 text-emerald-600" />,
     href: '/user-hub/users',
     cta: 'Browse users',
+  },
+  {
+    title: 'Favourites Analytics',
+    description: 'Adoption of favourite games and which games are most favourited.',
+    icon: <BarChart3 className="size-5 text-emerald-600" />,
+    href: '/user-hub/analytics',
+    cta: 'Open analytics',
   },
   {
     title: 'Audit & moderation',

--- a/app/user-hub/page.tsx
+++ b/app/user-hub/page.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { ArrowRight, BarChart3, ShieldCheck, Users } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { LoadingSpinner } from '@/components/loading-spinner';
+import { LoginForm } from '@/components/login-form';
+import { Navigation } from '@/components/navigation';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { AdminGate } from '@/components/user-hub/AdminGate';
+import { UserHubNav } from '@/components/user-hub/UserHubNav';
+import { useAuth } from '@/lib/auth';
+
+type HubOption = {
+  title: string;
+  description: string;
+  icon: React.ReactNode;
+  href?: string;
+  cta: string;
+  disabled?: boolean;
+};
+
+const OPTIONS: HubOption[] = [
+  {
+    title: 'Favourites Analytics',
+    description: 'Adoption of favourite games and which games are most favourited.',
+    icon: <BarChart3 className="size-5 text-emerald-600" />,
+    href: '/user-hub/analytics',
+    cta: 'Open analytics',
+  },
+  {
+    title: 'Users',
+    description: 'Search users and open a profile: favourites, rankings, status. Read-only.',
+    icon: <Users className="size-5 text-emerald-600" />,
+    href: '/user-hub/users',
+    cta: 'Browse users',
+  },
+  {
+    title: 'Audit & moderation',
+    description: 'Suspension history and a “who changed what” audit trail.',
+    icon: <ShieldCheck className="size-5 text-gray-400" />,
+    cta: 'Coming soon (Phase 2)',
+    disabled: true,
+  },
+];
+
+export default function UserHubLandingPage() {
+  const { isLoading, isAuthenticated, user } = useAuth();
+  const router = useRouter();
+
+  if (isLoading) {
+    return <LoadingSpinner message="Authenticating" subtitle="Verifying staff access..." />;
+  }
+  if (!isAuthenticated) {
+    return <LoginForm />;
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-green-50 to-blue-50 p-4 dark:from-slate-800 dark:to-emerald-900/30">
+      <div className="mx-auto max-w-5xl space-y-6">
+        <Navigation />
+
+        <div className="space-y-2 text-center">
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">User Hub</h1>
+          <p className="text-gray-600 dark:text-gray-300">
+            User analytics and management — admin-only.
+          </p>
+        </div>
+
+        {!user?.is_superuser
+          ? (
+              <AdminGate />
+            )
+          : (
+              <>
+                <UserHubNav />
+                <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+                  {OPTIONS.map(o => (
+                    <Card
+                      key={o.title}
+                      className={o.disabled ? 'opacity-60' : 'transition-shadow duration-200 hover:shadow-lg'}
+                    >
+                      <CardHeader>
+                        <CardTitle className="flex items-center gap-2 text-base">
+                          {o.icon}
+                          {o.title}
+                        </CardTitle>
+                        <CardDescription>{o.description}</CardDescription>
+                      </CardHeader>
+                      <CardContent>
+                        <Button
+                          variant={o.disabled ? 'outline' : 'default'}
+                          disabled={o.disabled}
+                          onClick={() => o.href && router.push(o.href)}
+                          className={o.disabled
+                            ? 'w-full'
+                            : 'w-full bg-gradient-to-r from-emerald-500 to-green-600 text-white hover:from-emerald-600 hover:to-green-700'}
+                        >
+                          {o.cta}
+                          {!o.disabled && <ArrowRight className="ml-2 size-4" />}
+                        </Button>
+                      </CardContent>
+                    </Card>
+                  ))}
+                </div>
+              </>
+            )}
+      </div>
+    </div>
+  );
+}

--- a/app/user-hub/page.tsx
+++ b/app/user-hub/page.tsx
@@ -30,7 +30,7 @@ const OPTIONS: HubOption[] = [
   },
   {
     title: 'Users',
-    description: 'Search users and open a profile: favourites, rankings, status. Read-only.',
+    description: 'Search and filter users; open a profile to view favourites and status. Read-only.',
     icon: <Users className="size-5 text-emerald-600" />,
     href: '/user-hub/users',
     cta: 'Browse users',
@@ -57,7 +57,7 @@ export default function UserHubLandingPage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-green-50 to-blue-50 p-4 dark:from-slate-800 dark:to-emerald-900/30">
-      <div className="mx-auto max-w-5xl space-y-6">
+      <div className="mx-auto max-w-7xl space-y-6">
         <Navigation />
 
         <div className="space-y-2 text-center">

--- a/app/user-hub/users/page.tsx
+++ b/app/user-hub/users/page.tsx
@@ -2,7 +2,7 @@
 
 import type { HubUser } from '@/types/user-hub';
 import { LayoutGrid, List, Users } from 'lucide-react';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { LoadingSpinner } from '@/components/loading-spinner';
 import { LoginForm } from '@/components/login-form';
 import { Navigation } from '@/components/navigation';
@@ -20,6 +20,7 @@ import {
 import { AdminGate } from '@/components/user-hub/AdminGate';
 import { UserCard } from '@/components/user-hub/UserCard';
 import { UserDetailSheet } from '@/components/user-hub/UserDetailSheet';
+import { UserHubNav } from '@/components/user-hub/UserHubNav';
 import { UserTable } from '@/components/user-hub/UserTable';
 import { useDebouncedValue } from '@/hooks/use-debounced-value';
 import { USER_LIST_PAGE_SIZE, useUserList } from '@/hooks/use-user-list';
@@ -40,6 +41,7 @@ export default function UserHubUsersPage() {
   const [q, setQ] = useState('');
   const debouncedQ = useDebouncedValue(q, 300);
   const [view, setView] = useState<'cards' | 'table'>('table');
+  const [presence, setPresence] = useState<'all' | 'online' | 'offline'>('all');
   const [selected, setSelected] = useState<HubUser | null>(null);
   const [sheetOpen, setSheetOpen] = useState(false);
 
@@ -54,6 +56,15 @@ export default function UserHubUsersPage() {
     isLoading: listLoading,
     error,
   } = useUserList(isAdmin, debouncedQ);
+
+  // Presence isn't server-filterable (is_online is Redis-derived, not a DB
+  // field), so this narrows the current page client-side.
+  const visibleUsers = useMemo(() => {
+    if (presence === 'all') {
+      return users;
+    }
+    return users.filter(u => (presence === 'online' ? u.is_online === true : u.is_online === false));
+  }, [users, presence]);
 
   if (isLoading) {
     return <LoadingSpinner message="Authenticating" subtitle="Verifying staff access..." />;
@@ -89,8 +100,9 @@ export default function UserHubUsersPage() {
             )
           : (
               <>
+                <UserHubNav />
                 <Card>
-                  <CardContent className="grid grid-cols-1 gap-3 pt-6 md:grid-cols-3">
+                  <CardContent className="grid grid-cols-1 gap-3 pt-6 md:grid-cols-4">
                     <div className="md:col-span-2">
                       <label htmlFor="user-search" className="mb-1 block text-xs font-medium text-gray-600">Search</label>
                       <Input
@@ -100,6 +112,17 @@ export default function UserHubUsersPage() {
                         value={q}
                         onChange={e => setQ(e.target.value)}
                       />
+                    </div>
+                    <div>
+                      <label htmlFor="user-presence" className="mb-1 block text-xs font-medium text-gray-600">Presence</label>
+                      <Select value={presence} onValueChange={v => setPresence(v as 'all' | 'online' | 'offline')}>
+                        <SelectTrigger id="user-presence"><SelectValue /></SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="all">All</SelectItem>
+                          <SelectItem value="online">Online</SelectItem>
+                          <SelectItem value="offline">Offline</SelectItem>
+                        </SelectContent>
+                      </Select>
                     </div>
                     <div>
                       <label htmlFor="user-ordering" className="mb-1 block text-xs font-medium text-gray-600">Sort</label>
@@ -114,6 +137,12 @@ export default function UserHubUsersPage() {
                     </div>
                   </CardContent>
                 </Card>
+                {presence !== 'all' && (
+                  <p className="-mt-3 text-center text-xs text-gray-500">
+                    Presence filter applies to the current page only (online status isn't
+                    server-side filterable yet).
+                  </p>
+                )}
 
                 <div className="flex items-center justify-end">
                   <div className="flex gap-1">
@@ -150,7 +179,7 @@ export default function UserHubUsersPage() {
                 {!listLoading && !error && (
                   view === 'cards'
                     ? (
-                        users.length === 0
+                        visibleUsers.length === 0
                           ? (
                               <div className="rounded-md border p-8 text-center text-sm text-gray-500">
                                 No users match your search.
@@ -158,12 +187,12 @@ export default function UserHubUsersPage() {
                             )
                           : (
                               <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3">
-                                {users.map(u => <UserCard key={u.id} user={u} onSelect={handleSelect} />)}
+                                {visibleUsers.map(u => <UserCard key={u.id} user={u} onSelect={handleSelect} />)}
                               </div>
                             )
                       )
                     : (
-                        <UserTable users={users} onSelect={handleSelect} />
+                        <UserTable users={visibleUsers} onSelect={handleSelect} />
                       )
                 )}
 

--- a/app/user-hub/users/page.tsx
+++ b/app/user-hub/users/page.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import type { HubUser } from '@/types/user-hub';
+import type { ChipKey } from '@/components/user-hub/ActiveFilterChips';
+import type { BoolParam, HubUser, SuspensionFilter, UserListFilters } from '@/types/user-hub';
 import { LayoutGrid, List, Users } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { LoadingSpinner } from '@/components/loading-spinner';
 import { LoginForm } from '@/components/login-form';
 import { Navigation } from '@/components/navigation';
@@ -17,54 +19,89 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { ActiveFilterChips } from '@/components/user-hub/ActiveFilterChips';
 import { AdminGate } from '@/components/user-hub/AdminGate';
 import { UserCard } from '@/components/user-hub/UserCard';
 import { UserDetailSheet } from '@/components/user-hub/UserDetailSheet';
 import { UserHubNav } from '@/components/user-hub/UserHubNav';
 import { UserTable } from '@/components/user-hub/UserTable';
+import { UserTableSkeleton } from '@/components/user-hub/UserTableSkeleton';
 import { useDebouncedValue } from '@/hooks/use-debounced-value';
+import { useFavouritesUsage } from '@/hooks/use-favourites-usage';
 import { USER_LIST_PAGE_SIZE, useUserList } from '@/hooks/use-user-list';
 import { useAuth } from '@/lib/auth';
+import { readFilters, serialiseFilters } from '@/lib/user-hub-filters';
+import { prettySlug } from '@/lib/user-hub-format';
 
-const ORDERING_OPTIONS: { value: string; label: string }[] = [
+const ORDERING_OPTIONS = [
   { value: 'id', label: 'ID (oldest)' },
   { value: '-id', label: 'ID (newest)' },
   { value: 'username', label: 'Username (A–Z)' },
   { value: '-username', label: 'Username (Z–A)' },
-  { value: 'email', label: 'Email (A–Z)' },
+  { value: '-date_joined', label: 'Newest joined' },
+  { value: '-last_login', label: 'Recently active' },
 ];
 
-export default function UserHubUsersPage() {
+/** `undefined` → the "all" sentinel shadcn Select needs; and back. */
+const ALL = 'all';
+
+function UserHubUsersInner() {
   const { isLoading, isAuthenticated, user } = useAuth();
   const isAdmin = isAuthenticated && !!user?.is_superuser;
 
-  const [q, setQ] = useState('');
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+  const router = useRouter();
+
+  const filters = useMemo(
+    () => readFilters(new URLSearchParams(searchParams.toString())),
+    [searchParams],
+  );
+
+  // Search box stays local for snappy typing; the debounced value is what we
+  // write to the URL (avoids history spam).
+  const [q, setQ] = useState(filters.search ?? '');
   const debouncedQ = useDebouncedValue(q, 300);
+
   const [view, setView] = useState<'cards' | 'table'>('table');
-  const [presence, setPresence] = useState<'all' | 'online' | 'offline'>('all');
   const [selected, setSelected] = useState<HubUser | null>(null);
   const [sheetOpen, setSheetOpen] = useState(false);
 
-  const {
-    users,
-    count,
-    totalPages,
-    page,
-    setPage,
-    ordering,
-    setOrdering,
-    isLoading: listLoading,
-    error,
-  } = useUserList(isAdmin, debouncedQ);
+  const writeFilters = useCallback(
+    (next: UserListFilters) => {
+      const qs = serialiseFilters(next);
+      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+    },
+    [pathname, router],
+  );
 
-  // Presence isn't server-filterable (is_online is Redis-derived, not a DB
-  // field), so this narrows the current page client-side.
-  const visibleUsers = useMemo(() => {
-    if (presence === 'all') {
-      return users;
+  // Patch a facet and reset to page 1 (the result set changed).
+  const updateFilter = useCallback(
+    (patch: Partial<UserListFilters>) => {
+      writeFilters({ ...filters, ...patch, page: 1 });
+    },
+    [filters, writeFilters],
+  );
+
+  // Sync the debounced search term into the URL when it diverges.
+  useEffect(() => {
+    const next = debouncedQ.trim() || undefined;
+    if (next !== filters.search) {
+      writeFilters({ ...filters, search: next, page: 1 });
     }
-    return users.filter(u => (presence === 'online' ? u.is_online === true : u.is_online === false));
-  }, [users, presence]);
+    // Only react to debounced input; filters/writeFilters are stable enough here.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedQ]);
+
+  const { users, count, totalPages, isLoading: listLoading, error } = useUserList(isAdmin, filters);
+
+  // Favourite-game picker options come from the analytics payload (games that
+  // have ≥1 favourite). Degrades gracefully if that endpoint isn't deployed.
+  const { data: favData } = useFavouritesUsage(isAdmin);
+  const gameOptions = useMemo(
+    () => (favData ? Object.keys(favData.game_popularity).sort() : []),
+    [favData],
+  );
 
   if (isLoading) {
     return <LoadingSpinner message="Authenticating" subtitle="Verifying staff access..." />;
@@ -76,6 +113,15 @@ export default function UserHubUsersPage() {
   function handleSelect(u: HubUser) {
     setSelected(u);
     setSheetOpen(true);
+  }
+
+  function clearChip(key: ChipKey) {
+    updateFilter({ [key]: undefined });
+  }
+
+  function clearAll() {
+    setQ('');
+    writeFilters({ ordering: filters.ordering, page: 1 });
   }
 
   return (
@@ -90,7 +136,7 @@ export default function UserHubUsersPage() {
             Users
           </h1>
           <p className="text-gray-600 dark:text-gray-300">
-            Search users and open a profile to view favourites, rankings and status. Read-only.
+            Search and filter users. Open a profile to view favourites and status. Read-only.
           </p>
         </div>
 
@@ -101,9 +147,10 @@ export default function UserHubUsersPage() {
           : (
               <>
                 <UserHubNav />
+
                 <Card>
-                  <CardContent className="grid grid-cols-1 gap-3 pt-6 md:grid-cols-4">
-                    <div className="md:col-span-2">
+                  <CardContent className="grid grid-cols-1 gap-3 pt-6 sm:grid-cols-2 lg:grid-cols-4">
+                    <div className="sm:col-span-2 lg:col-span-1">
                       <label htmlFor="user-search" className="mb-1 block text-xs font-medium text-gray-600">Search</label>
                       <Input
                         id="user-search"
@@ -113,21 +160,42 @@ export default function UserHubUsersPage() {
                         onChange={e => setQ(e.target.value)}
                       />
                     </div>
+
                     <div>
-                      <label htmlFor="user-presence" className="mb-1 block text-xs font-medium text-gray-600">Presence</label>
-                      <Select value={presence} onValueChange={v => setPresence(v as 'all' | 'online' | 'offline')}>
-                        <SelectTrigger id="user-presence"><SelectValue /></SelectTrigger>
+                      <label htmlFor="filter-favourite" className="mb-1 block text-xs font-medium text-gray-600">Favourited game</label>
+                      <Select
+                        value={filters.favourite_game ?? ALL}
+                        onValueChange={v => updateFilter({ favourite_game: v === ALL ? undefined : v })}
+                      >
+                        <SelectTrigger id="filter-favourite"><SelectValue /></SelectTrigger>
                         <SelectContent>
-                          <SelectItem value="all">All</SelectItem>
-                          <SelectItem value="online">Online</SelectItem>
-                          <SelectItem value="offline">Offline</SelectItem>
+                          <SelectItem value={ALL}>Any game</SelectItem>
+                          {gameOptions.map(slug => (
+                            <SelectItem key={slug} value={slug}>{prettySlug(slug)}</SelectItem>
+                          ))}
                         </SelectContent>
                       </Select>
                     </div>
+
                     <div>
-                      <label htmlFor="user-ordering" className="mb-1 block text-xs font-medium text-gray-600">Sort</label>
-                      <Select value={ordering} onValueChange={setOrdering}>
-                        <SelectTrigger id="user-ordering"><SelectValue /></SelectTrigger>
+                      <label htmlFor="filter-presence" className="mb-1 block text-xs font-medium text-gray-600">Presence</label>
+                      <Select
+                        value={filters.is_online ?? ALL}
+                        onValueChange={v => updateFilter({ is_online: v === ALL ? undefined : (v as BoolParam) })}
+                      >
+                        <SelectTrigger id="filter-presence"><SelectValue /></SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value={ALL}>All</SelectItem>
+                          <SelectItem value="true">Online</SelectItem>
+                          <SelectItem value="false">Offline</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+
+                    <div>
+                      <label htmlFor="filter-ordering" className="mb-1 block text-xs font-medium text-gray-600">Sort</label>
+                      <Select value={filters.ordering ?? 'id'} onValueChange={v => updateFilter({ ordering: v })}>
+                        <SelectTrigger id="filter-ordering"><SelectValue /></SelectTrigger>
                         <SelectContent>
                           {ORDERING_OPTIONS.map(o => (
                             <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
@@ -135,14 +203,58 @@ export default function UserHubUsersPage() {
                         </SelectContent>
                       </Select>
                     </div>
+
+                    <div>
+                      <label htmlFor="filter-suspension" className="mb-1 block text-xs font-medium text-gray-600">Suspension</label>
+                      <Select
+                        value={filters.suspension ?? ALL}
+                        onValueChange={v => updateFilter({ suspension: v === ALL ? undefined : (v as SuspensionFilter) })}
+                      >
+                        <SelectTrigger id="filter-suspension"><SelectValue /></SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value={ALL}>Any</SelectItem>
+                          <SelectItem value="none">Not suspended</SelectItem>
+                          <SelectItem value="any">Suspended</SelectItem>
+                          <SelectItem value="FULL_PLATFORM">Full platform</SelectItem>
+                          <SelectItem value="ALL_GAMES">All games</SelectItem>
+                          <SelectItem value="MULTIPLAYER">Multiplayer</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+
+                    <div>
+                      <label htmlFor="filter-beta" className="mb-1 block text-xs font-medium text-gray-600">Beta</label>
+                      <Select
+                        value={filters.is_beta_tester ?? ALL}
+                        onValueChange={v => updateFilter({ is_beta_tester: v === ALL ? undefined : (v as BoolParam) })}
+                      >
+                        <SelectTrigger id="filter-beta"><SelectValue /></SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value={ALL}>All</SelectItem>
+                          <SelectItem value="true">Beta testers</SelectItem>
+                          <SelectItem value="false">Non-beta</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+
+                    <div>
+                      <label htmlFor="filter-active" className="mb-1 block text-xs font-medium text-gray-600">Account</label>
+                      <Select
+                        value={filters.is_active ?? ALL}
+                        onValueChange={v => updateFilter({ is_active: v === ALL ? undefined : (v as BoolParam) })}
+                      >
+                        <SelectTrigger id="filter-active"><SelectValue /></SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value={ALL}>All</SelectItem>
+                          <SelectItem value="true">Active</SelectItem>
+                          <SelectItem value="false">Inactive</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
                   </CardContent>
                 </Card>
-                {presence !== 'all' && (
-                  <p className="-mt-3 text-center text-xs text-gray-500">
-                    Presence filter applies to the current page only (online status isn't
-                    server-side filterable yet).
-                  </p>
-                )}
+
+                <ActiveFilterChips filters={filters} onRemove={clearChip} onClearAll={clearAll} />
 
                 <div className="flex items-center justify-end">
                   <div className="flex gap-1">
@@ -174,35 +286,37 @@ export default function UserHubUsersPage() {
                   </div>
                 )}
 
-                {listLoading && <p className="text-center text-sm text-gray-500">Loading users…</p>}
-
-                {!listLoading && !error && (
-                  view === 'cards'
-                    ? (
-                        visibleUsers.length === 0
-                          ? (
-                              <div className="rounded-md border p-8 text-center text-sm text-gray-500">
-                                No users match your search.
-                              </div>
-                            )
-                          : (
-                              <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3">
-                                {visibleUsers.map(u => <UserCard key={u.id} user={u} onSelect={handleSelect} />)}
-                              </div>
-                            )
-                      )
-                    : (
-                        <UserTable users={visibleUsers} onSelect={handleSelect} />
-                      )
-                )}
+                {listLoading
+                  ? (
+                      <UserTableSkeleton />
+                    )
+                  : !error && (
+                      view === 'cards'
+                        ? (
+                            users.length === 0
+                              ? (
+                                  <div className="rounded-md border p-8 text-center text-sm text-gray-500">
+                                    No users match your filters.
+                                  </div>
+                                )
+                              : (
+                                  <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3">
+                                    {users.map(u => <UserCard key={u.id} user={u} onSelect={handleSelect} />)}
+                                  </div>
+                                )
+                          )
+                        : (
+                            <UserTable users={users} onSelect={handleSelect} />
+                          )
+                    )}
 
                 <DataPagination
-                  currentPage={page}
+                  currentPage={filters.page ?? 1}
                   totalPages={totalPages}
                   totalCount={count}
                   visibleCount={users.length}
                   pageSize={USER_LIST_PAGE_SIZE}
-                  onPageChange={setPage}
+                  onPageChange={p => writeFilters({ ...filters, page: p })}
                   disabled={listLoading}
                 />
               </>
@@ -211,5 +325,13 @@ export default function UserHubUsersPage() {
         <UserDetailSheet user={selected} open={sheetOpen} onOpenChange={setSheetOpen} />
       </div>
     </div>
+  );
+}
+
+export default function UserHubUsersPage() {
+  return (
+    <Suspense fallback={<LoadingSpinner message="Loading" subtitle="Preparing the user list..." />}>
+      <UserHubUsersInner />
+    </Suspense>
   );
 }

--- a/app/user-hub/users/page.tsx
+++ b/app/user-hub/users/page.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import type { HubUser } from '@/types/user-hub';
+import { LayoutGrid, List, Users } from 'lucide-react';
+import { useState } from 'react';
+import { LoadingSpinner } from '@/components/loading-spinner';
+import { LoginForm } from '@/components/login-form';
+import { Navigation } from '@/components/navigation';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { DataPagination } from '@/components/ui/data-pagination';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { AdminGate } from '@/components/user-hub/AdminGate';
+import { UserCard } from '@/components/user-hub/UserCard';
+import { UserDetailSheet } from '@/components/user-hub/UserDetailSheet';
+import { UserTable } from '@/components/user-hub/UserTable';
+import { useDebouncedValue } from '@/hooks/use-debounced-value';
+import { USER_LIST_PAGE_SIZE, useUserList } from '@/hooks/use-user-list';
+import { useAuth } from '@/lib/auth';
+
+const ORDERING_OPTIONS: { value: string; label: string }[] = [
+  { value: 'id', label: 'ID (oldest)' },
+  { value: '-id', label: 'ID (newest)' },
+  { value: 'username', label: 'Username (A–Z)' },
+  { value: '-username', label: 'Username (Z–A)' },
+  { value: 'email', label: 'Email (A–Z)' },
+];
+
+export default function UserHubUsersPage() {
+  const { isLoading, isAuthenticated, user } = useAuth();
+  const isAdmin = isAuthenticated && !!user?.is_superuser;
+
+  const [q, setQ] = useState('');
+  const debouncedQ = useDebouncedValue(q, 300);
+  const [view, setView] = useState<'cards' | 'table'>('table');
+  const [selected, setSelected] = useState<HubUser | null>(null);
+  const [sheetOpen, setSheetOpen] = useState(false);
+
+  const {
+    users,
+    count,
+    totalPages,
+    page,
+    setPage,
+    ordering,
+    setOrdering,
+    isLoading: listLoading,
+    error,
+  } = useUserList(isAdmin, debouncedQ);
+
+  if (isLoading) {
+    return <LoadingSpinner message="Authenticating" subtitle="Verifying staff access..." />;
+  }
+  if (!isAuthenticated) {
+    return <LoginForm />;
+  }
+
+  function handleSelect(u: HubUser) {
+    setSelected(u);
+    setSheetOpen(true);
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-green-50 to-blue-50 p-4 dark:from-slate-800 dark:to-emerald-900/30">
+      <div className="mx-auto max-w-7xl space-y-6">
+        <Navigation />
+
+        <div className="space-y-2 text-center">
+          <h1 className="flex items-center justify-center gap-2 text-3xl font-bold text-gray-900 dark:text-white">
+            <Users className="size-7 text-emerald-600" />
+            {' '}
+            Users
+          </h1>
+          <p className="text-gray-600 dark:text-gray-300">
+            Search users and open a profile to view favourites, rankings and status. Read-only.
+          </p>
+        </div>
+
+        {!isAdmin
+          ? (
+              <AdminGate />
+            )
+          : (
+              <>
+                <Card>
+                  <CardContent className="grid grid-cols-1 gap-3 pt-6 md:grid-cols-3">
+                    <div className="md:col-span-2">
+                      <label htmlFor="user-search" className="mb-1 block text-xs font-medium text-gray-600">Search</label>
+                      <Input
+                        id="user-search"
+                        aria-label="Search users"
+                        placeholder="Username, email or name…"
+                        value={q}
+                        onChange={e => setQ(e.target.value)}
+                      />
+                    </div>
+                    <div>
+                      <label htmlFor="user-ordering" className="mb-1 block text-xs font-medium text-gray-600">Sort</label>
+                      <Select value={ordering} onValueChange={setOrdering}>
+                        <SelectTrigger id="user-ordering"><SelectValue /></SelectTrigger>
+                        <SelectContent>
+                          {ORDERING_OPTIONS.map(o => (
+                            <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  </CardContent>
+                </Card>
+
+                <div className="flex items-center justify-end">
+                  <div className="flex gap-1">
+                    <Button
+                      size="sm"
+                      variant={view === 'cards' ? 'default' : 'outline'}
+                      onClick={() => setView('cards')}
+                      aria-label="Card view"
+                    >
+                      <LayoutGrid className="size-4" />
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant={view === 'table' ? 'default' : 'outline'}
+                      onClick={() => setView('table')}
+                      aria-label="Table view"
+                    >
+                      <List className="size-4" />
+                    </Button>
+                  </div>
+                </div>
+
+                {error && (
+                  <div
+                    role="alert"
+                    className="rounded-md border border-red-300 bg-red-50 p-3 text-sm text-red-900 dark:border-red-800 dark:bg-red-950/40 dark:text-red-200"
+                  >
+                    {error}
+                  </div>
+                )}
+
+                {listLoading && <p className="text-center text-sm text-gray-500">Loading users…</p>}
+
+                {!listLoading && !error && (
+                  view === 'cards'
+                    ? (
+                        users.length === 0
+                          ? (
+                              <div className="rounded-md border p-8 text-center text-sm text-gray-500">
+                                No users match your search.
+                              </div>
+                            )
+                          : (
+                              <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3">
+                                {users.map(u => <UserCard key={u.id} user={u} onSelect={handleSelect} />)}
+                              </div>
+                            )
+                      )
+                    : (
+                        <UserTable users={users} onSelect={handleSelect} />
+                      )
+                )}
+
+                <DataPagination
+                  currentPage={page}
+                  totalPages={totalPages}
+                  totalCount={count}
+                  visibleCount={users.length}
+                  pageSize={USER_LIST_PAGE_SIZE}
+                  onPageChange={setPage}
+                  disabled={listLoading}
+                />
+              </>
+            )}
+
+        <UserDetailSheet user={selected} open={sheetOpen} onOpenChange={setSheetOpen} />
+      </div>
+    </div>
+  );
+}

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import {
+  BarChart3,
   ChevronDown,
   ChevronUp,
   Database,
@@ -10,6 +11,7 @@ import {
   MessageCircle,
   Search,
   Sparkles,
+  UserCog,
   Users,
   Users2,
 } from 'lucide-react';
@@ -90,6 +92,25 @@ export function Navigation({ className }: NavigationProps) {
       ],
     },
     {
+      label: 'User Hub',
+      icon: UserCog,
+      description: 'User analytics and management',
+      children: [
+        {
+          label: 'Favourites Analytics',
+          href: '/user-hub/analytics',
+          icon: BarChart3,
+          description: 'Favourite-games adoption and popularity',
+        },
+        {
+          label: 'Users',
+          href: '/user-hub/users',
+          icon: Users,
+          description: 'Search users and view profiles',
+        },
+      ],
+    },
+    {
       label: 'Discord Control',
       href: '/discord-control',
       icon: MessageCircle,
@@ -122,8 +143,13 @@ export function Navigation({ className }: NavigationProps) {
 
   const currentPage = findCurrentPage(navigationPages);
 
-  const goHome = () => {
-    router.push('/');
+  // Fire a click-style handler from keyboard activation (Enter / Space) so
+  // the clickable nav rows are operable without a mouse.
+  const onActivateKey = (handler: () => void) => (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handler();
+    }
   };
 
   // Toggle category expansion
@@ -147,10 +173,14 @@ export function Navigation({ className }: NavigationProps) {
         <div key={page.label} className="mb-1">
           {/* Parent category header */}
           <div
+            role="button"
+            tabIndex={0}
+            aria-expanded={isExpanded}
             onClick={(e) => {
               e.stopPropagation();
               toggleCategory(page.label);
             }}
+            onKeyDown={onActivateKey(() => toggleCategory(page.label))}
             className={cn(
               'flex items-center gap-3 px-3 py-2.5 rounded-md cursor-pointer transition-all duration-200',
               hasActiveChild
@@ -180,11 +210,19 @@ export function Navigation({ className }: NavigationProps) {
                 return (
                   <div
                     key={child.href}
+                    role="button"
+                    tabIndex={0}
                     onClick={(e) => {
                       e.stopPropagation();
                       child.href && router.push(child.href);
                       setMobileMenuOpen(false);
                     }}
+                    onKeyDown={onActivateKey(() => {
+                      if (child.href) {
+                        router.push(child.href);
+                      }
+                      setMobileMenuOpen(false);
+                    })}
                     className={cn(
                       'flex items-center gap-3 px-3 py-2 rounded-md cursor-pointer transition-all duration-200',
                       isChildActive
@@ -207,11 +245,19 @@ export function Navigation({ className }: NavigationProps) {
     return (
       <div
         key={page.href}
+        role="button"
+        tabIndex={0}
         onClick={(e) => {
           e.stopPropagation();
           page.href && router.push(page.href);
           setMobileMenuOpen(false);
         }}
+        onKeyDown={onActivateKey(() => {
+          if (page.href) {
+            router.push(page.href);
+          }
+          setMobileMenuOpen(false);
+        })}
         className={cn(
           'flex items-center gap-3 px-3 py-2.5 rounded-md cursor-pointer transition-all duration-200 mb-1',
           isActive
@@ -304,8 +350,12 @@ export function Navigation({ className }: NavigationProps) {
         <>
           {/* Backdrop */}
           <div
+            role="button"
+            tabIndex={0}
+            aria-label="Close menu"
             className="fixed inset-0 z-40 bg-black/50 backdrop-blur-sm sm:hidden"
             onClick={() => setMobileMenuOpen(false)}
+            onKeyDown={onActivateKey(() => setMobileMenuOpen(false))}
           />
 
           {/* Mobile Menu Panel */}

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -7,6 +7,7 @@ import {
   Database,
   FileQuestion,
   Home,
+  LayoutDashboard,
   Menu,
   MessageCircle,
   Search,
@@ -47,6 +48,7 @@ export function Navigation({ className }: NavigationProps) {
   // State to track which categories are expanded
   const [expandedCategories, setExpandedCategories] = useState<{ [key: string]: boolean }>({
     'Footballer Data': true, // Expanded by default
+    'User Hub': true,
   });
 
   // State for mobile menu
@@ -96,6 +98,12 @@ export function Navigation({ className }: NavigationProps) {
       icon: UserCog,
       description: 'User analytics and management',
       children: [
+        {
+          label: 'Overview',
+          href: '/user-hub',
+          icon: LayoutDashboard,
+          description: 'All User Hub tools',
+        },
         {
           label: 'Favourites Analytics',
           href: '/user-hub/analytics',

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -105,16 +105,16 @@ export function Navigation({ className }: NavigationProps) {
           description: 'All User Hub tools',
         },
         {
-          label: 'Favourites Analytics',
-          href: '/user-hub/analytics',
-          icon: BarChart3,
-          description: 'Favourite-games adoption and popularity',
-        },
-        {
           label: 'Users',
           href: '/user-hub/users',
           icon: Users,
           description: 'Search users and view profiles',
+        },
+        {
+          label: 'Favourites Analytics',
+          href: '/user-hub/analytics',
+          icon: BarChart3,
+          description: 'Favourite-games adoption and popularity',
         },
       ],
     },

--- a/components/user-hub/ActiveFilterChips.tsx
+++ b/components/user-hub/ActiveFilterChips.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import type { UserListFilters } from '@/types/user-hub';
+import { X } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { prettySlug, suspensionLabel } from '@/lib/user-hub-format';
+
+/**
+ * Filter keys that render as removable chips (search has its own input; page
+ *  and ordering are not facets). Exported so the page and tests agree on the set.
+ */
+export type ChipKey = 'is_online' | 'favourite_game' | 'has_favourites' | 'is_beta_tester' | 'suspension' | 'is_active';
+
+/** Human label for an active filter value, or null if not set. */
+export function chipLabel(key: ChipKey, filters: UserListFilters): string | null {
+  switch (key) {
+    case 'is_online':
+      return filters.is_online === 'true' ? 'Online' : filters.is_online === 'false' ? 'Offline' : null;
+    case 'favourite_game':
+      return filters.favourite_game ? `Favourited: ${prettySlug(filters.favourite_game)}` : null;
+    case 'has_favourites':
+      return filters.has_favourites === 'true' ? 'Has favourites' : filters.has_favourites === 'false' ? 'No favourites' : null;
+    case 'is_beta_tester':
+      return filters.is_beta_tester === 'true' ? 'Beta testers' : filters.is_beta_tester === 'false' ? 'Non-beta' : null;
+    case 'is_active':
+      return filters.is_active === 'true' ? 'Active' : filters.is_active === 'false' ? 'Inactive' : null;
+    case 'suspension':
+      if (!filters.suspension) {
+        return null;
+      }
+      if (filters.suspension === 'none') {
+        return 'Not suspended';
+      }
+      if (filters.suspension === 'any') {
+        return 'Suspended (any)';
+      }
+      return suspensionLabel(filters.suspension);
+    default:
+      return null;
+  }
+}
+
+const CHIP_KEYS: ChipKey[] = ['is_online', 'favourite_game', 'has_favourites', 'is_beta_tester', 'suspension', 'is_active'];
+
+/** Returns the active chip keys for the given filters (for the page + tests). */
+export function activeChipKeys(filters: UserListFilters): ChipKey[] {
+  return CHIP_KEYS.filter(k => chipLabel(k, filters) !== null);
+}
+
+type Props = {
+  filters: UserListFilters;
+  onRemove: (key: ChipKey) => void;
+  onClearAll: () => void;
+};
+
+export function ActiveFilterChips({ filters, onRemove, onClearAll }: Props) {
+  const active = activeChipKeys(filters);
+  if (active.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {active.map((key) => {
+        const label = chipLabel(key, filters);
+        return (
+          <Badge key={key} variant="secondary" className="gap-1 pr-1">
+            {label}
+            <button
+              type="button"
+              aria-label={`Remove ${label} filter`}
+              onClick={() => onRemove(key)}
+              className="ml-0.5 rounded-sm p-0.5 hover:bg-black/10 dark:hover:bg-white/10"
+            >
+              <X className="size-3" />
+            </button>
+          </Badge>
+        );
+      })}
+      <Button variant="ghost" size="sm" className="h-6 px-2 text-xs" onClick={onClearAll}>
+        Clear all
+      </Button>
+    </div>
+  );
+}

--- a/components/user-hub/AdminGate.tsx
+++ b/components/user-hub/AdminGate.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { ShieldAlert } from 'lucide-react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+/**
+ * Phase-1 client gate for the User Hub. The user is already authenticated
+ * (staff) by the time this renders — this only blocks the hub's private
+ * user-data surfaces to superusers. It is NOT the security boundary: every
+ * underlying endpoint is `IsAdminUser` server-side; this is a friendlier
+ * "you don't have access" than silently hitting 403s.
+ */
+export function AdminGate() {
+  return (
+    <div className="mx-auto max-w-md py-16">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <ShieldAlert className="size-5 text-orange-600" />
+            Superuser access required
+          </CardTitle>
+          <CardDescription>
+            The User Hub surfaces private user data, so it's limited to superusers.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-gray-600 dark:text-gray-300">
+            You're signed in, but your account isn't a superuser. Ask an administrator
+            to grant access if you need it.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/user-hub/AnalyticsSkeleton.tsx
+++ b/components/user-hub/AnalyticsSkeleton.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+
+/** Placeholder for the favourites-analytics summary cards + chart. */
+export function AnalyticsSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <Card key={i}>
+            <CardHeader className="pb-2">
+              <Skeleton className="h-4 w-32" />
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-8 w-20" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-5 w-40" />
+        </CardHeader>
+        <CardContent>
+          <Skeleton className="h-64 w-full" />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/user-hub/FavouriteInsights.tsx
+++ b/components/user-hub/FavouriteInsights.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import type { FavouritesUsageResponse } from '@/types/user-hub';
+import { Crown, Download } from 'lucide-react';
+import { useMemo } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  favouriteDepthDistribution,
+  favouritesToCsv,
+  firstChoiceCounts,
+} from '@/lib/user-hub-analytics';
+
+type Props = {
+  data: FavouritesUsageResponse;
+};
+
+type Row = { key: string; label: string; count: number };
+
+/** A labelled proportional bar (emerald fill) — used for both panels. */
+function BarRow({ row, max }: { row: Row; max: number }) {
+  const pct = max > 0 ? Math.round((row.count / max) * 100) : 0;
+  return (
+    <div className="flex items-center gap-3 text-sm">
+      <span className="w-28 shrink-0 truncate text-gray-600 dark:text-gray-300">{row.label}</span>
+      <div className="h-2 flex-1 overflow-hidden rounded-full bg-gray-100 dark:bg-gray-800">
+        <div className="h-full rounded-full bg-emerald-500" style={{ width: `${pct}%` }} />
+      </div>
+      <span className="w-8 shrink-0 text-right font-mono text-xs text-gray-500">{row.count}</span>
+    </div>
+  );
+}
+
+/**
+ * Deeper favourites analytics derived from the per-user payload: which game is
+ *  most often the #1 pick, how many games people favourite, and a CSV export.
+ */
+export function FavouriteInsights({ data }: Props) {
+  const firstChoice = useMemo(() => firstChoiceCounts(data.users).slice(0, 8), [data.users]);
+  const depth = useMemo(() => favouriteDepthDistribution(data.users), [data.users]);
+
+  const firstChoiceMax = firstChoice[0]?.count ?? 0;
+  const depthMax = Math.max(0, ...depth.map(d => d.count));
+
+  function exportCsv() {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const blob = new Blob([favouritesToCsv(data.users)], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'favourites-usage.csv';
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between gap-2 space-y-0">
+        <CardTitle className="text-base">Insights</CardTitle>
+        <Button size="sm" variant="outline" onClick={exportCsv} disabled={data.users.length === 0}>
+          <Download className="mr-2 size-4" />
+          Export CSV
+        </Button>
+      </CardHeader>
+      <CardContent className="grid grid-cols-1 gap-6 md:grid-cols-2">
+        <div className="space-y-2">
+          <p className="flex items-center gap-1.5 text-sm font-medium">
+            <Crown className="size-4 text-amber-500" />
+            Top #1 picks
+          </p>
+          <p className="text-xs text-gray-500">Which game users favourite first.</p>
+          {firstChoice.length === 0
+            ? (
+                <p className="py-4 text-center text-sm text-gray-500">No data yet.</p>
+              )
+            : (
+                <div className="space-y-1.5 pt-1">
+                  {firstChoice.map(r => (
+                    <BarRow key={r.slug} row={{ key: r.slug, label: r.label, count: r.count }} max={firstChoiceMax} />
+                  ))}
+                </div>
+              )}
+        </div>
+
+        <div className="space-y-2">
+          <p className="text-sm font-medium">Favourites per user</p>
+          <p className="text-xs text-gray-500">How many games each user favourites.</p>
+          <div className="space-y-1.5 pt-1">
+            {depth.map(d => (
+              <BarRow key={d.bucket} row={{ key: d.bucket, label: `${d.bucket} game${d.bucket === '1' ? '' : 's'}`, count: d.count }} max={depthMax} />
+            ))}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/user-hub/FavouritesUsageSummary.tsx
+++ b/components/user-hub/FavouritesUsageSummary.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import type { FavouritesUsageResponse } from '@/types/user-hub';
+import { Star, Users } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+type Props = {
+  data: FavouritesUsageResponse;
+};
+
+/** Top-line adoption cards for the favourites-usage analytics page. */
+export function FavouritesUsageSummary({ data }: Props) {
+  const { users_with_favourites: withFav, total_users: total, game_popularity } = data;
+  const pct = total > 0 ? Math.round((withFav / total) * 100) : 0;
+  const distinctGames = Object.keys(game_popularity).length;
+
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="flex items-center gap-2 text-sm font-medium text-gray-600 dark:text-gray-300">
+            <Star className="size-4 text-amber-500" />
+            Users with favourites
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-2xl font-bold">
+            {withFav.toLocaleString()}
+            <span className="ml-1 text-base font-normal text-gray-500">
+              /
+              {' '}
+              {total.toLocaleString()}
+            </span>
+          </p>
+          <p className="text-xs text-gray-500">
+            {pct}
+            % adoption
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="flex items-center gap-2 text-sm font-medium text-gray-600 dark:text-gray-300">
+            <Users className="size-4 text-emerald-600" />
+            Total users
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-2xl font-bold">{total.toLocaleString()}</p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="flex items-center gap-2 text-sm font-medium text-gray-600 dark:text-gray-300">
+            <Star className="size-4 text-amber-500" />
+            Games favourited
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-2xl font-bold">{distinctGames}</p>
+          <p className="text-xs text-gray-500">distinct games with ≥1 favourite</p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/user-hub/FavouritesUsageSummary.tsx
+++ b/components/user-hub/FavouritesUsageSummary.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import type { FavouritesUsageResponse } from '@/types/user-hub';
-import { Star, Users } from 'lucide-react';
+import { Layers, Star, Users } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { avgFavouritesPerUser } from '@/lib/user-hub-analytics';
 
 type Props = {
   data: FavouritesUsageResponse;
@@ -13,9 +14,10 @@ export function FavouritesUsageSummary({ data }: Props) {
   const { users_with_favourites: withFav, total_users: total, game_popularity } = data;
   const pct = total > 0 ? Math.round((withFav / total) * 100) : 0;
   const distinctGames = Object.keys(game_popularity).length;
+  const avgPerUser = avgFavouritesPerUser(data);
 
   return (
-    <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
       <Card>
         <CardHeader className="pb-2">
           <CardTitle className="flex items-center gap-2 text-sm font-medium text-gray-600 dark:text-gray-300">
@@ -61,6 +63,19 @@ export function FavouritesUsageSummary({ data }: Props) {
         <CardContent>
           <p className="text-2xl font-bold">{distinctGames}</p>
           <p className="text-xs text-gray-500">distinct games with ≥1 favourite</p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="flex items-center gap-2 text-sm font-medium text-gray-600 dark:text-gray-300">
+            <Layers className="size-4 text-emerald-600" />
+            Avg per user
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-2xl font-bold">{avgPerUser.toFixed(1)}</p>
+          <p className="text-xs text-gray-500">favourites per user (who has any)</p>
         </CardContent>
       </Card>
     </div>

--- a/components/user-hub/GamePopularityChart.tsx
+++ b/components/user-hub/GamePopularityChart.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useMemo } from 'react';
+import { Bar, BarChart, CartesianGrid, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { toChartData } from '@/lib/user-hub-format';
+
+type Props = {
+  /** game-id slug → favourite count. */
+  gamePopularity: Record<string, number>;
+};
+
+const BAR_COLORS = [
+  '#10b981',
+  '#3b82f6',
+  '#f59e0b',
+  '#ef4444',
+  '#8b5cf6',
+  '#ec4899',
+  '#14b8a6',
+  '#f97316',
+  '#6366f1',
+  '#84cc16',
+];
+
+/** Horizontal bar chart of how many users favourited each game. */
+export function GamePopularityChart({ gamePopularity }: Props) {
+  const data = useMemo(() => toChartData(gamePopularity), [gamePopularity]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Game popularity</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {data.length === 0
+          ? (
+              <p className="py-8 text-center text-sm text-gray-500">
+                No favourites recorded yet.
+              </p>
+            )
+          : (
+              <div style={{ height: Math.max(160, data.length * 40) }}>
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={data} layout="vertical" margin={{ left: 8, right: 16 }}>
+                    <CartesianGrid horizontal={false} strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-gray-700" />
+                    <XAxis type="number" allowDecimals={false} tick={{ fontSize: 12 }} />
+                    <YAxis type="category" dataKey="label" width={140} tick={{ fontSize: 12 }} />
+                    <Tooltip cursor={{ fill: 'rgba(16,185,129,0.08)' }} />
+                    <Bar dataKey="count" name="Users" radius={[0, 4, 4, 0]}>
+                      {data.map((row, i) => (
+                        <Cell key={row.slug} fill={BAR_COLORS[i % BAR_COLORS.length]} />
+                      ))}
+                    </Bar>
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/user-hub/GamePopularityChart.tsx
+++ b/components/user-hub/GamePopularityChart.tsx
@@ -8,6 +8,8 @@ import { toChartData } from '@/lib/user-hub-format';
 type Props = {
   /** game-id slug → favourite count. */
   gamePopularity: Record<string, number>;
+  /** When set, bars become clickable and call this with the game slug. */
+  onGameSelect?: (slug: string) => void;
 };
 
 const BAR_COLORS = [
@@ -23,14 +25,56 @@ const BAR_COLORS = [
   '#84cc16',
 ];
 
-/** Horizontal bar chart of how many users favourited each game. */
-export function GamePopularityChart({ gamePopularity }: Props) {
+/**
+ * Theme-aware tooltip (the default recharts tooltip is light-only, so its
+ *  text is unreadable in dark mode). Uses shadcn popover tokens.
+ */
+function PopularityTooltip({
+  active,
+  payload,
+}: {
+  active?: boolean;
+  payload?: { payload?: { label?: string; count?: number } }[];
+}) {
+  const row = payload?.[0]?.payload;
+  if (!active || !row) {
+    return null;
+  }
+  return (
+    <div className="rounded-md border bg-popover px-3 py-2 text-sm text-popover-foreground shadow-md">
+      <p className="font-medium">{row.label}</p>
+      <p className="text-muted-foreground">
+        {row.count}
+        {' '}
+        {row.count === 1 ? 'user' : 'users'}
+      </p>
+    </div>
+  );
+}
+
+/**
+ * Horizontal bar chart of how many users favourited each game. When
+ *  `onGameSelect` is provided, clicking a bar drills into that game.
+ */
+export function GamePopularityChart({ gamePopularity, onGameSelect }: Props) {
   const data = useMemo(() => toChartData(gamePopularity), [gamePopularity]);
+  const interactive = !!onGameSelect;
+
+  // Recharts passes the bar's data entry (our row, with `slug`) as the first arg.
+  const handleBarClick = (entry: unknown) => {
+    const slug = (entry as { slug?: string })?.slug;
+    if (slug) {
+      onGameSelect?.(slug);
+    }
+  };
 
   return (
     <Card>
       <CardHeader>
         <CardTitle className="text-base">Game popularity</CardTitle>
+        {interactive && (
+          <p className="text-xs text-muted-foreground">Click a game to see who favourited it.</p>
+        )}
       </CardHeader>
       <CardContent>
         {data.length === 0
@@ -46,8 +90,14 @@ export function GamePopularityChart({ gamePopularity }: Props) {
                     <CartesianGrid horizontal={false} strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-gray-700" />
                     <XAxis type="number" allowDecimals={false} tick={{ fontSize: 12 }} />
                     <YAxis type="category" dataKey="label" width={140} tick={{ fontSize: 12 }} />
-                    <Tooltip cursor={{ fill: 'rgba(16,185,129,0.08)' }} />
-                    <Bar dataKey="count" name="Users" radius={[0, 4, 4, 0]}>
+                    <Tooltip cursor={{ fill: 'rgba(16,185,129,0.08)' }} content={<PopularityTooltip />} />
+                    <Bar
+                      dataKey="count"
+                      name="Users"
+                      radius={[0, 4, 4, 0]}
+                      onClick={interactive ? handleBarClick : undefined}
+                      className={interactive ? 'cursor-pointer' : undefined}
+                    >
                       {data.map((row, i) => (
                         <Cell key={row.slug} fill={BAR_COLORS[i % BAR_COLORS.length]} />
                       ))}

--- a/components/user-hub/UserCard.tsx
+++ b/components/user-hub/UserCard.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import type { HubUser } from '@/types/user-hub';
+import { Mail } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { BetaBadges, FavouriteGamesBadges, OnlineDot, SuspensionBadge } from './user-badges';
+
+type Props = {
+  user: HubUser;
+  onSelect: (user: HubUser) => void;
+};
+
+/** Card view of a user (mobile / cards toggle). Click opens the detail sheet. */
+export function UserCard({ user, onSelect }: Props) {
+  return (
+    <Card
+      onClick={() => onSelect(user)}
+      className="cursor-pointer transition-shadow duration-200 hover:shadow-md"
+    >
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center justify-between gap-2 text-base">
+          <span className="truncate">
+            {user.username}
+            {user.is_superuser
+              ? <span className="ml-2 text-xs text-amber-600" title="Superuser">★</span>
+              : user.is_staff
+                ? <span className="ml-2 text-xs text-emerald-600" title="Staff">◆</span>
+                : null}
+          </span>
+          <span className="font-mono text-xs text-gray-400">
+            #
+            {user.id}
+          </span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <p className="flex items-center gap-1.5 truncate text-sm text-gray-600 dark:text-gray-300">
+          <Mail className="size-3.5 shrink-0" />
+          {user.email || '—'}
+        </p>
+        <div><FavouriteGamesBadges games={user.favourite_games} /></div>
+        <div className="flex flex-wrap items-center gap-1">
+          <SuspensionBadge user={user} />
+          <BetaBadges user={user} max={2} />
+          {!user.is_active && <span className="text-xs text-gray-400">inactive</span>}
+        </div>
+        <OnlineDot user={user} />
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/user-hub/UserCard.tsx
+++ b/components/user-hub/UserCard.tsx
@@ -3,7 +3,7 @@
 import type { HubUser } from '@/types/user-hub';
 import { Mail } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { BetaBadges, FavouriteGamesBadges, OnlineDot, SuspensionBadge } from './user-badges';
+import { BetaBadges, FavouriteGamesBadges, OnlineDot, SuspensionBadge, UserAvatar } from './user-badges';
 
 type Props = {
   user: HubUser;
@@ -19,13 +19,16 @@ export function UserCard({ user, onSelect }: Props) {
     >
       <CardHeader className="pb-2">
         <CardTitle className="flex items-center justify-between gap-2 text-base">
-          <span className="truncate">
-            {user.username}
-            {user.is_superuser
-              ? <span className="ml-2 text-xs text-amber-600" title="Superuser">★</span>
-              : user.is_staff
-                ? <span className="ml-2 text-xs text-emerald-600" title="Staff">◆</span>
-                : null}
+          <span className="flex items-center gap-2 truncate">
+            <UserAvatar user={user} />
+            <span className="truncate">
+              {user.username}
+              {user.is_superuser
+                ? <span className="ml-2 text-xs text-amber-600" title="Superuser">★</span>
+                : user.is_staff
+                  ? <span className="ml-2 text-xs text-emerald-600" title="Staff">◆</span>
+                  : null}
+            </span>
           </span>
           <span className="font-mono text-xs text-gray-400">
             #

--- a/components/user-hub/UserCard.tsx
+++ b/components/user-hub/UserCard.tsx
@@ -14,8 +14,17 @@ type Props = {
 export function UserCard({ user, onSelect }: Props) {
   return (
     <Card
+      role="button"
+      tabIndex={0}
+      aria-label={`Open ${user.username}`}
       onClick={() => onSelect(user)}
-      className="cursor-pointer transition-shadow duration-200 hover:shadow-md"
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onSelect(user);
+        }
+      }}
+      className="cursor-pointer transition-shadow duration-200 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
     >
       <CardHeader className="pb-2">
         <CardTitle className="flex items-center justify-between gap-2 text-base">

--- a/components/user-hub/UserDetailSheet.tsx
+++ b/components/user-hub/UserDetailSheet.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import type { HubUser, UserRankingsResponse } from '@/types/user-hub';
+import type { HubUser } from '@/types/user-hub';
 import { ExternalLink, History, ShieldBan } from 'lucide-react';
-import { useCallback, useEffect, useState } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -14,7 +13,6 @@ import {
 } from '@/components/ui/sheet';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import config from '@/lib/config';
-import { UserHubAPI } from '@/lib/user-hub-api';
 import { prettySlug, suspensionLabel } from '@/lib/user-hub-format';
 import { BetaBadges, OnlineDot, UserAvatar } from './user-badges';
 
@@ -34,65 +32,7 @@ function Field({ label, value }: { label: string; value: React.ReactNode }) {
   );
 }
 
-/**
- * Defensively render one rankings section (shape varies per game). Game names
- *  are prettified; a rank is shown as "#N", otherwise a raw score.
- */
-function RankingsSection({ title, value }: { title: string; value: unknown }) {
-  if (!Array.isArray(value) || value.length === 0) {
-    return null;
-  }
-  return (
-    <div className="space-y-1">
-      <div className="flex items-center justify-between border-b border-gray-100 pb-1 dark:border-gray-800">
-        <p className="text-xs font-semibold uppercase text-gray-500">{title}</p>
-        <p className="text-[10px] uppercase text-gray-400">Game · Rank</p>
-      </div>
-      {value.slice(0, 10).map((row, i) => {
-        const r = (row ?? {}) as Record<string, unknown>;
-        const rawLabel = r.game_name ?? r.game ?? r.name ?? r.label ?? r.key;
-        const label = typeof rawLabel === 'string'
-          ? prettySlug(rawLabel)
-          : rawLabel != null ? String(rawLabel) : `Entry ${i + 1}`;
-        const rank = r.rank ?? r.position;
-        const score = r.score ?? r.points ?? r.value;
-        return (
-          <div key={`${title}-${label}`} className="flex justify-between text-sm">
-            <span>{label}</span>
-            <span className="font-mono text-gray-600">
-              {rank !== undefined ? `#${String(rank)}` : score !== undefined ? String(score) : '—'}
-            </span>
-          </div>
-        );
-      })}
-    </div>
-  );
-}
-
 export function UserDetailSheet({ user, open, onOpenChange }: Props) {
-  const [rankings, setRankings] = useState<UserRankingsResponse | null>(null);
-  const [rankingsLoading, setRankingsLoading] = useState(false);
-  const [rankingsError, setRankingsError] = useState<string | null>(null);
-
-  const loadRankings = useCallback(async (id: number) => {
-    setRankingsLoading(true);
-    setRankingsError(null);
-    setRankings(null);
-    try {
-      setRankings(await UserHubAPI.getUserRankings(id));
-    } catch (err: unknown) {
-      setRankingsError(err instanceof Error ? err.message : 'Failed to load rankings');
-    } finally {
-      setRankingsLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    if (open && user) {
-      loadRankings(user.id);
-    }
-  }, [open, user, loadRankings]);
-
   if (!user) {
     return null;
   }
@@ -101,8 +41,6 @@ export function UserDetailSheet({ user, open, onOpenChange }: Props) {
   // /admin/Accounts/user/<id>/change/.
   const adminUrl = config.getAdminUrl(`Accounts/user/${user.id}/change/`);
   const fullName = [user.first_name, user.last_name].filter(Boolean).join(' ') || '—';
-  const hasAnyRanking = rankings
-    && Object.values(rankings).some(v => Array.isArray(v) && v.length > 0);
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
@@ -134,10 +72,9 @@ export function UserDetailSheet({ user, open, onOpenChange }: Props) {
         </div>
 
         <Tabs defaultValue="profile" className="mt-4">
-          <TabsList className="grid w-full grid-cols-4">
+          <TabsList className="grid w-full grid-cols-3">
             <TabsTrigger value="profile">Profile</TabsTrigger>
             <TabsTrigger value="favourites">Favourites</TabsTrigger>
-            <TabsTrigger value="rankings">Rankings</TabsTrigger>
             <TabsTrigger value="audit">Audit</TabsTrigger>
           </TabsList>
 
@@ -176,30 +113,6 @@ export function UserDetailSheet({ user, open, onOpenChange }: Props) {
                     ))}
                   </ol>
                 )}
-          </TabsContent>
-
-          <TabsContent value="rankings" className="mt-3 space-y-3">
-            <p className="text-xs text-gray-500">
-              The user's current leaderboard position per game (last-30-days window;
-              <span className="font-mono"> #1</span>
-              {' '}
-              is best). Sections with no entries mean the
-              user isn't ranked there yet.
-            </p>
-            {rankingsLoading && <p className="text-sm text-gray-500">Loading rankings…</p>}
-            {rankingsError && <p className="text-sm text-red-600">{rankingsError}</p>}
-            {!rankingsLoading && !rankingsError && !hasAnyRanking && (
-              <p className="py-6 text-center text-sm text-gray-500">No ranking data for this user.</p>
-            )}
-            {rankings && (
-              <>
-                <RankingsSection title="Game rankings" value={rankings.game_rankings} />
-                <RankingsSection title="Stoppage time" value={rankings.stoppage_time_rankings} />
-                <RankingsSection title="Scout" value={rankings.scout_rankings} />
-                <RankingsSection title="Conquest" value={rankings.conquest_rankings} />
-                <RankingsSection title="Grid" value={rankings.grid_rankings} />
-              </>
-            )}
           </TabsContent>
 
           <TabsContent value="audit" className="mt-3">

--- a/components/user-hub/UserDetailSheet.tsx
+++ b/components/user-hub/UserDetailSheet.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import type { HubUser, UserRankingsResponse } from '@/types/user-hub';
+import { ExternalLink, History, ShieldBan } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import config from '@/lib/config';
+import { UserHubAPI } from '@/lib/user-hub-api';
+import { prettySlug, suspensionLabel } from '@/lib/user-hub-format';
+import { BetaBadges, OnlineDot } from './user-badges';
+
+type Props = {
+  /** The row's user (list payload); null when the sheet is closed. */
+  user: HubUser | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+function Field({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex justify-between gap-4 border-b border-gray-100 py-1.5 text-sm dark:border-gray-800">
+      <span className="text-gray-500">{label}</span>
+      <span className="text-right font-medium">{value ?? '—'}</span>
+    </div>
+  );
+}
+
+/** Defensively render one rankings section (shape varies per game). */
+function RankingsSection({ title, value }: { title: string; value: unknown }) {
+  if (Array.isArray(value) && value.length > 0) {
+    return (
+      <div className="space-y-1">
+        <p className="text-xs font-semibold uppercase text-gray-500">{title}</p>
+        {value.slice(0, 10).map((row, i) => {
+          const r = (row ?? {}) as Record<string, unknown>;
+          const label = r.game_name ?? r.game ?? r.name ?? r.label ?? r.key ?? `#${i + 1}`;
+          const rank = r.rank ?? r.position ?? r.score ?? r.points ?? r.value;
+          return (
+            <div key={`${title}-${String(label)}`} className="flex justify-between text-sm">
+              <span>{String(label)}</span>
+              {rank !== undefined && <span className="font-mono text-gray-600">{String(rank)}</span>}
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+  return null;
+}
+
+export function UserDetailSheet({ user, open, onOpenChange }: Props) {
+  const [rankings, setRankings] = useState<UserRankingsResponse | null>(null);
+  const [rankingsLoading, setRankingsLoading] = useState(false);
+  const [rankingsError, setRankingsError] = useState<string | null>(null);
+
+  const loadRankings = useCallback(async (id: number) => {
+    setRankingsLoading(true);
+    setRankingsError(null);
+    setRankings(null);
+    try {
+      setRankings(await UserHubAPI.getUserRankings(id));
+    } catch (err: unknown) {
+      setRankingsError(err instanceof Error ? err.message : 'Failed to load rankings');
+    } finally {
+      setRankingsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (open && user) {
+      loadRankings(user.id);
+    }
+  }, [open, user, loadRankings]);
+
+  if (!user) {
+    return null;
+  }
+
+  const adminUrl = config.getAdminUrl(`accounts/user/${user.id}/change/`);
+  const fullName = [user.first_name, user.last_name].filter(Boolean).join(' ') || '—';
+  const hasAnyRanking = rankings
+    && Object.values(rankings).some(v => Array.isArray(v) && v.length > 0);
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="w-full overflow-y-auto sm:max-w-xl">
+        <SheetHeader>
+          <SheetTitle className="flex items-center gap-2">
+            {user.username}
+            {user.is_superuser && <Badge variant="secondary" className="bg-amber-100 text-amber-900">superuser</Badge>}
+            {!user.is_superuser && user.is_staff && <Badge variant="secondary">staff</Badge>}
+          </SheetTitle>
+          <SheetDescription>
+            User #
+            {user.id}
+            {' '}
+            ·
+            {' '}
+            <OnlineDot user={user} />
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="mt-4">
+          <Button asChild variant="outline" className="w-full">
+            <a href={adminUrl} target="_blank" rel="noopener noreferrer">
+              <ExternalLink className="mr-2 size-4" />
+              Manage in Django Admin
+            </a>
+          </Button>
+        </div>
+
+        <Tabs defaultValue="profile" className="mt-4">
+          <TabsList className="grid w-full grid-cols-4">
+            <TabsTrigger value="profile">Profile</TabsTrigger>
+            <TabsTrigger value="favourites">Favourites</TabsTrigger>
+            <TabsTrigger value="rankings">Rankings</TabsTrigger>
+            <TabsTrigger value="audit">Audit</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="profile" className="mt-3">
+            <Field label="Username" value={user.username} />
+            <Field label="Email" value={user.email || '—'} />
+            <Field label="Full name" value={fullName} />
+            <Field label="Active" value={user.is_active ? 'Yes' : 'No'} />
+            <Field label="Beta" value={user.is_beta_tester ? <BetaBadges user={user} max={4} /> : 'No'} />
+            <Field
+              label="Suspension"
+              value={user.suspension_scope
+                ? <Badge variant="destructive">{suspensionLabel(user.suspension_scope)}</Badge>
+                : 'None'}
+            />
+            {user.suspended_until && <Field label="Suspended until" value={user.suspended_until} />}
+            {user.date_joined && <Field label="Joined" value={new Date(user.date_joined).toLocaleDateString()} />}
+            {user.last_login && <Field label="Last login" value={new Date(user.last_login).toLocaleString()} />}
+          </TabsContent>
+
+          <TabsContent value="favourites" className="mt-3">
+            {user.favourite_games.length === 0
+              ? (
+                  <p className="py-6 text-center text-sm text-gray-500">No favourite games.</p>
+                )
+              : (
+                  <ol className="space-y-1">
+                    {user.favourite_games.map((g, i) => (
+                      <li key={g} className="flex items-center gap-2 text-sm">
+                        <span className="w-5 font-mono text-xs text-gray-400">
+                          {i + 1}
+                          .
+                        </span>
+                        <Badge variant="outline">{prettySlug(g)}</Badge>
+                      </li>
+                    ))}
+                  </ol>
+                )}
+          </TabsContent>
+
+          <TabsContent value="rankings" className="mt-3 space-y-3">
+            {rankingsLoading && <p className="text-sm text-gray-500">Loading rankings…</p>}
+            {rankingsError && <p className="text-sm text-red-600">{rankingsError}</p>}
+            {!rankingsLoading && !rankingsError && !hasAnyRanking && (
+              <p className="py-6 text-center text-sm text-gray-500">No ranking data for this user.</p>
+            )}
+            {rankings && (
+              <>
+                <RankingsSection title="Game rankings" value={rankings.game_rankings} />
+                <RankingsSection title="Stoppage time" value={rankings.stoppage_time_rankings} />
+                <RankingsSection title="Scout" value={rankings.scout_rankings} />
+                <RankingsSection title="Conquest" value={rankings.conquest_rankings} />
+                <RankingsSection title="Grid" value={rankings.grid_rankings} />
+              </>
+            )}
+          </TabsContent>
+
+          <TabsContent value="audit" className="mt-3">
+            <div className="space-y-3 py-4 text-center">
+              <ShieldBan className="mx-auto size-8 text-gray-300" />
+              <p className="text-sm font-medium text-gray-600 dark:text-gray-300">
+                Suspension history & audit trail
+              </p>
+              <p className="mx-auto max-w-xs text-xs text-gray-500">
+                <History className="mr-1 inline size-3" />
+                Coming in Phase 2 — per-user suspension history and a "who changed what"
+                audit log (see backend issue #1246). For now, changes are made and tracked
+                via Django Admin.
+              </p>
+            </div>
+          </TabsContent>
+        </Tabs>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/components/user-hub/UserDetailSheet.tsx
+++ b/components/user-hub/UserDetailSheet.tsx
@@ -16,7 +16,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import config from '@/lib/config';
 import { UserHubAPI } from '@/lib/user-hub-api';
 import { prettySlug, suspensionLabel } from '@/lib/user-hub-format';
-import { BetaBadges, OnlineDot } from './user-badges';
+import { BetaBadges, OnlineDot, UserAvatar } from './user-badges';
 
 type Props = {
   /** The row's user (list payload); null when the sheet is closed. */
@@ -34,27 +34,39 @@ function Field({ label, value }: { label: string; value: React.ReactNode }) {
   );
 }
 
-/** Defensively render one rankings section (shape varies per game). */
+/**
+ * Defensively render one rankings section (shape varies per game). Game names
+ *  are prettified; a rank is shown as "#N", otherwise a raw score.
+ */
 function RankingsSection({ title, value }: { title: string; value: unknown }) {
-  if (Array.isArray(value) && value.length > 0) {
-    return (
-      <div className="space-y-1">
-        <p className="text-xs font-semibold uppercase text-gray-500">{title}</p>
-        {value.slice(0, 10).map((row, i) => {
-          const r = (row ?? {}) as Record<string, unknown>;
-          const label = r.game_name ?? r.game ?? r.name ?? r.label ?? r.key ?? `#${i + 1}`;
-          const rank = r.rank ?? r.position ?? r.score ?? r.points ?? r.value;
-          return (
-            <div key={`${title}-${String(label)}`} className="flex justify-between text-sm">
-              <span>{String(label)}</span>
-              {rank !== undefined && <span className="font-mono text-gray-600">{String(rank)}</span>}
-            </div>
-          );
-        })}
-      </div>
-    );
+  if (!Array.isArray(value) || value.length === 0) {
+    return null;
   }
-  return null;
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between border-b border-gray-100 pb-1 dark:border-gray-800">
+        <p className="text-xs font-semibold uppercase text-gray-500">{title}</p>
+        <p className="text-[10px] uppercase text-gray-400">Game · Rank</p>
+      </div>
+      {value.slice(0, 10).map((row, i) => {
+        const r = (row ?? {}) as Record<string, unknown>;
+        const rawLabel = r.game_name ?? r.game ?? r.name ?? r.label ?? r.key;
+        const label = typeof rawLabel === 'string'
+          ? prettySlug(rawLabel)
+          : rawLabel != null ? String(rawLabel) : `Entry ${i + 1}`;
+        const rank = r.rank ?? r.position;
+        const score = r.score ?? r.points ?? r.value;
+        return (
+          <div key={`${title}-${label}`} className="flex justify-between text-sm">
+            <span>{label}</span>
+            <span className="font-mono text-gray-600">
+              {rank !== undefined ? `#${String(rank)}` : score !== undefined ? String(score) : '—'}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
 }
 
 export function UserDetailSheet({ user, open, onOpenChange }: Props) {
@@ -85,7 +97,9 @@ export function UserDetailSheet({ user, open, onOpenChange }: Props) {
     return null;
   }
 
-  const adminUrl = config.getAdminUrl(`accounts/user/${user.id}/change/`);
+  // Django admin URL — the app label is `Accounts` (capitalised), matching
+  // /admin/Accounts/user/<id>/change/.
+  const adminUrl = config.getAdminUrl(`Accounts/user/${user.id}/change/`);
   const fullName = [user.first_name, user.last_name].filter(Boolean).join(' ') || '—';
   const hasAnyRanking = rankings
     && Object.values(rankings).some(v => Array.isArray(v) && v.length > 0);
@@ -95,6 +109,7 @@ export function UserDetailSheet({ user, open, onOpenChange }: Props) {
       <SheetContent className="w-full overflow-y-auto sm:max-w-xl">
         <SheetHeader>
           <SheetTitle className="flex items-center gap-2">
+            <UserAvatar user={user} className="size-9" />
             {user.username}
             {user.is_superuser && <Badge variant="secondary" className="bg-amber-100 text-amber-900">superuser</Badge>}
             {!user.is_superuser && user.is_staff && <Badge variant="secondary">staff</Badge>}
@@ -164,6 +179,13 @@ export function UserDetailSheet({ user, open, onOpenChange }: Props) {
           </TabsContent>
 
           <TabsContent value="rankings" className="mt-3 space-y-3">
+            <p className="text-xs text-gray-500">
+              The user's current leaderboard position per game (last-30-days window;
+              <span className="font-mono"> #1</span>
+              {' '}
+              is best). Sections with no entries mean the
+              user isn't ranked there yet.
+            </p>
             {rankingsLoading && <p className="text-sm text-gray-500">Loading rankings…</p>}
             {rankingsError && <p className="text-sm text-red-600">{rankingsError}</p>}
             {!rankingsLoading && !rankingsError && !hasAnyRanking && (

--- a/components/user-hub/UserHubNav.tsx
+++ b/components/user-hub/UserHubNav.tsx
@@ -8,8 +8,8 @@ import { cn } from '@/lib/utils';
 /** The User Hub's sub-sections — single source of truth for the in-page nav. */
 export const USER_HUB_SECTIONS = [
   { href: '/user-hub', label: 'Overview', icon: LayoutDashboard },
-  { href: '/user-hub/analytics', label: 'Favourites Analytics', icon: BarChart3 },
   { href: '/user-hub/users', label: 'Users', icon: Users },
+  { href: '/user-hub/analytics', label: 'Favourites Analytics', icon: BarChart3 },
 ] as const;
 
 /**

--- a/components/user-hub/UserHubNav.tsx
+++ b/components/user-hub/UserHubNav.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { BarChart3, LayoutDashboard, Users } from 'lucide-react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { cn } from '@/lib/utils';
+
+/** The User Hub's sub-sections — single source of truth for the in-page nav. */
+export const USER_HUB_SECTIONS = [
+  { href: '/user-hub', label: 'Overview', icon: LayoutDashboard },
+  { href: '/user-hub/analytics', label: 'Favourites Analytics', icon: BarChart3 },
+  { href: '/user-hub/users', label: 'Users', icon: Users },
+] as const;
+
+/**
+ * Segmented tab bar shown at the top of every User Hub page so the sections
+ *  are reachable from one another (not only via the navbar dropdown).
+ */
+export function UserHubNav() {
+  const pathname = usePathname();
+
+  return (
+    <nav className="flex flex-wrap items-center justify-center gap-1 rounded-lg border bg-white/60 p-1 dark:bg-gray-800/60">
+      {USER_HUB_SECTIONS.map((s) => {
+        const Icon = s.icon;
+        const isActive = pathname === s.href;
+        return (
+          <Link
+            key={s.href}
+            href={s.href}
+            className={cn(
+              'flex items-center gap-2 rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
+              isActive
+                ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300'
+                : 'text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700/50',
+            )}
+          >
+            <Icon className="size-4" />
+            {s.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/components/user-hub/UserTable.tsx
+++ b/components/user-hub/UserTable.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import type { HubUser } from '@/types/user-hub';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { BetaBadges, FavouriteGamesBadges, OnlineDot, SuspensionBadge } from './user-badges';
+
+type Props = {
+  users: HubUser[];
+  onSelect: (user: HubUser) => void;
+};
+
+/** Dense admin table of users. Row click opens the detail sheet. */
+export function UserTable({ users, onSelect }: Props) {
+  if (users.length === 0) {
+    return (
+      <div className="rounded-md border p-8 text-center text-sm text-gray-500">
+        No users match your search.
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-md border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-16 text-right font-mono text-xs">ID</TableHead>
+            <TableHead>Username</TableHead>
+            <TableHead className="hidden md:table-cell">Email</TableHead>
+            <TableHead>Favourites</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead className="hidden lg:table-cell">Presence</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {users.map(u => (
+            <TableRow
+              key={u.id}
+              data-testid={`user-row-${u.id}`}
+              onClick={() => onSelect(u)}
+              className="cursor-pointer"
+            >
+              <TableCell className="text-right font-mono text-xs text-gray-500">
+                #
+                {u.id}
+              </TableCell>
+              <TableCell className="font-medium">
+                {u.username}
+                {u.is_superuser
+                  ? <span className="ml-2 text-xs text-amber-600" title="Superuser">★</span>
+                  : u.is_staff
+                    ? <span className="ml-2 text-xs text-emerald-600" title="Staff">◆</span>
+                    : null}
+                {!u.is_active && <span className="ml-2 text-xs text-gray-400">(inactive)</span>}
+              </TableCell>
+              <TableCell className="hidden text-sm text-gray-600 dark:text-gray-300 md:table-cell">
+                {u.email || '—'}
+              </TableCell>
+              <TableCell><FavouriteGamesBadges games={u.favourite_games} /></TableCell>
+              <TableCell>
+                <span className="inline-flex flex-wrap items-center gap-1">
+                  <SuspensionBadge user={u} />
+                  <BetaBadges user={u} max={1} />
+                </span>
+              </TableCell>
+              <TableCell className="hidden lg:table-cell"><OnlineDot user={u} /></TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/components/user-hub/UserTable.tsx
+++ b/components/user-hub/UserTable.tsx
@@ -21,7 +21,7 @@ export function UserTable({ users, onSelect }: Props) {
   if (users.length === 0) {
     return (
       <div className="rounded-md border p-8 text-center text-sm text-gray-500">
-        No users match your search.
+        No users match your filters.
       </div>
     );
   }

--- a/components/user-hub/UserTable.tsx
+++ b/components/user-hub/UserTable.tsx
@@ -44,7 +44,16 @@ export function UserTable({ users, onSelect }: Props) {
             <TableRow
               key={u.id}
               data-testid={`user-row-${u.id}`}
+              role="button"
+              tabIndex={0}
+              aria-label={`Open ${u.username}`}
               onClick={() => onSelect(u)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  onSelect(u);
+                }
+              }}
               className="cursor-pointer"
             >
               <TableCell className="text-right font-mono text-xs text-gray-500">

--- a/components/user-hub/UserTable.tsx
+++ b/components/user-hub/UserTable.tsx
@@ -9,7 +9,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
-import { BetaBadges, FavouriteGamesBadges, OnlineDot, SuspensionBadge } from './user-badges';
+import { BetaBadges, FavouriteGamesBadges, OnlineDot, SuspensionBadge, UserAvatar } from './user-badges';
 
 type Props = {
   users: HubUser[];
@@ -52,13 +52,18 @@ export function UserTable({ users, onSelect }: Props) {
                 {u.id}
               </TableCell>
               <TableCell className="font-medium">
-                {u.username}
-                {u.is_superuser
-                  ? <span className="ml-2 text-xs text-amber-600" title="Superuser">★</span>
-                  : u.is_staff
-                    ? <span className="ml-2 text-xs text-emerald-600" title="Staff">◆</span>
-                    : null}
-                {!u.is_active && <span className="ml-2 text-xs text-gray-400">(inactive)</span>}
+                <span className="flex items-center gap-2">
+                  <UserAvatar user={u} className="size-7" />
+                  <span>
+                    {u.username}
+                    {u.is_superuser
+                      ? <span className="ml-2 text-xs text-amber-600" title="Superuser">★</span>
+                      : u.is_staff
+                        ? <span className="ml-2 text-xs text-emerald-600" title="Staff">◆</span>
+                        : null}
+                    {!u.is_active && <span className="ml-2 text-xs text-gray-400">(inactive)</span>}
+                  </span>
+                </span>
               </TableCell>
               <TableCell className="hidden text-sm text-gray-600 dark:text-gray-300 md:table-cell">
                 {u.email || '—'}

--- a/components/user-hub/UserTableSkeleton.tsx
+++ b/components/user-hub/UserTableSkeleton.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { Skeleton } from '@/components/ui/skeleton';
+import { USER_LIST_PAGE_SIZE } from '@/hooks/use-user-list';
+
+/** Placeholder rows matching the user table layout (avoids layout shift). */
+export function UserTableSkeleton() {
+  return (
+    <div className="rounded-md border">
+      {Array.from({ length: USER_LIST_PAGE_SIZE }).map((_, i) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <div key={i} className="flex items-center gap-3 border-b p-3 last:border-b-0">
+          <Skeleton className="size-7 rounded-full" />
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="hidden h-4 w-40 md:block" />
+          <Skeleton className="ml-auto h-5 w-24" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/user-hub/__tests__/ActiveFilterChips.test.tsx
+++ b/components/user-hub/__tests__/ActiveFilterChips.test.tsx
@@ -1,0 +1,64 @@
+import type { UserListFilters } from '@/types/user-hub';
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { activeChipKeys, ActiveFilterChips } from '@/components/user-hub/ActiveFilterChips';
+
+afterEach(cleanup);
+
+describe('activeChipKeys', () => {
+  it('returns only set facets (search/ordering/page are not chips)', () => {
+    const filters: UserListFilters = {
+      search: 'x',
+      ordering: '-id',
+      page: 2,
+      is_online: 'true',
+      favourite_game: 'grid',
+    };
+
+    expect(activeChipKeys(filters).sort()).toEqual(['favourite_game', 'is_online']);
+  });
+
+  it('is empty when no facets are set', () => {
+    expect(activeChipKeys({ ordering: 'id', page: 1 })).toEqual([]);
+  });
+});
+
+describe('ActiveFilterChips', () => {
+  it('renders nothing when no facets are active', () => {
+    const { container } = render(
+      <ActiveFilterChips filters={{ ordering: 'id', page: 1 }} onRemove={vi.fn()} onClearAll={vi.fn()} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders a chip per active facet with readable labels', () => {
+    render(
+      <ActiveFilterChips
+        filters={{ is_online: 'true', favourite_game: 'the-scout', suspension: 'any' }}
+        onRemove={vi.fn()}
+        onClearAll={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Online')).toBeInTheDocument();
+    expect(screen.getByText('Favourited: The Scout')).toBeInTheDocument();
+    expect(screen.getByText('Suspended (any)')).toBeInTheDocument();
+  });
+
+  it('fires onRemove with the facet key and onClearAll', async () => {
+    const onRemove = vi.fn();
+    const onClearAll = vi.fn();
+    render(
+      <ActiveFilterChips filters={{ is_online: 'true' }} onRemove={onRemove} onClearAll={onClearAll} />,
+    );
+    await userEvent.click(screen.getByRole('button', { name: /Remove Online filter/ }));
+
+    expect(onRemove).toHaveBeenCalledWith('is_online');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Clear all' }));
+
+    expect(onClearAll).toHaveBeenCalled();
+  });
+});

--- a/components/user-hub/__tests__/UserTable.test.tsx
+++ b/components/user-hub/__tests__/UserTable.test.tsx
@@ -1,0 +1,77 @@
+import type { HubUser } from '@/types/user-hub';
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { UserTable } from '@/components/user-hub/UserTable';
+
+function user(overrides: Partial<HubUser> = {}): HubUser {
+  return {
+    id: 1,
+    username: 'kalin',
+    email: 'kalin@example.com',
+    first_name: 'Kalin',
+    last_name: 'D',
+    is_active: true,
+    is_staff: false,
+    is_superuser: false,
+    favourite_games: ['grid', 'quiz'],
+    suspension_scope: null,
+    suspended_until: null,
+    suspension_reason: null,
+    beta_features: [],
+    is_beta_tester: false,
+    is_online: true,
+    ...overrides,
+  };
+}
+
+describe('UserTable', () => {
+  afterEach(cleanup);
+
+  it('shows an empty state when there are no users', () => {
+    render(<UserTable users={[]} onSelect={vi.fn()} />);
+
+    expect(screen.getByText(/No users match/)).toBeInTheDocument();
+  });
+
+  it('renders a row per user with username + favourites', () => {
+    render(
+      <UserTable
+        users={[
+          user(),
+          user({ id: 2, username: 'admin', is_superuser: true, favourite_games: ['career-path'] }),
+        ]}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('user-row-1')).toBeInTheDocument();
+    expect(screen.getByTestId('user-row-2')).toBeInTheDocument();
+    expect(screen.getByText('kalin')).toBeInTheDocument();
+    expect(screen.getByText('admin')).toBeInTheDocument();
+    // user 1's favourites + user 2's distinct favourite
+    expect(screen.getByText('Grid')).toBeInTheDocument();
+    expect(screen.getByText('Quiz')).toBeInTheDocument();
+    expect(screen.getByText('Career Path')).toBeInTheDocument();
+  });
+
+  it('shows a suspension badge for suspended users', () => {
+    render(
+      <UserTable
+        users={[user({ suspension_scope: 'FULL_PLATFORM', suspension_reason: 'spam' })]}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Full suspension')).toBeInTheDocument();
+  });
+
+  it('calls onSelect with the user when a row is clicked', async () => {
+    const onSelect = vi.fn();
+    const u = user({ id: 7, username: 'clicked' });
+    render(<UserTable users={[u]} onSelect={onSelect} />);
+    await userEvent.click(screen.getByTestId('user-row-7'));
+
+    expect(onSelect).toHaveBeenCalledWith(u);
+  });
+});

--- a/components/user-hub/user-badges.tsx
+++ b/components/user-hub/user-badges.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import type { HubUser } from '@/types/user-hub';
+import { Badge } from '@/components/ui/badge';
+import { prettySlug, suspensionLabel } from '@/lib/user-hub-format';
+import { cn } from '@/lib/utils';
+
+/** Renders the suspension state, or null when the user is in good standing. */
+export function SuspensionBadge({ user }: { user: HubUser }) {
+  if (!user.suspension_scope) {
+    return null;
+  }
+  return (
+    <Badge variant="destructive" title={user.suspension_reason ?? undefined}>
+      {suspensionLabel(user.suspension_scope)}
+    </Badge>
+  );
+}
+
+/** Beta-tester / per-feature badges. Shows up to `max` feature chips. */
+export function BetaBadges({ user, max = 3 }: { user: HubUser; max?: number }) {
+  if (!user.is_beta_tester && (!user.beta_features || user.beta_features.length === 0)) {
+    return null;
+  }
+  const features = user.beta_features ?? [];
+  const shown = features.slice(0, max);
+  const extra = features.length - shown.length;
+  return (
+    <span className="inline-flex flex-wrap items-center gap-1">
+      <Badge variant="secondary" className="bg-purple-100 text-purple-900 dark:bg-purple-900/40 dark:text-purple-100">
+        beta
+      </Badge>
+      {shown.map(f => (
+        <Badge key={f} variant="outline" className="text-xs">{f}</Badge>
+      ))}
+      {extra > 0 && (
+        <span className="text-xs text-gray-500">
+          +
+          {extra}
+        </span>
+      )}
+    </span>
+  );
+}
+
+/** Favourite-game chips (slugs prettified), capped with a +N overflow. */
+export function FavouriteGamesBadges({ games, max = 3 }: { games: string[]; max?: number }) {
+  if (!games || games.length === 0) {
+    return <span className="text-xs text-gray-400">—</span>;
+  }
+  const shown = games.slice(0, max);
+  const extra = games.length - shown.length;
+  return (
+    <span className="inline-flex flex-wrap items-center gap-1">
+      {shown.map(g => (
+        <Badge key={g} variant="outline" className="text-xs">{prettySlug(g)}</Badge>
+      ))}
+      {extra > 0 && (
+        <span className="text-xs text-gray-500">
+          +
+          {extra}
+        </span>
+      )}
+    </span>
+  );
+}
+
+/** Presence dot. `is_online` may be undefined (Redis unavailable) → "unknown". */
+export function OnlineDot({ user }: { user: HubUser }) {
+  const state = user.is_online === undefined ? 'unknown' : user.is_online ? 'online' : 'offline';
+  const color
+    = state === 'online' ? 'bg-emerald-500' : state === 'offline' ? 'bg-gray-300 dark:bg-gray-600' : 'bg-amber-400';
+  return (
+    <span className="inline-flex items-center gap-1.5" title={state}>
+      <span className={cn('size-2 rounded-full', color)} />
+      <span className="text-xs capitalize text-gray-500">{state}</span>
+    </span>
+  );
+}

--- a/components/user-hub/user-badges.tsx
+++ b/components/user-hub/user-badges.tsx
@@ -1,9 +1,20 @@
 'use client';
 
 import type { HubUser } from '@/types/user-hub';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
-import { prettySlug, suspensionLabel } from '@/lib/user-hub-format';
+import { initialsFor, prettySlug, suspensionLabel } from '@/lib/user-hub-format';
 import { cn } from '@/lib/utils';
+
+/** Profile-picture avatar with initials fallback. */
+export function UserAvatar({ user, className }: { user: HubUser; className?: string }) {
+  return (
+    <Avatar className={cn('size-8', className)}>
+      {user.profile_picture_url && <AvatarImage src={user.profile_picture_url} alt={user.username} />}
+      <AvatarFallback className="text-xs">{initialsFor(user)}</AvatarFallback>
+    </Avatar>
+  );
+}
 
 /** Renders the suspension state, or null when the user is in good standing. */
 export function SuspensionBadge({ user }: { user: HubUser }) {

--- a/hooks/use-favourites-usage.ts
+++ b/hooks/use-favourites-usage.ts
@@ -1,0 +1,57 @@
+/**
+ * Loads the admin favourites-usage analytics. Returns a friendly error when
+ * the endpoint isn't deployed yet (it ships in a separate BE PR), so the
+ * analytics page can degrade gracefully instead of crashing.
+ */
+
+import type { FavouritesUsageResponse } from '@/types/user-hub';
+import { useCallback, useEffect, useState } from 'react';
+import config from '@/lib/config';
+import { UserHubAPI } from '@/lib/user-hub-api';
+
+export type UseFavouritesUsage = {
+  data: FavouritesUsageResponse | null;
+  isLoading: boolean;
+  /** Friendly, already-formatted message, or null. */
+  error: string | null;
+  /** True when the error looks like "endpoint not deployed yet" (404). */
+  notDeployed: boolean;
+  refetch: () => void;
+};
+
+export function useFavouritesUsage(isAuthenticated: boolean): UseFavouritesUsage {
+  const [data, setData] = useState<FavouritesUsageResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [notDeployed, setNotDeployed] = useState(false);
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    setNotDeployed(false);
+    try {
+      const res = await UserHubAPI.getFavouritesUsage();
+      setData(res);
+    } catch (err: unknown) {
+      const raw = err instanceof Error ? err.message : 'Failed to load favourites usage';
+      const is404 = /404|Not Found/i.test(raw);
+      setNotDeployed(is404);
+      setError(
+        is404
+          ? `The favourites-usage endpoint isn't available at ${config.API_BASE_URL} yet.\n\nIt deploys with its backend PR (GET /accounts/admin/favourites-usage/). This view will populate automatically once that's live.`
+          : raw,
+      );
+      setData(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      load();
+    }
+  }, [isAuthenticated, load]);
+
+  return { data, isLoading, error, notDeployed, refetch: load };
+}

--- a/hooks/use-user-list.ts
+++ b/hooks/use-user-list.ts
@@ -1,0 +1,85 @@
+/**
+ * Loads the admin user list with server-side search, ordering and pagination
+ * (DRF `?search=` / `?ordering=` / `?page=`). Page size is fixed by the BE
+ * (PageNumberPagination, PAGE_SIZE=10) — we read `count` to derive totalPages.
+ */
+
+import type { HubUser } from '@/types/user-hub';
+import { useCallback, useEffect, useState } from 'react';
+import { UserHubAPI } from '@/lib/user-hub-api';
+
+/** BE PageNumberPagination default (extratime/settings.py PAGE_SIZE). */
+export const USER_LIST_PAGE_SIZE = 10;
+
+export type UseUserList = {
+  users: HubUser[];
+  count: number;
+  totalPages: number;
+  page: number;
+  setPage: (page: number) => void;
+  search: string;
+  setSearch: (q: string) => void;
+  ordering: string;
+  setOrdering: (o: string) => void;
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => void;
+};
+
+export function useUserList(isAuthenticated: boolean, debouncedSearch: string): UseUserList {
+  const [users, setUsers] = useState<HubUser[]>([]);
+  const [count, setCount] = useState(0);
+  const [page, setPage] = useState(1);
+  const [search, setSearch] = useState('');
+  const [ordering, setOrdering] = useState('id');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const res = await UserHubAPI.listUsers({
+        search: debouncedSearch.trim() || undefined,
+        ordering,
+        page,
+      });
+      setUsers(res.results);
+      setCount(res.count ?? 0);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Failed to load users');
+      setUsers([]);
+      setCount(0);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [debouncedSearch, ordering, page]);
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      load();
+    }
+  }, [isAuthenticated, load]);
+
+  // Reset to page 1 whenever the result set narrows.
+  useEffect(() => {
+    setPage(1);
+  }, [debouncedSearch, ordering]);
+
+  const totalPages = Math.max(1, Math.ceil(count / USER_LIST_PAGE_SIZE));
+
+  return {
+    users,
+    count,
+    totalPages,
+    page,
+    setPage,
+    search,
+    setSearch,
+    ordering,
+    setOrdering,
+    isLoading,
+    error,
+    refetch: load,
+  };
+}

--- a/hooks/use-user-list.ts
+++ b/hooks/use-user-list.ts
@@ -1,10 +1,11 @@
 /**
- * Loads the admin user list with server-side search, ordering and pagination
- * (DRF `?search=` / `?ordering=` / `?page=`). Page size is fixed by the BE
- * (PageNumberPagination, PAGE_SIZE=10) — we read `count` to derive totalPages.
+ * Loads the admin user list for a given filter set (server-side search,
+ * faceted filters, ordering, pagination). The page owns the filter state (and
+ * syncs it to the URL); this hook is a thin fetcher. Page size is fixed by the
+ * BE (PageNumberPagination, PAGE_SIZE=10) — we read `count` to derive totalPages.
  */
 
-import type { HubUser } from '@/types/user-hub';
+import type { HubUser, UserListFilters } from '@/types/user-hub';
 import { useCallback, useEffect, useState } from 'react';
 import { UserHubAPI } from '@/lib/user-hub-api';
 
@@ -15,34 +16,28 @@ export type UseUserList = {
   users: HubUser[];
   count: number;
   totalPages: number;
-  page: number;
-  setPage: (page: number) => void;
-  search: string;
-  setSearch: (q: string) => void;
-  ordering: string;
-  setOrdering: (o: string) => void;
   isLoading: boolean;
   error: string | null;
   refetch: () => void;
 };
 
-export function useUserList(isAuthenticated: boolean, debouncedSearch: string): UseUserList {
+export function useUserList(isAuthenticated: boolean, filters: UserListFilters): UseUserList {
   const [users, setUsers] = useState<HubUser[]>([]);
   const [count, setCount] = useState(0);
-  const [page, setPage] = useState(1);
-  const [search, setSearch] = useState('');
-  const [ordering, setOrdering] = useState('id');
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Serialize the filter object so the effect re-runs on any value change
+  // without depending on referential identity of the caller's object.
+  const filterKey = JSON.stringify(filters);
 
   const load = useCallback(async () => {
     setIsLoading(true);
     setError(null);
     try {
       const res = await UserHubAPI.listUsers({
-        search: debouncedSearch.trim() || undefined,
-        ordering,
-        page,
+        ...filters,
+        search: filters.search?.trim() || undefined,
       });
       setUsers(res.results);
       setCount(res.count ?? 0);
@@ -53,7 +48,10 @@ export function useUserList(isAuthenticated: boolean, debouncedSearch: string): 
     } finally {
       setIsLoading(false);
     }
-  }, [debouncedSearch, ordering, page]);
+    // filterKey captures every filter value; `filters` itself is intentionally
+    // not a dep (it's a fresh object each render).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filterKey]);
 
   useEffect(() => {
     if (isAuthenticated) {
@@ -61,25 +59,7 @@ export function useUserList(isAuthenticated: boolean, debouncedSearch: string): 
     }
   }, [isAuthenticated, load]);
 
-  // Reset to page 1 whenever the result set narrows.
-  useEffect(() => {
-    setPage(1);
-  }, [debouncedSearch, ordering]);
-
   const totalPages = Math.max(1, Math.ceil(count / USER_LIST_PAGE_SIZE));
 
-  return {
-    users,
-    count,
-    totalPages,
-    page,
-    setPage,
-    search,
-    setSearch,
-    ordering,
-    setOrdering,
-    isLoading,
-    error,
-    refetch: load,
-  };
+  return { users, count, totalPages, isLoading, error, refetch: load };
 }

--- a/lib/__tests__/user-hub-analytics.test.ts
+++ b/lib/__tests__/user-hub-analytics.test.ts
@@ -1,0 +1,67 @@
+import type { FavouritesUsageResponse, FavouritesUsageUser } from '@/types/user-hub';
+import { describe, expect, it } from 'vitest';
+import {
+  avgFavouritesPerUser,
+  favouriteDepthDistribution,
+  favouritesToCsv,
+  firstChoiceCounts,
+} from '@/lib/user-hub-analytics';
+
+function user(id: number, favourite_games: string[]): FavouritesUsageUser {
+  return { id, username: `u${id}`, favourite_games };
+}
+
+const USERS: FavouritesUsageUser[] = [
+  user(1, ['grid', 'quiz']),
+  user(2, ['grid']),
+  user(3, ['quiz', 'grid', 'the-scout']),
+  user(4, []),
+];
+
+function response(users: FavouritesUsageUser[]): FavouritesUsageResponse {
+  const withFav = users.filter(u => u.favourite_games.length > 0).length;
+  return { users_with_favourites: withFav, total_users: users.length, game_popularity: {}, users };
+}
+
+describe('avgFavouritesPerUser', () => {
+  it('averages over users who have favourites', () => {
+    // (2 + 1 + 3) / 3 = 2
+    expect(avgFavouritesPerUser(response(USERS))).toBe(2);
+  });
+
+  it('is 0 when nobody has favourites', () => {
+    expect(avgFavouritesPerUser(response([user(1, [])]))).toBe(0);
+  });
+});
+
+describe('firstChoiceCounts', () => {
+  it('counts #1 picks and sorts desc', () => {
+    // first picks: grid, grid, quiz → grid:2, quiz:1
+    const rows = firstChoiceCounts(USERS);
+
+    expect(rows[0]).toEqual({ slug: 'grid', label: 'Grid', count: 2 });
+    expect(rows[1]).toEqual({ slug: 'quiz', label: 'Quiz', count: 1 });
+  });
+});
+
+describe('favouriteDepthDistribution', () => {
+  it('buckets favourite counts', () => {
+    const dist = favouriteDepthDistribution(USERS);
+
+    expect(dist.find(d => d.bucket === '1')?.count).toBe(1); // user 2
+    expect(dist.find(d => d.bucket === '2')?.count).toBe(1); // user 1
+    expect(dist.find(d => d.bucket === '3')?.count).toBe(1); // user 3
+    expect(dist.find(d => d.bucket === '5+')?.count).toBe(0);
+  });
+});
+
+describe('favouritesToCsv', () => {
+  it('emits a header + one row per user, escaping cells', () => {
+    const csv = favouritesToCsv([user(1, ['grid', 'quiz']), { id: 2, username: 'a,b', favourite_games: [] }]);
+    const lines = csv.split('\n');
+
+    expect(lines[0]).toBe('id,username,favourite_count,favourite_games');
+    expect(lines[1]).toBe('1,u1,2,grid|quiz');
+    expect(lines[2]).toBe('2,"a,b",0,');
+  });
+});

--- a/lib/__tests__/user-hub-api.test.ts
+++ b/lib/__tests__/user-hub-api.test.ts
@@ -65,21 +65,43 @@ describe('UserHubAPI', () => {
       expect(url).not.toContain('search=');
       expect(url).toContain('ordering=id');
     });
+
+    it('serialises the faceted filter params', async () => {
+      mockApiFetcher.mockResolvedValue({ count: 0, next: null, previous: null, results: [] });
+      await UserHubAPI.listUsers({
+        is_online: 'true',
+        favourite_game: 'grid',
+        has_favourites: 'true',
+        is_beta_tester: 'true',
+        suspension: 'FULL_PLATFORM',
+        is_active: 'true',
+      });
+      const url = mockApiFetcher.mock.calls[0][0] as string;
+
+      expect(url).toContain('is_online=true');
+      expect(url).toContain('favourite_game=grid');
+      expect(url).toContain('has_favourites=true');
+      expect(url).toContain('is_beta_tester=true');
+      expect(url).toContain('suspension=FULL_PLATFORM');
+      expect(url).toContain('is_active=true');
+    });
+
+    it('does NOT drop a "false" filter value', async () => {
+      mockApiFetcher.mockResolvedValue({ count: 0, next: null, previous: null, results: [] });
+      await UserHubAPI.listUsers({ is_online: 'false', is_active: 'false' });
+      const url = mockApiFetcher.mock.calls[0][0] as string;
+
+      expect(url).toContain('is_online=false');
+      expect(url).toContain('is_active=false');
+    });
   });
 
-  describe('getUser / getUserRankings', () => {
+  describe('getUser', () => {
     it('hits /accounts/users/{id}/', async () => {
       mockApiFetcher.mockResolvedValue({ id: 5 });
       await UserHubAPI.getUser(5);
 
       expect(mockApiFetcher).toHaveBeenCalledWith('accounts/users/5/');
-    });
-
-    it('hits /accounts/users/{id}/rankings/', async () => {
-      mockApiFetcher.mockResolvedValue({});
-      await UserHubAPI.getUserRankings(5);
-
-      expect(mockApiFetcher).toHaveBeenCalledWith('accounts/users/5/rankings/');
     });
   });
 });

--- a/lib/__tests__/user-hub-api.test.ts
+++ b/lib/__tests__/user-hub-api.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { apiFetcher } from '@/lib/api-fetcher';
+import { UserHubAPI } from '@/lib/user-hub-api';
+
+vi.mock('@/lib/api-fetcher', () => ({
+  apiFetcher: vi.fn(),
+}));
+
+const mockApiFetcher = vi.mocked(apiFetcher);
+
+describe('UserHubAPI', () => {
+  beforeEach(() => mockApiFetcher.mockReset());
+
+  afterEach(() => vi.restoreAllMocks());
+
+  describe('getFavouritesUsage', () => {
+    it('hits /accounts/admin/favourites-usage/', async () => {
+      const payload = {
+        users_with_favourites: 3,
+        total_users: 10,
+        game_popularity: { grid: 2, quiz: 1 },
+        users: [{ id: 1, username: 'a', favourite_games: ['grid'] }],
+      };
+      mockApiFetcher.mockResolvedValue(payload);
+
+      const result = await UserHubAPI.getFavouritesUsage();
+
+      expect(mockApiFetcher).toHaveBeenCalledWith('accounts/admin/favourites-usage/');
+      expect(result).toEqual(payload);
+    });
+
+    it('propagates apiFetcher errors (e.g. 404 before deploy)', async () => {
+      mockApiFetcher.mockRejectedValueOnce(new Error('404 Not Found'));
+
+      await expect(UserHubAPI.getFavouritesUsage()).rejects.toThrow('404 Not Found');
+    });
+  });
+
+  describe('listUsers', () => {
+    it('hits /accounts/users/ with no params', async () => {
+      mockApiFetcher.mockResolvedValue({ count: 0, next: null, previous: null, results: [] });
+      await UserHubAPI.listUsers();
+
+      expect(mockApiFetcher).toHaveBeenCalledWith('accounts/users/');
+    });
+
+    it('serialises params and drops undefined/empty', async () => {
+      mockApiFetcher.mockResolvedValue({ count: 0, next: null, previous: null, results: [] });
+      await UserHubAPI.listUsers({ search: 'kalin', ordering: '-id', page: 2 });
+
+      const url = mockApiFetcher.mock.calls[0][0] as string;
+
+      expect(url.startsWith('accounts/users/?')).toBe(true);
+      expect(url).toContain('search=kalin');
+      expect(url).toContain('ordering=-id');
+      expect(url).toContain('page=2');
+    });
+
+    it('omits an empty search term', async () => {
+      mockApiFetcher.mockResolvedValue({ count: 0, next: null, previous: null, results: [] });
+      await UserHubAPI.listUsers({ search: '', ordering: 'id', page: 1 });
+      const url = mockApiFetcher.mock.calls[0][0] as string;
+
+      expect(url).not.toContain('search=');
+      expect(url).toContain('ordering=id');
+    });
+  });
+
+  describe('getUser / getUserRankings', () => {
+    it('hits /accounts/users/{id}/', async () => {
+      mockApiFetcher.mockResolvedValue({ id: 5 });
+      await UserHubAPI.getUser(5);
+
+      expect(mockApiFetcher).toHaveBeenCalledWith('accounts/users/5/');
+    });
+
+    it('hits /accounts/users/{id}/rankings/', async () => {
+      mockApiFetcher.mockResolvedValue({});
+      await UserHubAPI.getUserRankings(5);
+
+      expect(mockApiFetcher).toHaveBeenCalledWith('accounts/users/5/rankings/');
+    });
+  });
+});

--- a/lib/__tests__/user-hub-filters.test.ts
+++ b/lib/__tests__/user-hub-filters.test.ts
@@ -1,0 +1,70 @@
+import type { UserListFilters } from '@/types/user-hub';
+import { describe, expect, it } from 'vitest';
+import { readFilters, serialiseFilters } from '@/lib/user-hub-filters';
+
+describe('readFilters', () => {
+  it('applies safe defaults for an empty query', () => {
+    const f = readFilters(new URLSearchParams(''));
+
+    expect(f).toEqual({
+      search: undefined,
+      ordering: 'id',
+      page: 1,
+      is_online: undefined,
+      favourite_game: undefined,
+      has_favourites: undefined,
+      is_beta_tester: undefined,
+      suspension: undefined,
+      is_active: undefined,
+    });
+  });
+
+  it('parses all facets', () => {
+    const f = readFilters(new URLSearchParams(
+      'search=kalin&ordering=-date_joined&page=3&is_online=true&favourite_game=grid&suspension=any&is_active=false',
+    ));
+
+    expect(f.search).toBe('kalin');
+    expect(f.ordering).toBe('-date_joined');
+    expect(f.page).toBe(3);
+    expect(f.is_online).toBe('true');
+    expect(f.favourite_game).toBe('grid');
+    expect(f.suspension).toBe('any');
+    expect(f.is_active).toBe('false');
+  });
+
+  it('ignores invalid bool / suspension / page values', () => {
+    const f = readFilters(new URLSearchParams('is_online=maybe&suspension=bogus&page=0'));
+
+    expect(f.is_online).toBeUndefined();
+    expect(f.suspension).toBeUndefined();
+    expect(f.page).toBe(1);
+  });
+});
+
+describe('serialiseFilters', () => {
+  it('omits defaults and empties', () => {
+    expect(serialiseFilters({ ordering: 'id', page: 1 })).toBe('');
+  });
+
+  it('keeps the "false" value (not dropped)', () => {
+    expect(serialiseFilters({ is_online: 'false' })).toBe('is_online=false');
+  });
+
+  it('round-trips through readFilters', () => {
+    const original: UserListFilters = {
+      search: 'abc',
+      ordering: '-id',
+      page: 2,
+      is_online: 'false',
+      favourite_game: 'the-scout',
+      has_favourites: 'true',
+      is_beta_tester: 'true',
+      suspension: 'FULL_PLATFORM',
+      is_active: 'false',
+    };
+    const back = readFilters(new URLSearchParams(serialiseFilters(original)));
+
+    expect(back).toEqual(original);
+  });
+});

--- a/lib/__tests__/user-hub-format.test.ts
+++ b/lib/__tests__/user-hub-format.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { prettySlug, suspensionLabel, toChartData } from '@/lib/user-hub-format';
+
+describe('prettySlug', () => {
+  it('title-cases a kebab slug', () => {
+    expect(prettySlug('avatars-of-football')).toBe('Avatars Of Football');
+    expect(prettySlug('grid')).toBe('Grid');
+  });
+
+  it('is safe on empty input', () => {
+    expect(prettySlug('')).toBe('');
+  });
+});
+
+describe('toChartData', () => {
+  it('sorts by count descending and prettifies labels', () => {
+    const rows = toChartData({ 'grid': 2, 'quiz': 5, 'the-scout': 1 });
+
+    expect(rows.map(r => r.slug)).toEqual(['quiz', 'grid', 'the-scout']);
+    expect(rows[0]).toEqual({ slug: 'quiz', label: 'Quiz', count: 5 });
+    expect(rows[2].label).toBe('The Scout');
+  });
+
+  it('returns an empty array for no data', () => {
+    expect(toChartData({})).toEqual([]);
+  });
+});
+
+describe('suspensionLabel', () => {
+  it('maps scopes to labels', () => {
+    expect(suspensionLabel('FULL_PLATFORM')).toBe('Full suspension');
+    expect(suspensionLabel('MULTIPLAYER')).toBe('MP suspended');
+    expect(suspensionLabel('ALL_GAMES')).toBe('Games suspended');
+  });
+
+  it('returns empty string for no suspension', () => {
+    expect(suspensionLabel(null)).toBe('');
+  });
+});

--- a/lib/__tests__/user-hub-format.test.ts
+++ b/lib/__tests__/user-hub-format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { prettySlug, suspensionLabel, toChartData } from '@/lib/user-hub-format';
+import { initialsFor, prettySlug, suspensionLabel, toChartData } from '@/lib/user-hub-format';
 
 describe('prettySlug', () => {
   it('title-cases a kebab slug', () => {
@@ -23,6 +23,16 @@ describe('toChartData', () => {
 
   it('returns an empty array for no data', () => {
     expect(toChartData({})).toEqual([]);
+  });
+});
+
+describe('initialsFor', () => {
+  it('uses first + last initials when present', () => {
+    expect(initialsFor({ first_name: 'Kalin', last_name: 'Dimitrov', username: 'kd' })).toBe('KD');
+  });
+
+  it('falls back to the username when no name', () => {
+    expect(initialsFor({ first_name: '', last_name: '', username: 'admin' })).toBe('AD');
   });
 });
 

--- a/lib/user-hub-analytics.ts
+++ b/lib/user-hub-analytics.ts
@@ -1,0 +1,59 @@
+// Pure analytics derived from the favourites-usage payload (no BE, no deps).
+// Everything here works off `users[]` (each user's ordered favourite_games)
+// plus the totals already in the response.
+
+import type { FavouritesUsageResponse, FavouritesUsageUser } from '@/types/user-hub';
+import { prettySlug } from './user-hub-format';
+
+export type SlugCount = { slug: string; label: string; count: number };
+export type DepthBucket = { bucket: string; count: number };
+
+/** Average number of favourites among users who have any. */
+export function avgFavouritesPerUser(data: FavouritesUsageResponse): number {
+  if (data.users_with_favourites === 0) {
+    return 0;
+  }
+  const total = data.users.reduce((sum, u) => sum + u.favourite_games.length, 0);
+  return total / data.users_with_favourites;
+}
+
+/** How many users picked each game as their #1 (index-0) favourite, desc. */
+export function firstChoiceCounts(users: FavouritesUsageUser[]): SlugCount[] {
+  const counts = new Map<string, number>();
+  for (const u of users) {
+    const first = u.favourite_games[0];
+    if (first) {
+      counts.set(first, (counts.get(first) ?? 0) + 1);
+    }
+  }
+  return [...counts.entries()]
+    .map(([slug, count]) => ({ slug, label: prettySlug(slug), count }))
+    .sort((a, b) => b.count - a.count);
+}
+
+/** Distribution of how many games users favourite: 1, 2, 3, 4, 5+. */
+export function favouriteDepthDistribution(users: FavouritesUsageUser[]): DepthBucket[] {
+  const buckets: Record<string, number> = { '1': 0, '2': 0, '3': 0, '4': 0, '5+': 0 };
+  for (const u of users) {
+    const n = u.favourite_games.length;
+    if (n <= 0) {
+      continue;
+    }
+    const key = n >= 5 ? '5+' : String(n);
+    buckets[key] += 1;
+  }
+  return Object.entries(buckets).map(([bucket, count]) => ({ bucket, count }));
+}
+
+function csvCell(value: string): string {
+  return /[",\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+}
+
+/** CSV of the users×favourites matrix (one row per user). */
+export function favouritesToCsv(users: FavouritesUsageUser[]): string {
+  const header = 'id,username,favourite_count,favourite_games';
+  const rows = users.map(u =>
+    [u.id, csvCell(u.username), u.favourite_games.length, csvCell(u.favourite_games.join('|'))].join(','),
+  );
+  return [header, ...rows].join('\n');
+}

--- a/lib/user-hub-api.ts
+++ b/lib/user-hub-api.ts
@@ -3,7 +3,6 @@ import type {
   HubUser,
   UserListParams,
   UserListResponse,
-  UserRankingsResponse,
 } from '@/types/user-hub';
 import { apiFetcher } from '@/lib/api-fetcher';
 
@@ -46,10 +45,5 @@ export class UserHubAPI {
   /** GET /accounts/users/{id}/ — single user (admin detail). */
   static async getUser(id: number): Promise<HubUser> {
     return apiFetcher<HubUser>(`accounts/users/${id}/`);
-  }
-
-  /** GET /accounts/users/{id}/rankings/ — per-game rankings for the detail view. */
-  static async getUserRankings(id: number): Promise<UserRankingsResponse> {
-    return apiFetcher<UserRankingsResponse>(`accounts/users/${id}/rankings/`);
   }
 }

--- a/lib/user-hub-api.ts
+++ b/lib/user-hub-api.ts
@@ -1,0 +1,55 @@
+import type {
+  FavouritesUsageResponse,
+  HubUser,
+  UserListParams,
+  UserListResponse,
+  UserRankingsResponse,
+} from '@/types/user-hub';
+import { apiFetcher } from '@/lib/api-fetcher';
+
+/**
+ * Build a `?key=value&...` string from a params object, dropping `undefined`,
+ *  `null`, the literal string `'all'`, and empty strings. Mirrors `team-api`.
+ */
+function buildQuery(params: Record<string, unknown> | undefined): string {
+  if (!params) {
+    return '';
+  }
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null || value === '' || value === 'all') {
+      continue;
+    }
+    search.append(key, String(value));
+  }
+  const qs = search.toString();
+  return qs ? `?${qs}` : '';
+}
+
+/**
+ * Admin-only User Hub endpoints (all require `IsAdminUser` server-side; the
+ * Bearer JWT is attached by `apiFetcher`). Read-only in Phase 1 — there is
+ * intentionally NO delete or write method here.
+ */
+export class UserHubAPI {
+  /** GET /accounts/admin/favourites-usage/ — favourites adoption + popularity. */
+  static async getFavouritesUsage(): Promise<FavouritesUsageResponse> {
+    return apiFetcher<FavouritesUsageResponse>('accounts/admin/favourites-usage/');
+  }
+
+  /** GET /accounts/users/ — paginated, searchable (?search=), orderable (?ordering=). */
+  static async listUsers(params?: UserListParams): Promise<UserListResponse> {
+    const qs = buildQuery(params as Record<string, unknown> | undefined);
+    return apiFetcher<UserListResponse>(`accounts/users/${qs}`);
+  }
+
+  /** GET /accounts/users/{id}/ — single user (admin detail). */
+  static async getUser(id: number): Promise<HubUser> {
+    return apiFetcher<HubUser>(`accounts/users/${id}/`);
+  }
+
+  /** GET /accounts/users/{id}/rankings/ — per-game rankings for the detail view. */
+  static async getUserRankings(id: number): Promise<UserRankingsResponse> {
+    return apiFetcher<UserRankingsResponse>(`accounts/users/${id}/rankings/`);
+  }
+}

--- a/lib/user-hub-filters.ts
+++ b/lib/user-hub-filters.ts
@@ -1,0 +1,70 @@
+// Pure (de)serialisation between the Users-page URL query string and the typed
+// UserListFilters object. Kept framework-free so it round-trips in unit tests
+// and the page stays thin.
+
+import type { BoolParam, SuspensionFilter, UserListFilters } from '@/types/user-hub';
+
+const DEFAULT_ORDERING = 'id';
+
+const SUSPENSION_VALUES: SuspensionFilter[] = ['none', 'any', 'MULTIPLAYER', 'ALL_GAMES', 'FULL_PLATFORM'];
+
+function asBool(value: string | null): BoolParam | undefined {
+  return value === 'true' || value === 'false' ? value : undefined;
+}
+
+/** Parse a URL query into the typed filter state, applying safe defaults. */
+export function readFilters(params: URLSearchParams): UserListFilters {
+  const str = (k: string) => params.get(k) || undefined;
+  const pageRaw = Number.parseInt(params.get('page') ?? '1', 10);
+  const suspension = params.get('suspension');
+
+  return {
+    search: str('search'),
+    ordering: str('ordering') ?? DEFAULT_ORDERING,
+    page: Number.isNaN(pageRaw) || pageRaw < 1 ? 1 : pageRaw,
+    is_online: asBool(params.get('is_online')),
+    favourite_game: str('favourite_game'),
+    has_favourites: asBool(params.get('has_favourites')),
+    is_beta_tester: asBool(params.get('is_beta_tester')),
+    suspension: SUSPENSION_VALUES.includes(suspension as SuspensionFilter)
+      ? (suspension as SuspensionFilter)
+      : undefined,
+    is_active: asBool(params.get('is_active')),
+  };
+}
+
+/**
+ * Serialise filter state back to a query string, omitting defaults/empties so
+ *  URLs stay clean (no `?ordering=id&page=1`).
+ */
+export function serialiseFilters(f: UserListFilters): string {
+  const p = new URLSearchParams();
+  if (f.search) {
+    p.set('search', f.search);
+  }
+  if (f.ordering && f.ordering !== DEFAULT_ORDERING) {
+    p.set('ordering', f.ordering);
+  }
+  if (f.page && f.page > 1) {
+    p.set('page', String(f.page));
+  }
+  if (f.is_online) {
+    p.set('is_online', f.is_online);
+  }
+  if (f.favourite_game) {
+    p.set('favourite_game', f.favourite_game);
+  }
+  if (f.has_favourites) {
+    p.set('has_favourites', f.has_favourites);
+  }
+  if (f.is_beta_tester) {
+    p.set('is_beta_tester', f.is_beta_tester);
+  }
+  if (f.suspension) {
+    p.set('suspension', f.suspension);
+  }
+  if (f.is_active) {
+    p.set('is_active', f.is_active);
+  }
+  return p.toString();
+}

--- a/lib/user-hub-format.ts
+++ b/lib/user-hub-format.ts
@@ -1,0 +1,31 @@
+// Pure formatting helpers for the User Hub (no React) so components stay
+// fast-refresh friendly and the logic is unit-testable in isolation.
+
+import type { SuspensionScope } from '@/types/user-hub';
+
+/** Turn a kebab slug into a readable label until a slug→display-name map exists. */
+export function prettySlug(slug: string): string {
+  return slug
+    .split('-')
+    .map(w => (w ? w[0].toUpperCase() + w.slice(1) : w))
+    .join(' ');
+}
+
+/** Sort a game-popularity map into chart rows, most-favourited first. */
+export function toChartData(
+  gamePopularity: Record<string, number>,
+): { slug: string; label: string; count: number }[] {
+  return Object.entries(gamePopularity)
+    .map(([slug, count]) => ({ slug, label: prettySlug(slug), count }))
+    .sort((a, b) => b.count - a.count);
+}
+
+/** Human label for a suspension scope. */
+export function suspensionLabel(scope: SuspensionScope): string {
+  switch (scope) {
+    case 'MULTIPLAYER': return 'MP suspended';
+    case 'ALL_GAMES': return 'Games suspended';
+    case 'FULL_PLATFORM': return 'Full suspension';
+    default: return '';
+  }
+}

--- a/lib/user-hub-format.ts
+++ b/lib/user-hub-format.ts
@@ -1,7 +1,15 @@
 // Pure formatting helpers for the User Hub (no React) so components stay
 // fast-refresh friendly and the logic is unit-testable in isolation.
 
-import type { SuspensionScope } from '@/types/user-hub';
+import type { HubUser, SuspensionScope } from '@/types/user-hub';
+
+/** Up-to-2-char initials for an avatar fallback (first/last name, else username). */
+export function initialsFor(user: Pick<HubUser, 'first_name' | 'last_name' | 'username'>): string {
+  const first = user.first_name?.trim()?.[0] ?? '';
+  const last = user.last_name?.trim()?.[0] ?? '';
+  const initials = (first + last).toUpperCase();
+  return initials || (user.username?.slice(0, 2).toUpperCase() ?? '?');
+}
 
 /** Turn a kebab slug into a readable label until a slug→display-name map exists. */
 export function prettySlug(slug: string): string {

--- a/types/user-hub.ts
+++ b/types/user-hub.ts
@@ -1,0 +1,89 @@
+// Types for the admin-only User Hub (favourites analytics + user management).
+// Field names mirror the Django BE `AdminUserSerializer` and the
+// `/accounts/admin/favourites-usage/` payload — keep them in sync if the BE
+// serializer changes.
+
+/** DRF PageNumberPagination envelope (count / next / previous / results). */
+export type Paginated<T> = {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: T[];
+};
+
+// ---- favourites-usage analytics ------------------------------------------
+
+export type FavouritesUsageUser = {
+  id: number;
+  username: string;
+  favourite_games: string[];
+};
+
+/** GET /accounts/admin/favourites-usage/ (IsAdminUser). */
+export type FavouritesUsageResponse = {
+  users_with_favourites: number;
+  total_users: number;
+  /** game-id slug → number of users who favourited it. */
+  game_popularity: Record<string, number>;
+  users: FavouritesUsageUser[];
+};
+
+// ---- user list / detail ---------------------------------------------------
+
+/** Suspension scopes mirrored from the BE `UserSuspension.scope` choices. */
+export type SuspensionScope = 'MULTIPLAYER' | 'ALL_GAMES' | 'FULL_PLATFORM' | null;
+
+/**
+ * Subset of `AdminUserSerializer` fields the hub reads. The serializer
+ * returns more; we type only what we render so the shape stays honest.
+ */
+export type HubUser = {
+  id: number;
+  username: string;
+  email: string;
+  first_name: string;
+  last_name: string;
+  is_active: boolean;
+  is_staff: boolean;
+  is_superuser: boolean;
+  favourite_games: string[];
+  suspension_scope: SuspensionScope;
+  suspended_until: string | null;
+  suspension_reason?: string | null;
+  beta_features: string[];
+  is_beta_tester: boolean;
+  needs_username_update?: boolean;
+  // Presence fields are Redis-derived and may be absent/unknown.
+  is_online?: boolean;
+  last_seen?: string | null;
+  date_joined?: string | null;
+  last_login?: string | null;
+  profile_picture_url?: string | null;
+  date_of_birth?: string | null;
+};
+
+export type UserListResponse = Paginated<HubUser>;
+
+/** Query params accepted by `GET /accounts/users/`. */
+export type UserListParams = {
+  /** DRF SearchFilter — matches username/email/first_name/last_name/phone_number. */
+  search?: string;
+  /** DRF OrderingFilter field (e.g. `id`, `-username`). */
+  ordering?: string;
+  page?: number;
+};
+
+// ---- per-user rankings ----------------------------------------------------
+
+/**
+ * GET /accounts/users/{id}/rankings/ — the BE returns several ranking
+ * sections whose inner shapes vary per game. We keep this permissive and
+ * render defensively rather than over-fitting nested structures.
+ */
+export type UserRankingsResponse = {
+  game_rankings?: unknown;
+  stoppage_time_rankings?: unknown;
+  scout_rankings?: unknown;
+  conquest_rankings?: unknown;
+  grid_rankings?: unknown;
+};

--- a/types/user-hub.ts
+++ b/types/user-hub.ts
@@ -64,26 +64,33 @@ export type HubUser = {
 
 export type UserListResponse = Paginated<HubUser>;
 
-/** Query params accepted by `GET /accounts/users/`. */
+/**
+ * Tri-state boolean filters use string `'true'`/`'false'` (not boolean) so they
+ *  map 1:1 to URL params and dodge `buildQuery`'s falsy-skip ambiguity.
+ */
+export type BoolParam = 'true' | 'false';
+
+/** Suspension filter values: not-suspended, any-suspension, or an exact scope. */
+export type SuspensionFilter = 'none' | 'any' | 'MULTIPLAYER' | 'ALL_GAMES' | 'FULL_PLATFORM';
+
+/** Query params accepted by `GET /accounts/users/` (mirrors AdminUserFilter). */
 export type UserListParams = {
   /** DRF SearchFilter — matches username/email/first_name/last_name/phone_number. */
   search?: string;
-  /** DRF OrderingFilter field (e.g. `id`, `-username`). */
+  /** DRF OrderingFilter field (e.g. `id`, `-username`, `-date_joined`). */
   ordering?: string;
   page?: number;
+  is_online?: BoolParam;
+  favourite_game?: string;
+  has_favourites?: BoolParam;
+  is_beta_tester?: BoolParam;
+  suspension?: SuspensionFilter;
+  is_active?: BoolParam;
+  nationality?: number;
 };
 
-// ---- per-user rankings ----------------------------------------------------
-
-/**
- * GET /accounts/users/{id}/rankings/ — the BE returns several ranking
- * sections whose inner shapes vary per game. We keep this permissive and
- * render defensively rather than over-fitting nested structures.
- */
-export type UserRankingsResponse = {
-  game_rankings?: unknown;
-  stoppage_time_rankings?: unknown;
-  scout_rankings?: unknown;
-  conquest_rankings?: unknown;
-  grid_rankings?: unknown;
-};
+/** The full filter state the Users page owns and syncs to the URL. */
+export type UserListFilters = Pick<
+  UserListParams,
+  'search' | 'ordering' | 'page' | 'is_online' | 'favourite_game' | 'has_favourites' | 'is_beta_tester' | 'suspension' | 'is_active'
+>;


### PR DESCRIPTION
## What

Adds a **User Hub** to the automation platform — an admin-only section that aggregates user analytics and profiles. This is **Phase 1: read-only**, built entirely against **existing** `IsAdminUser` endpoints. No new backend work is required beyond merging the favourites-usage endpoint (FootballExtraTime/App#1245).

Gated on `is_superuser` (the page surfaces private user data; the real boundary remains the BE's `IsAdminUser`).

### Favourites Analytics — `/user-hub/analytics`
- Adoption summary (users with favourites / total, % adoption, distinct games) + a game-popularity bar chart (recharts, already a dep).
- **Depends on FootballExtraTime/App#1245** (not deployed yet) → shows a clean "endpoint isn't available yet" panel until that ships, then populates automatically.

### Users — `/user-hub/users`
- Paginated, searchable, sortable list over `GET /accounts/users/` (DRF `?search=` / `?ordering=` / `?page=`), table/cards toggle.
- Row opens a **slide-in detail Sheet**: Profile, Favourite Games, Rankings (`/accounts/users/{id}/rankings/`). **Suspensions** and **Audit History** tabs are labelled "coming soon" (Phase 2).
- Management = **"Manage in Django Admin"** deep-link. **Read-only — no delete action anywhere.**

## How (no new tech debt)
- New `lib/user-hub-api.ts` (`UserHubAPI`, mirrors `TeamAPI`), `lib/user-hub-format.ts` (pure helpers), `hooks/use-favourites-usage.ts` + `hooks/use-user-list.ts`, `types/user-hub.ts`, and `components/user-hub/*`.
- Reuses existing primitives: `DataPagination`, `useDebouncedValue`, recharts, shadcn `Sheet`/`Tabs`/`Table`/`Badge`. **No new dependencies.**
- Nav: new "User Hub" group; dashboard "User Hub" card enabled. While touching `navigation.tsx`, also made its existing clickable rows keyboard-operable (`role`/`tabIndex`/`onKeyDown`) and removed two dead vars so the files lint clean.

## Testing
- `npm run test:run` — **172 pass** (incl. new `user-hub-api`, `user-hub-format`, `UserTable` tests). Husky pre-commit (lint-staged + vitest) green.
- `npm run build` — succeeds; both new routes prerender.
- New files are `check-types`-clean (pre-existing `components/ui/*` baseline type errors are unrelated).

## Follow-up
- **Phase 2** (audit trail `AdminActionLog` + DRF `AuditMixin` + `X-ET-Source`, and in-hub suspend/beta management — no deletion): **FootballExtraTime/App#1246**

🤖 Generated with [Claude Code](https://claude.com/claude-code)