### PR TITLE
feat(user-hub): adoption-over-time + favourited-vs-played charts

### DIFF
--- a/app/user-hub/analytics/page.tsx
+++ b/app/user-hub/analytics/page.tsx
@@ -7,20 +7,25 @@ import { LoginForm } from '@/components/login-form';
 import { Navigation } from '@/components/navigation';
 import { Button } from '@/components/ui/button';
 import { AdminGate } from '@/components/user-hub/AdminGate';
+import { AdoptionTrendsChart } from '@/components/user-hub/AdoptionTrendsChart';
 import { AnalyticsSkeleton } from '@/components/user-hub/AnalyticsSkeleton';
+import { FavouredVsPlayedChart } from '@/components/user-hub/FavouredVsPlayedChart';
 import { FavouriteInsights } from '@/components/user-hub/FavouriteInsights';
 import { FavouritesUsageSummary } from '@/components/user-hub/FavouritesUsageSummary';
 import { GamePopularityChart } from '@/components/user-hub/GamePopularityChart';
 import { UserHubNav } from '@/components/user-hub/UserHubNav';
+import { useAdoptionTrends } from '@/hooks/use-adoption-trends';
+import { useFavouredVsPlayed } from '@/hooks/use-favoured-vs-played';
 import { useFavouritesUsage } from '@/hooks/use-favourites-usage';
 import { useAuth } from '@/lib/auth';
 
 export default function UserHubAnalyticsPage() {
   const { isLoading, isAuthenticated, user } = useAuth();
   const router = useRouter();
-  const { data, isLoading: dataLoading, error, notDeployed, refetch } = useFavouritesUsage(
-    isAuthenticated && !!user?.is_superuser,
-  );
+  const isAdmin = isAuthenticated && !!user?.is_superuser;
+  const { data, isLoading: dataLoading, error, notDeployed, refetch } = useFavouritesUsage(isAdmin);
+  const trends = useAdoptionTrends(isAdmin);
+  const played = useFavouredVsPlayed(isAdmin);
 
   if (isLoading) {
     return <LoadingSpinner message="Authenticating" subtitle="Verifying staff access..." />;
@@ -76,6 +81,25 @@ export default function UserHubAnalyticsPage() {
                     <FavouriteInsights data={data} />
                   </>
                 )}
+
+                {/* Independently guarded — each degrades on its own if its BE
+                    endpoint isn't deployed yet. */}
+                <AdoptionTrendsChart
+                  data={trends.data}
+                  isLoading={trends.isLoading}
+                  error={trends.error}
+                  notDeployed={trends.notDeployed}
+                  granularity={trends.granularity}
+                  onGranularityChange={trends.setGranularity}
+                  onRetry={trends.refetch}
+                />
+                <FavouredVsPlayedChart
+                  data={played.data}
+                  isLoading={played.isLoading}
+                  error={played.error}
+                  notDeployed={played.notDeployed}
+                  onRetry={played.refetch}
+                />
               </>
             )}
       </div>

--- a/components/user-hub/AdoptionTrendsChart.tsx
+++ b/components/user-hub/AdoptionTrendsChart.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import type { AdoptionTrendsResponse, TrendGranularity } from '@/types/user-hub';
+import { Area, AreaChart, CartesianGrid, Legend, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { formatTrendDate } from '@/lib/user-hub-analytics';
+import { cn } from '@/lib/utils';
+
+type Props = {
+  data: AdoptionTrendsResponse | null;
+  isLoading: boolean;
+  error: string | null;
+  notDeployed: boolean;
+  granularity: TrendGranularity;
+  onGranularityChange: (g: TrendGranularity) => void;
+  onRetry: () => void;
+};
+
+/** Theme-aware tooltip (default recharts tooltip is unreadable in dark mode). */
+function TrendTooltip({
+  active,
+  payload,
+  label,
+  granularity,
+}: {
+  active?: boolean;
+  payload?: { name?: string; value?: number; color?: string }[];
+  label?: string;
+  granularity: TrendGranularity;
+}) {
+  if (!active || !payload?.length) {
+    return null;
+  }
+  return (
+    <div className="rounded-md border bg-popover px-3 py-2 text-sm text-popover-foreground shadow-md">
+      <p className="mb-1 font-medium">{label ? formatTrendDate(label, granularity) : ''}</p>
+      {payload.map(p => (
+        <p key={p.name} className="flex items-center gap-1.5 text-muted-foreground">
+          <span className="size-2 rounded-full" style={{ backgroundColor: p.color }} />
+          {p.name}
+          :
+          {' '}
+          <span className="font-mono text-foreground">{p.value}</span>
+        </p>
+      ))}
+    </div>
+  );
+}
+
+const PILLS: TrendGranularity[] = ['day', 'week'];
+
+export function AdoptionTrendsChart({ data, isLoading, error, notDeployed, granularity, onGranularityChange, onRetry }: Props) {
+  if (notDeployed) {
+    return null;
+  }
+
+  const points = data?.points ?? [];
+  const hasBackfill = data?.include_backfill;
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between gap-2 space-y-0">
+        <CardTitle className="text-base">Adoption over time</CardTitle>
+        <div className="flex gap-1 rounded-md border p-0.5">
+          {PILLS.map(g => (
+            <button
+              key={g}
+              type="button"
+              onClick={() => onGranularityChange(g)}
+              className={cn(
+                'rounded px-2 py-0.5 text-xs font-medium capitalize transition-colors',
+                granularity === g
+                  ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300'
+                  : 'text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-700/50',
+              )}
+            >
+              {g}
+            </button>
+          ))}
+        </div>
+      </CardHeader>
+      <CardContent>
+        {isLoading && <Skeleton className="h-64 w-full" />}
+
+        {error && !isLoading && (
+          <div role="alert" className="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-200">
+            {error}
+            <div className="mt-2">
+              <Button size="sm" variant="outline" onClick={onRetry}>Retry</Button>
+            </div>
+          </div>
+        )}
+
+        {!isLoading && !error && points.length === 0 && (
+          <p className="py-8 text-center text-sm text-gray-500">No adoption data yet.</p>
+        )}
+
+        {!isLoading && !error && points.length > 0 && (
+          <>
+            <div className="h-64 w-full">
+              <ResponsiveContainer width="100%" height="100%">
+                <AreaChart data={points} margin={{ left: 4, right: 8, top: 4 }}>
+                  <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-gray-700" />
+                  <XAxis dataKey="date" tick={{ fontSize: 12 }} tickFormatter={v => formatTrendDate(v, granularity)} minTickGap={24} />
+                  <YAxis allowDecimals={false} tick={{ fontSize: 12 }} width={36} />
+                  <Tooltip content={<TrendTooltip granularity={granularity} />} />
+                  <Legend wrapperStyle={{ fontSize: 12 }} />
+                  <Area type="monotone" dataKey="cumulative_users" name="Cumulative users" stroke="#10b981" fill="#10b981" fillOpacity={0.2} />
+                  <Area type="monotone" dataKey="new_adopters" name="New adopters" stroke="#3b82f6" fill="#3b82f6" fillOpacity={0.15} />
+                </AreaChart>
+              </ResponsiveContainer>
+            </div>
+            {hasBackfill && (
+              <p className="mt-2 text-xs text-gray-500">
+                Includes pre-launch favourites (approximate dates).
+              </p>
+            )}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/user-hub/FavouredVsPlayedChart.tsx
+++ b/components/user-hub/FavouredVsPlayedChart.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import type { FavouredVsPlayedResponse, GameEngagementRow } from '@/types/user-hub';
+import { useMemo } from 'react';
+import { Bar, BarChart, CartesianGrid, Legend, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { sortEngagementRows } from '@/lib/user-hub-analytics';
+import { prettySlug } from '@/lib/user-hub-format';
+
+type Props = {
+  data: FavouredVsPlayedResponse | null;
+  isLoading: boolean;
+  error: string | null;
+  notDeployed: boolean;
+  onRetry: () => void;
+};
+
+/** Theme-aware tooltip showing the three counts + play-through %. */
+function EngagementTooltip({
+  active,
+  payload,
+}: {
+  active?: boolean;
+  payload?: { payload?: GameEngagementRow }[];
+}) {
+  const row = payload?.[0]?.payload;
+  if (!active || !row) {
+    return null;
+  }
+  return (
+    <div className="rounded-md border bg-popover px-3 py-2 text-sm text-popover-foreground shadow-md">
+      <p className="mb-1 font-medium">{prettySlug(row.slug)}</p>
+      <p className="text-muted-foreground">
+        Favourited:
+        <span className="font-mono text-foreground">{row.favourited_count}</span>
+      </p>
+      <p className="text-muted-foreground">
+        Started:
+        <span className="font-mono text-foreground">{row.started_count}</span>
+      </p>
+      <p className="text-muted-foreground">
+        Finished:
+        <span className="font-mono text-foreground">{row.finished_count}</span>
+      </p>
+      <p className="text-muted-foreground">
+        Play-through:
+        <span className="font-mono text-foreground">
+          {row.play_through_pct}
+          %
+        </span>
+      </p>
+    </div>
+  );
+}
+
+export function FavouredVsPlayedChart({ data, isLoading, error, notDeployed, onRetry }: Props) {
+  const rows = useMemo(() => (data ? sortEngagementRows(data.games) : []), [data]);
+
+  if (notDeployed) {
+    return null;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Favourited vs played</CardTitle>
+        <p className="text-xs text-muted-foreground">
+          Of users who favourited a game, how many started it and how many finished.
+        </p>
+      </CardHeader>
+      <CardContent>
+        {isLoading && <Skeleton className="h-72 w-full" />}
+
+        {error && !isLoading && (
+          <div role="alert" className="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-200">
+            {error}
+            <div className="mt-2">
+              <Button size="sm" variant="outline" onClick={onRetry}>Retry</Button>
+            </div>
+          </div>
+        )}
+
+        {!isLoading && !error && rows.length === 0 && (
+          <p className="py-8 text-center text-sm text-gray-500">No engagement data yet.</p>
+        )}
+
+        {!isLoading && !error && rows.length > 0 && (
+          <div style={{ height: Math.max(200, rows.length * 56) }}>
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={rows} layout="vertical" margin={{ left: 8, right: 16 }}>
+                <CartesianGrid horizontal={false} strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-gray-700" />
+                <XAxis type="number" allowDecimals={false} tick={{ fontSize: 12 }} />
+                <YAxis type="category" dataKey="slug" width={140} tick={{ fontSize: 12 }} tickFormatter={prettySlug} />
+                <Tooltip cursor={{ fill: 'rgba(16,185,129,0.08)' }} content={<EngagementTooltip />} />
+                <Legend wrapperStyle={{ fontSize: 12 }} />
+                <Bar dataKey="favourited_count" name="Favourited" fill="#10b981" radius={[0, 3, 3, 0]} />
+                <Bar dataKey="started_count" name="Started" fill="#3b82f6" radius={[0, 3, 3, 0]} />
+                <Bar dataKey="finished_count" name="Finished" fill="#f59e0b" radius={[0, 3, 3, 0]} />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/hooks/use-adoption-trends.ts
+++ b/hooks/use-adoption-trends.ts
@@ -1,0 +1,56 @@
+/**
+ * Loads favourites adoption-over-time. Owns the day/week granularity. Degrades
+ * gracefully (notDeployed) when the BE endpoint isn't live yet.
+ */
+
+import type { AdoptionTrendsResponse, TrendGranularity } from '@/types/user-hub';
+import { useCallback, useEffect, useState } from 'react';
+import config from '@/lib/config';
+import { UserHubAPI } from '@/lib/user-hub-api';
+
+export type UseAdoptionTrends = {
+  data: AdoptionTrendsResponse | null;
+  isLoading: boolean;
+  error: string | null;
+  notDeployed: boolean;
+  granularity: TrendGranularity;
+  setGranularity: (g: TrendGranularity) => void;
+  refetch: () => void;
+};
+
+export function useAdoptionTrends(isAuthenticated: boolean): UseAdoptionTrends {
+  const [data, setData] = useState<AdoptionTrendsResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [notDeployed, setNotDeployed] = useState(false);
+  const [granularity, setGranularity] = useState<TrendGranularity>('day');
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    setNotDeployed(false);
+    try {
+      setData(await UserHubAPI.getAdoptionTrends(granularity));
+    } catch (err: unknown) {
+      const raw = err instanceof Error ? err.message : 'Failed to load adoption trends';
+      const is404 = /404|Not Found/i.test(raw);
+      setNotDeployed(is404);
+      setError(
+        is404
+          ? `The adoption-trends endpoint isn't available at ${config.API_BASE_URL} yet (GET /accounts/admin/favourites-trends/). This populates automatically once its backend PR is live.`
+          : raw,
+      );
+      setData(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [granularity]);
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      load();
+    }
+  }, [isAuthenticated, load]);
+
+  return { data, isLoading, error, notDeployed, granularity, setGranularity, refetch: load };
+}

--- a/hooks/use-favoured-vs-played.ts
+++ b/hooks/use-favoured-vs-played.ts
@@ -1,0 +1,53 @@
+/**
+ * Loads favourited-vs-played engagement per game. Degrades gracefully
+ * (notDeployed) when the BE endpoint isn't live yet.
+ */
+
+import type { FavouredVsPlayedResponse } from '@/types/user-hub';
+import { useCallback, useEffect, useState } from 'react';
+import config from '@/lib/config';
+import { UserHubAPI } from '@/lib/user-hub-api';
+
+export type UseFavouredVsPlayed = {
+  data: FavouredVsPlayedResponse | null;
+  isLoading: boolean;
+  error: string | null;
+  notDeployed: boolean;
+  refetch: () => void;
+};
+
+export function useFavouredVsPlayed(isAuthenticated: boolean): UseFavouredVsPlayed {
+  const [data, setData] = useState<FavouredVsPlayedResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [notDeployed, setNotDeployed] = useState(false);
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    setNotDeployed(false);
+    try {
+      setData(await UserHubAPI.getFavouredVsPlayed());
+    } catch (err: unknown) {
+      const raw = err instanceof Error ? err.message : 'Failed to load engagement';
+      const is404 = /404|Not Found/i.test(raw);
+      setNotDeployed(is404);
+      setError(
+        is404
+          ? `The favourited-vs-played endpoint isn't available at ${config.API_BASE_URL} yet (GET /accounts/admin/favourites-vs-played/). This populates automatically once its backend PR is live.`
+          : raw,
+      );
+      setData(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      load();
+    }
+  }, [isAuthenticated, load]);
+
+  return { data, isLoading, error, notDeployed, refetch: load };
+}

--- a/lib/__tests__/user-hub-analytics.test.ts
+++ b/lib/__tests__/user-hub-analytics.test.ts
@@ -1,11 +1,40 @@
-import type { FavouritesUsageResponse, FavouritesUsageUser } from '@/types/user-hub';
+import type { FavouritesUsageResponse, FavouritesUsageUser, GameEngagementRow } from '@/types/user-hub';
 import { describe, expect, it } from 'vitest';
 import {
   avgFavouritesPerUser,
   favouriteDepthDistribution,
   favouritesToCsv,
   firstChoiceCounts,
+  formatTrendDate,
+  sortEngagementRows,
 } from '@/lib/user-hub-analytics';
+
+describe('formatTrendDate', () => {
+  it('formats a day tick', () => {
+    expect(formatTrendDate('2026-06-09', 'day')).toBe('9 Jun');
+  });
+
+  it('prefixes week ticks', () => {
+    expect(formatTrendDate('2026-06-09', 'week')).toBe('wk 9 Jun');
+  });
+
+  it('passes through an unparseable value', () => {
+    expect(formatTrendDate('not-a-date', 'day')).toBe('not-a-date');
+  });
+});
+
+describe('sortEngagementRows', () => {
+  it('sorts by favourited_count desc without mutating input', () => {
+    const rows: GameEngagementRow[] = [
+      { slug: 'a', favourited_count: 1, started_count: 0, finished_count: 0, play_through_pct: 0 },
+      { slug: 'b', favourited_count: 5, started_count: 0, finished_count: 0, play_through_pct: 0 },
+    ];
+    const sorted = sortEngagementRows(rows);
+
+    expect(sorted.map(r => r.slug)).toEqual(['b', 'a']);
+    expect(rows[0].slug).toBe('a'); // original untouched
+  });
+});
 
 function user(id: number, favourite_games: string[]): FavouritesUsageUser {
   return { id, username: `u${id}`, favourite_games };

--- a/lib/__tests__/user-hub-api.test.ts
+++ b/lib/__tests__/user-hub-api.test.ts
@@ -104,4 +104,41 @@ describe('UserHubAPI', () => {
       expect(mockApiFetcher).toHaveBeenCalledWith('accounts/users/5/');
     });
   });
+
+  describe('getAdoptionTrends', () => {
+    it('hits the trends endpoint with no granularity', async () => {
+      mockApiFetcher.mockResolvedValue({ granularity: 'day', include_backfill: false, points: [] });
+      await UserHubAPI.getAdoptionTrends();
+
+      expect(mockApiFetcher).toHaveBeenCalledWith('accounts/admin/favourites-trends/');
+    });
+
+    it('passes the granularity param', async () => {
+      mockApiFetcher.mockResolvedValue({ granularity: 'week', include_backfill: false, points: [] });
+      await UserHubAPI.getAdoptionTrends('week');
+
+      expect(mockApiFetcher).toHaveBeenCalledWith('accounts/admin/favourites-trends/?granularity=week');
+    });
+
+    it('propagates errors (e.g. 404 before deploy)', async () => {
+      mockApiFetcher.mockRejectedValueOnce(new Error('404 Not Found'));
+
+      await expect(UserHubAPI.getAdoptionTrends()).rejects.toThrow('404 Not Found');
+    });
+  });
+
+  describe('getFavouredVsPlayed', () => {
+    it('hits the favourites-vs-played endpoint', async () => {
+      mockApiFetcher.mockResolvedValue({ games: [], total_users: 0 });
+      await UserHubAPI.getFavouredVsPlayed();
+
+      expect(mockApiFetcher).toHaveBeenCalledWith('accounts/admin/favourites-vs-played/');
+    });
+
+    it('propagates errors', async () => {
+      mockApiFetcher.mockRejectedValueOnce(new Error('404 Not Found'));
+
+      await expect(UserHubAPI.getFavouredVsPlayed()).rejects.toThrow('404 Not Found');
+    });
+  });
 });

--- a/lib/user-hub-analytics.ts
+++ b/lib/user-hub-analytics.ts
@@ -2,10 +2,27 @@
 // Everything here works off `users[]` (each user's ordered favourite_games)
 // plus the totals already in the response.
 
-import type { FavouritesUsageResponse, FavouritesUsageUser } from '@/types/user-hub';
+import type { FavouritesUsageResponse, FavouritesUsageUser, GameEngagementRow, TrendGranularity } from '@/types/user-hub';
 import { prettySlug } from './user-hub-format';
 
 export type SlugCount = { slug: string; label: string; count: number };
+
+/** Format a trend period (ISO date) for an axis tick. */
+export function formatTrendDate(iso: string, granularity: TrendGranularity): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) {
+    return iso;
+  }
+  // The BE sends a calendar date (no time); format in UTC so it renders as the
+  // intended day regardless of the viewer's timezone.
+  const label = new Intl.DateTimeFormat('en-GB', { day: 'numeric', month: 'short', timeZone: 'UTC' }).format(d);
+  return granularity === 'week' ? `wk ${label}` : label;
+}
+
+/** Engagement rows sorted by favourited count, desc. */
+export function sortEngagementRows(rows: GameEngagementRow[]): GameEngagementRow[] {
+  return [...rows].sort((a, b) => b.favourited_count - a.favourited_count);
+}
 export type DepthBucket = { bucket: string; count: number };
 
 /** Average number of favourites among users who have any. */

--- a/lib/user-hub-api.ts
+++ b/lib/user-hub-api.ts
@@ -1,6 +1,9 @@
 import type {
+  AdoptionTrendsResponse,
+  FavouredVsPlayedResponse,
   FavouritesUsageResponse,
   HubUser,
+  TrendGranularity,
   UserListParams,
   UserListResponse,
 } from '@/types/user-hub';
@@ -45,5 +48,16 @@ export class UserHubAPI {
   /** GET /accounts/users/{id}/ — single user (admin detail). */
   static async getUser(id: number): Promise<HubUser> {
     return apiFetcher<HubUser>(`accounts/users/${id}/`);
+  }
+
+  /** GET /accounts/admin/favourites-trends/ — adoption over time. */
+  static async getAdoptionTrends(granularity?: TrendGranularity): Promise<AdoptionTrendsResponse> {
+    const qs = buildQuery(granularity ? { granularity } : undefined);
+    return apiFetcher<AdoptionTrendsResponse>(`accounts/admin/favourites-trends/${qs}`);
+  }
+
+  /** GET /accounts/admin/favourites-vs-played/ — favourited vs started/finished. */
+  static async getFavouredVsPlayed(): Promise<FavouredVsPlayedResponse> {
+    return apiFetcher<FavouredVsPlayedResponse>('accounts/admin/favourites-vs-played/');
   }
 }

--- a/types/user-hub.ts
+++ b/types/user-hub.ts
@@ -28,6 +28,41 @@ export type FavouritesUsageResponse = {
   users: FavouritesUsageUser[];
 };
 
+// ---- adoption-over-time trends --------------------------------------------
+
+export type TrendGranularity = 'day' | 'week';
+
+export type TrendPoint = {
+  /** ISO date (period start). */
+  date: string;
+  new_adopters: number;
+  cumulative_users: number;
+};
+
+/** GET /accounts/admin/favourites-trends/ (IsAdminUser). */
+export type AdoptionTrendsResponse = {
+  granularity: TrendGranularity;
+  include_backfill: boolean;
+  points: TrendPoint[];
+};
+
+// ---- favourited vs played -------------------------------------------------
+
+export type GameEngagementRow = {
+  slug: string;
+  favourited_count: number;
+  started_count: number;
+  finished_count: number;
+  /** Of favouriters who started, the share who finished (0–100). */
+  play_through_pct: number;
+};
+
+/** GET /accounts/admin/favourites-vs-played/ (IsAdminUser). */
+export type FavouredVsPlayedResponse = {
+  games: GameEngagementRow[];
+  total_users: number;
+};
+
 // ---- user list / detail ---------------------------------------------------
 
 /** Suspension scopes mirrored from the BE `UserSuspension.scope` choices. */


### PR DESCRIPTION
Adds the two charts you asked for to the **Favourites Analytics** page, backed by the new admin endpoints in **FootballExtraTime/App#1248**.

## Adoption over time
Area chart with a **day/week** toggle — cumulative users + new adopters per period. Since `favourite_games` had no timestamp, the BE now logs favourite add/remove events server-side (so timestamps are automatic — the FE never sends one). Pre-launch favourites are backfilled with an approximate date, footnoted on the chart.

## Favourited vs played
Grouped horizontal bars per game: **favourited / started / finished**, with the **play-through %** in the tooltip — i.e. of the users who favourited a game, how many actually started it and how many finished.

## How
- New typed `UserHubAPI.getAdoptionTrends(granularity?)` + `getFavouredVsPlayed()`.
- Two hooks mirroring `useFavouritesUsage`, each **404-degrades independently** — if one backend endpoint isn't deployed yet, only that card hides; the rest of the page is unaffected.
- Pure helpers (`formatTrendDate` UTC-stable, `sortEngagementRows`), theme-aware tooltips (readable in dark mode), skeleton / empty / error states.
- **No new deps** (recharts already bundled). `is_dummy` users are excluded server-side.

## Tests / checks
New tests for the API methods (URL + granularity param + 404 propagation) and the helpers. **200 tests pass**, type-check + lint clean, build prerenders all routes, Husky green.

## Depends on
**FootballExtraTime/App#1248** (the two endpoints + the history model/backfill). The page degrades gracefully until that deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)