### PR TITLE
feat(reports): platform reporting section

### DIFF
--- a/app/reports/multiplayer/page.tsx
+++ b/app/reports/multiplayer/page.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import type { ReportWindow } from '@/types/reports';
+import { useMemo, useState } from 'react';
+import { ReportError } from '@/components/reports/ReportError';
+import { ReportsShell } from '@/components/reports/ReportsShell';
+import { WindowPicker } from '@/components/reports/WindowPicker';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useReport } from '@/hooks/use-report';
+import { useAuth } from '@/lib/auth';
+import { ReportsAPI } from '@/lib/reports-api';
+import { prettySlug } from '@/lib/user-hub-format';
+
+export default function MultiplayerReportPage() {
+  const { isAuthenticated, user } = useAuth();
+  const enabled = isAuthenticated && !!(user?.is_staff || user?.is_superuser);
+
+  const [window, setWindow] = useState<ReportWindow>(30);
+  const [includeBots, setIncludeBots] = useState(false);
+  const params = useMemo(() => ({ window, include_bots: includeBots }), [window, includeBots]);
+
+  // ReportsAPI methods are static, so the reference is already stable across
+  // renders — no useCallback needed to stop useReport's effect re-firing.
+  const { data, isLoading, error, notDeployed, refetch } = useReport(
+    ReportsAPI.getMultiplayer,
+    params,
+    enabled,
+    'The multiplayer reporting endpoint',
+  );
+
+  return (
+    <ReportsShell
+      title="Multiplayer"
+      description="Rooms opened, started and finished. Counts rooms — not per-player participations."
+    >
+      <WindowPicker
+        value={window}
+        onChange={setWindow}
+        includeBots={includeBots}
+        onIncludeBotsChange={setIncludeBots}
+      />
+
+      {error
+        ? <ReportError error={error} notDeployed={notDeployed} onRetry={refetch} />
+        : isLoading || !data
+          ? <Skeleton className="h-64 w-full" />
+          : (
+              <>
+                <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+                  {[
+                    { label: 'Rooms created', value: data.totals.rooms_created },
+                    { label: 'Started', value: data.totals.rooms_started },
+                    { label: 'Finished', value: data.totals.rooms_finished },
+                    { label: 'Cancelled', value: data.totals.rooms_cancelled },
+                  ].map(tile => (
+                    <Card key={tile.label}>
+                      <CardContent className="p-4">
+                        <p className="text-sm font-medium text-gray-600 dark:text-gray-300">{tile.label}</p>
+                        <p className="text-3xl font-bold text-gray-900 dark:text-white">
+                          {tile.value.toLocaleString()}
+                        </p>
+                      </CardContent>
+                    </Card>
+                  ))}
+                </div>
+
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Lobbies that never started</CardTitle>
+                    <CardDescription>
+                      {data.totals.never_started_pct}
+                      % of rooms opened in this window never got going. High values usually
+                      mean people couldn't find enough players.
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent className="overflow-x-auto">
+                    <table className="w-full text-sm">
+                      <thead>
+                        <tr className="border-b text-left text-gray-600 dark:border-slate-700 dark:text-gray-300">
+                          <th className="py-2 pr-4 font-medium">Game</th>
+                          <th className="py-2 pr-4 text-right font-medium">Created</th>
+                          <th className="py-2 pr-4 text-right font-medium">Started</th>
+                          <th className="py-2 pr-4 text-right font-medium">Finished</th>
+                          <th className="py-2 pr-4 text-right font-medium">Cancelled</th>
+                          <th className="py-2 text-right font-medium">Never started</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {data.by_game.map(row => (
+                          <tr key={row.game_type} className="border-b last:border-0 dark:border-slate-700">
+                            <td className="py-2 pr-4 font-medium text-gray-900 dark:text-white">
+                              {prettySlug(row.game_type)}
+                            </td>
+                            <td className="py-2 pr-4 text-right">{row.rooms_created.toLocaleString()}</td>
+                            <td className="py-2 pr-4 text-right">{row.rooms_started.toLocaleString()}</td>
+                            <td className="py-2 pr-4 text-right">{row.rooms_finished.toLocaleString()}</td>
+                            <td className="py-2 pr-4 text-right">{row.rooms_cancelled.toLocaleString()}</td>
+                            <td className="py-2 text-right">
+                              {row.never_started_pct}
+                              %
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                    {data.by_game.length === 0 && (
+                      <p className="py-6 text-center text-sm text-gray-500 dark:text-gray-400">
+                        No multiplayer rooms in this window.
+                      </p>
+                    )}
+                  </CardContent>
+                </Card>
+              </>
+            )}
+    </ReportsShell>
+  );
+}

--- a/app/reports/page.tsx
+++ b/app/reports/page.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import type { ReportWindow } from '@/types/reports';
+import { useMemo, useState } from 'react';
+import { ActivityChart } from '@/components/reports/ActivityChart';
+import { PulseTiles } from '@/components/reports/PulseTiles';
+import { ReportError } from '@/components/reports/ReportError';
+import { ReportsShell } from '@/components/reports/ReportsShell';
+import { WindowPicker } from '@/components/reports/WindowPicker';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useReport } from '@/hooks/use-report';
+import { useAuth } from '@/lib/auth';
+import { ReportsAPI } from '@/lib/reports-api';
+import { prettySlug } from '@/lib/user-hub-format';
+
+export default function ReportsPage() {
+  const { isAuthenticated, user } = useAuth();
+  const enabled = isAuthenticated && !!(user?.is_staff || user?.is_superuser);
+
+  const [window, setWindow] = useState<ReportWindow>(30);
+  const [includeBots, setIncludeBots] = useState(false);
+
+  const params = useMemo(() => ({ window, include_bots: includeBots }), [window, includeBots]);
+
+  // ReportsAPI methods are static, so the references are already stable across
+  // renders — no useCallback needed to keep useReport's effect from re-firing.
+  const summary = useReport(ReportsAPI.getSummary, params, enabled, 'The reporting summary endpoint');
+  const activity = useReport(ReportsAPI.getActivity, params, enabled, 'The reporting activity endpoint');
+
+  return (
+    <ReportsShell
+      title="Daily Pulse"
+      description="How today is going, measured against a typical day of the same weekday."
+    >
+      <WindowPicker
+        value={window}
+        onChange={setWindow}
+        includeBots={includeBots}
+        onIncludeBotsChange={setIncludeBots}
+      />
+
+      {summary.error
+        ? <ReportError error={summary.error} notDeployed={summary.notDeployed} onRetry={summary.refetch} />
+        : summary.isLoading || !summary.data
+          ? <Skeleton className="h-32 w-full" />
+          : (
+              <>
+                <PulseTiles pulse={summary.data.pulse} />
+                <p className="text-center text-xs text-gray-500 dark:text-gray-400">
+                  Compared with the mean of the last
+                  {' '}
+                  {summary.data.pulse.baseline_weeks}
+                  {' '}
+                  {summary.data.pulse.weekday}
+                  s — not with yesterday, which would make every Monday look like a crash.
+                </p>
+              </>
+            )}
+
+      {activity.error
+        ? <ReportError error={activity.error} notDeployed={activity.notDeployed} onRetry={activity.refetch} />
+        : activity.isLoading || !activity.data
+          ? <Skeleton className="h-80 w-full" />
+          : (
+              <ActivityChart
+                series={activity.data.series}
+                title={`Activity — last ${activity.data.window} days`}
+                description={`${activity.data.totals.games_started.toLocaleString()} games started, ${activity.data.totals.games_finished.toLocaleString()} finished, ${activity.data.totals.distinct_players.toLocaleString()} distinct players.`}
+              />
+            )}
+
+      {summary.data && (
+        <Card>
+          <CardHeader>
+            <CardTitle>By game</CardTitle>
+            <CardDescription>
+              Busiest first over the last
+              {' '}
+              {summary.data.window}
+              {' '}
+              days. Solo is games started minus multiplayer participations.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b text-left text-gray-600 dark:border-slate-700 dark:text-gray-300">
+                  <th className="py-2 pr-4 font-medium">Game</th>
+                  <th className="py-2 pr-4 text-right font-medium">Started</th>
+                  <th className="py-2 pr-4 text-right font-medium">Finished</th>
+                  <th className="py-2 pr-4 text-right font-medium">Players</th>
+                  <th className="py-2 pr-4 text-right font-medium">Multiplayer</th>
+                  <th className="py-2 text-right font-medium">Solo</th>
+                </tr>
+              </thead>
+              <tbody>
+                {summary.data.by_game.map(row => (
+                  <tr key={row.game_type} className="border-b last:border-0 dark:border-slate-700">
+                    <td className="py-2 pr-4 font-medium text-gray-900 dark:text-white">
+                      {prettySlug(row.game_type)}
+                    </td>
+                    <td className="py-2 pr-4 text-right">{row.games_started.toLocaleString()}</td>
+                    <td className="py-2 pr-4 text-right">{row.games_finished.toLocaleString()}</td>
+                    <td className="py-2 pr-4 text-right">{row.distinct_players.toLocaleString()}</td>
+                    <td className="py-2 pr-4 text-right">{row.mp_player_sessions.toLocaleString()}</td>
+                    <td className="py-2 text-right">
+                      {(row.games_started - row.mp_player_sessions).toLocaleString()}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </CardContent>
+        </Card>
+      )}
+    </ReportsShell>
+  );
+}

--- a/app/reports/players/page.tsx
+++ b/app/reports/players/page.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import type { ReportWindow } from '@/types/reports';
+import { useMemo, useState } from 'react';
+import { ReportError } from '@/components/reports/ReportError';
+import { ReportsShell } from '@/components/reports/ReportsShell';
+import { WindowPicker } from '@/components/reports/WindowPicker';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useReport } from '@/hooks/use-report';
+import { useAuth } from '@/lib/auth';
+import { ReportsAPI } from '@/lib/reports-api';
+import { prettySlug } from '@/lib/user-hub-format';
+
+export default function PlayersReportPage() {
+  const { isAuthenticated, user } = useAuth();
+  const enabled = isAuthenticated && !!(user?.is_staff || user?.is_superuser);
+
+  const [window, setWindow] = useState<ReportWindow>(7);
+  const [includeBots, setIncludeBots] = useState(false);
+  const params = useMemo(
+    () => ({ window, include_bots: includeBots, limit: 25 }),
+    [window, includeBots],
+  );
+
+  // ReportsAPI methods are static, so the reference is already stable across
+  // renders — no useCallback needed to stop useReport's effect re-firing.
+  const { data, isLoading, error, notDeployed, refetch } = useReport(
+    ReportsAPI.getTopPlayers,
+    params,
+    enabled,
+    'The top-players reporting endpoint',
+  );
+
+  return (
+    <ReportsShell
+      title="Players"
+      description="Who played the most. Bot/simulation accounts are excluded by default."
+    >
+      <WindowPicker
+        value={window}
+        onChange={setWindow}
+        includeBots={includeBots}
+        onIncludeBotsChange={setIncludeBots}
+      />
+
+      {error
+        ? <ReportError error={error} notDeployed={notDeployed} onRetry={refetch} />
+        : isLoading || !data
+          ? <Skeleton className="h-96 w-full" />
+          : (
+              <Card>
+                <CardHeader>
+                  <CardTitle>
+                    Most active — last
+                    {' '}
+                    {data.window}
+                    {' '}
+                    days
+                  </CardTitle>
+                  <CardDescription>
+                    Games played counts sessions started, matching the Daily Pulse.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b text-left text-gray-600 dark:border-slate-700 dark:text-gray-300">
+                        <th className="py-2 pr-4 font-medium">#</th>
+                        <th className="py-2 pr-4 font-medium">Player</th>
+                        <th className="py-2 pr-4 text-right font-medium">Played</th>
+                        <th className="py-2 pr-4 text-right font-medium">Finished</th>
+                        <th className="py-2 font-medium">Games</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {data.players.map((player, index) => (
+                        <tr key={player.user_id} className="border-b last:border-0 dark:border-slate-700">
+                          <td className="py-2 pr-4 text-gray-500 dark:text-gray-400">{index + 1}</td>
+                          <td className="py-2 pr-4 font-medium text-gray-900 dark:text-white">
+                            {player.username}
+                          </td>
+                          <td className="py-2 pr-4 text-right">{player.games_played.toLocaleString()}</td>
+                          <td className="py-2 pr-4 text-right">{player.games_finished.toLocaleString()}</td>
+                          <td className="py-2">
+                            <div className="flex flex-wrap gap-1">
+                              {player.games.map(game => (
+                                <Badge key={game} variant="secondary" className="text-xs">
+                                  {prettySlug(game)}
+                                </Badge>
+                              ))}
+                            </div>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                  {data.players.length === 0 && (
+                    <p className="py-6 text-center text-sm text-gray-500 dark:text-gray-400">
+                      Nobody played in this window.
+                    </p>
+                  )}
+                </CardContent>
+              </Card>
+            )}
+    </ReportsShell>
+  );
+}

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -6,8 +6,10 @@ import {
   ChevronUp,
   Database,
   FileQuestion,
+  Gamepad2,
   Home,
   LayoutDashboard,
+  LineChart,
   Menu,
   MessageCircle,
   Search,
@@ -49,6 +51,7 @@ export function Navigation({ className }: NavigationProps) {
   const [expandedCategories, setExpandedCategories] = useState<{ [key: string]: boolean }>({
     'Footballer Data': true, // Expanded by default
     'User Hub': true,
+    'Reports': true,
   });
 
   // State for mobile menu
@@ -115,6 +118,31 @@ export function Navigation({ className }: NavigationProps) {
           href: '/user-hub/analytics',
           icon: BarChart3,
           description: 'Favourite-games adoption and popularity',
+        },
+      ],
+    },
+    {
+      label: 'Reports',
+      icon: LineChart,
+      description: 'Platform activity and multiplayer reporting',
+      children: [
+        {
+          label: 'Daily Pulse',
+          href: '/reports',
+          icon: BarChart3,
+          description: 'How today compares with a typical day',
+        },
+        {
+          label: 'Multiplayer',
+          href: '/reports/multiplayer',
+          icon: Gamepad2,
+          description: 'Room funnel: created, started, finished',
+        },
+        {
+          label: 'Players',
+          href: '/reports/players',
+          icon: Users,
+          description: 'Most active players over a window',
         },
       ],
     },

--- a/components/reports/ActivityChart.tsx
+++ b/components/reports/ActivityChart.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import type { ActivityDay } from '@/types/reports';
+import { CartesianGrid, Legend, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+/** Day-month tick, in UTC so it renders as the intended day regardless of viewer TZ. */
+function formatDay(iso: string): string {
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime())
+    ? iso
+    : new Intl.DateTimeFormat('en-GB', { day: 'numeric', month: 'short', timeZone: 'UTC' }).format(d);
+}
+
+export function ActivityChart({ series, title, description }: {
+  series: ActivityDay[];
+  title: string;
+  description: string;
+}) {
+  const data = series.map(row => ({ ...row, label: formatDay(row.date) }));
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+      <CardContent className="h-80">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={data} margin={{ top: 8, right: 16, bottom: 8, left: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-slate-700" />
+            <XAxis dataKey="label" tick={{ fontSize: 12 }} interval="preserveStartEnd" />
+            <YAxis tick={{ fontSize: 12 }} allowDecimals={false} />
+            <Tooltip
+              contentStyle={{ fontSize: 12 }}
+              labelFormatter={label => `${label}`}
+            />
+            <Legend wrapperStyle={{ fontSize: 12 }} />
+            <Line type="monotone" dataKey="games_started" name="Started" stroke="#059669" strokeWidth={2} dot={false} />
+            <Line type="monotone" dataKey="games_finished" name="Finished" stroke="#2563eb" strokeWidth={2} dot={false} />
+            <Line type="monotone" dataKey="distinct_players" name="Players" stroke="#f59e0b" strokeWidth={2} dot={false} />
+          </LineChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/reports/PulseTiles.tsx
+++ b/components/reports/PulseTiles.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import type { ActivityMetrics, Pulse, PulseMetric } from '@/types/reports';
+import { Minus, TrendingDown, TrendingUp } from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+const TILES: { key: keyof ActivityMetrics; label: string; hint: string }[] = [
+  { key: 'games_started', label: 'Games started', hint: 'Sessions begun today' },
+  { key: 'games_finished', label: 'Games finished', hint: 'Of those, played to the end' },
+  { key: 'distinct_players', label: 'Players', hint: 'Distinct people who played' },
+  { key: 'mp_player_sessions', label: 'Multiplayer', hint: 'Participations in rooms' },
+];
+
+/**
+ * A delta is only meaningful against the same weekday — a games platform dips
+ * hard at weekends, so "vs yesterday" would read as a crash every Monday. The BE
+ * sends the mean of the last four same weekdays; we show the comparison against
+ * that, and say so, rather than leaving the reader to guess the reference point.
+ */
+function Delta({ metric }: { metric: PulseMetric }) {
+  if (metric.delta_pct_vs_baseline === null) {
+    return (
+      <span className="flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
+        <Minus className="size-3" />
+        no baseline yet
+      </span>
+    );
+  }
+
+  const pct = metric.delta_pct_vs_baseline;
+  const flat = Math.abs(pct) < 5;
+  const up = pct > 0;
+  const Icon = flat ? Minus : up ? TrendingUp : TrendingDown;
+
+  return (
+    <span
+      className={cn(
+        'flex items-center gap-1 text-xs font-medium',
+        flat
+          ? 'text-gray-500 dark:text-gray-400'
+          : up
+            ? 'text-emerald-600 dark:text-emerald-400'
+            : 'text-red-600 dark:text-red-400',
+      )}
+    >
+      <Icon className="size-3" />
+      {pct > 0 ? '+' : ''}
+      {pct}
+      % vs usual
+    </span>
+  );
+}
+
+export function PulseTiles({ pulse }: { pulse: Pulse }) {
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      {TILES.map(({ key, label, hint }) => {
+        const metric = pulse.metrics[key];
+        return (
+          <Card key={key}>
+            <CardContent className="space-y-1 p-4">
+              <p className="text-sm font-medium text-gray-600 dark:text-gray-300">{label}</p>
+              <p className="text-3xl font-bold text-gray-900 dark:text-white">
+                {metric.today.toLocaleString()}
+              </p>
+              <Delta metric={metric} />
+              <p className="pt-1 text-xs text-gray-500 dark:text-gray-400">
+                {hint}
+                {' · '}
+                typical
+                {' '}
+                {pulse.weekday}
+                {': '}
+                {metric.baseline_same_weekday.toLocaleString()}
+              </p>
+            </CardContent>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/reports/ReportError.tsx
+++ b/components/reports/ReportError.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { AlertTriangle, RefreshCw } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+export function ReportError({ error, notDeployed, onRetry }: {
+  error: string;
+  notDeployed: boolean;
+  onRetry: () => void;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <AlertTriangle className="size-5 text-orange-600" />
+          {notDeployed ? 'Not available yet' : 'Could not load'}
+        </CardTitle>
+        <CardDescription>
+          {notDeployed
+            ? 'This report depends on a backend endpoint that is not deployed yet.'
+            : 'The backend returned an error.'}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="whitespace-pre-line text-sm text-gray-600 dark:text-gray-300">{error}</p>
+        <Button size="sm" variant="outline" onClick={onRetry}>
+          <RefreshCw className="mr-2 size-4" />
+          Retry
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/reports/ReportsNav.tsx
+++ b/components/reports/ReportsNav.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { BarChart3, Gamepad2, Users } from 'lucide-react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { cn } from '@/lib/utils';
+
+const TABS = [
+  { href: '/reports', label: 'Daily Pulse', icon: BarChart3 },
+  { href: '/reports/multiplayer', label: 'Multiplayer', icon: Gamepad2 },
+  { href: '/reports/players', label: 'Players', icon: Users },
+];
+
+export function ReportsNav() {
+  const pathname = usePathname();
+
+  return (
+    <nav className="flex flex-wrap gap-2">
+      {TABS.map(({ href, label, icon: Icon }) => {
+        const active = pathname === href;
+        return (
+          <Link
+            key={href}
+            href={href}
+            className={cn(
+              'flex items-center gap-2 rounded-md border px-3 py-2 text-sm font-medium transition-colors',
+              active
+                ? 'border-emerald-600 bg-emerald-600 text-white'
+                : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50 dark:border-slate-700 dark:bg-slate-800 dark:text-gray-200 dark:hover:bg-slate-700',
+            )}
+          >
+            <Icon className="size-4" />
+            {label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/components/reports/ReportsShell.tsx
+++ b/components/reports/ReportsShell.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { AlertTriangle } from 'lucide-react';
+import { LoadingSpinner } from '@/components/loading-spinner';
+import { LoginForm } from '@/components/login-form';
+import { Navigation } from '@/components/navigation';
+import { ReportsNav } from '@/components/reports/ReportsNav';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { useAuth } from '@/lib/auth';
+
+/**
+ * Chrome shared by every Reports page: auth, staff gate, header, sub-nav.
+ *
+ * Gated on `is_staff`, not `is_superuser` — that mirrors the BE, where every
+ * `/core/reporting/*` endpoint is `IsAdminUser` (DRF's name for is_staff). The
+ * User Hub gates on superuser instead because it exposes private per-user data;
+ * these are platform aggregates. This is a friendlier "no access" than silently
+ * hitting 403s, not the security boundary.
+ */
+export function ReportsShell({ title, description, children }: {
+  title: string;
+  description: string;
+  children: ReactNode;
+}) {
+  const { isLoading, isAuthenticated, user } = useAuth();
+
+  if (isLoading) {
+    return <LoadingSpinner message="Authenticating" subtitle="Verifying staff access..." />;
+  }
+  if (!isAuthenticated) {
+    return <LoginForm />;
+  }
+
+  const isStaff = !!(user?.is_staff || user?.is_superuser);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-green-50 to-blue-50 p-4 dark:from-slate-800 dark:to-emerald-900/30">
+      <div className="mx-auto max-w-7xl space-y-6">
+        <Navigation />
+
+        <div className="space-y-2 text-center">
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">{title}</h1>
+          <p className="text-gray-600 dark:text-gray-300">{description}</p>
+        </div>
+
+        {isStaff
+          ? (
+              <>
+                <ReportsNav />
+                {children}
+              </>
+            )
+          : (
+              <div className="mx-auto max-w-md py-16">
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="flex items-center gap-2">
+                      <AlertTriangle className="size-5 text-orange-600" />
+                      Staff access required
+                    </CardTitle>
+                    <CardDescription>
+                      Reports are limited to staff accounts.
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="text-sm text-gray-600 dark:text-gray-300">
+                      You're signed in, but your account isn't staff. Ask an administrator
+                      to grant access if you need it.
+                    </p>
+                  </CardContent>
+                </Card>
+              </div>
+            )}
+      </div>
+    </div>
+  );
+}

--- a/components/reports/WindowPicker.tsx
+++ b/components/reports/WindowPicker.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import type { ReportWindow } from '@/types/reports';
+import { Button } from '@/components/ui/button';
+import { REPORT_WINDOWS } from '@/types/reports';
+
+/**
+ * Window selector. The options mirror ALLOWED_WINDOWS on the BE, which rejects
+ * anything else with a 400 — so this can't drift into requests that fail.
+ */
+export function WindowPicker({
+  value,
+  onChange,
+  includeBots,
+  onIncludeBotsChange,
+}: {
+  value: ReportWindow;
+  onChange: (w: ReportWindow) => void;
+  includeBots: boolean;
+  onIncludeBotsChange: (v: boolean) => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <span className="text-sm text-gray-600 dark:text-gray-300">Window</span>
+      {REPORT_WINDOWS.map(w => (
+        <Button
+          key={w}
+          size="sm"
+          variant={w === value ? 'default' : 'outline'}
+          onClick={() => onChange(w)}
+        >
+          {w}
+          d
+        </Button>
+      ))}
+      <Button
+        size="sm"
+        variant={includeBots ? 'default' : 'outline'}
+        className="ml-2"
+        onClick={() => onIncludeBotsChange(!includeBots)}
+        title="Bot/simulation accounts (is_dummy) are excluded by default"
+      >
+        {includeBots ? 'Bots included' : 'Bots excluded'}
+      </Button>
+    </div>
+  );
+}

--- a/hooks/use-report.ts
+++ b/hooks/use-report.ts
@@ -1,0 +1,66 @@
+/**
+ * Generic loader for the Reports endpoints.
+ *
+ * Mirrors `use-favourites-usage`, including its "not deployed yet" handling: the
+ * BE endpoints ship in their own PRs, so a 404 gets a friendly explanation
+ * rather than a raw error the reader can't act on.
+ */
+
+import type { ReportParams } from '@/types/reports';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import config from '@/lib/config';
+
+export type UseReport<T> = {
+  data: T | null;
+  isLoading: boolean;
+  error: string | null;
+  /** True when the failure looks like "endpoint not deployed yet" (404). */
+  notDeployed: boolean;
+  refetch: () => void;
+};
+
+export function useReport<T>(
+  fetcher: (params?: ReportParams) => Promise<T>,
+  params: ReportParams,
+  enabled: boolean,
+  endpointLabel: string,
+): UseReport<T> {
+  const [data, setData] = useState<T | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [notDeployed, setNotDeployed] = useState(false);
+
+  // Params are rebuilt on each render by callers; key on the values so the
+  // effect doesn't refetch forever on an identical object.
+  const key = JSON.stringify(params);
+  const stableParams = useMemo(() => params, [key]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    setNotDeployed(false);
+    try {
+      setData(await fetcher(stableParams));
+    } catch (err: unknown) {
+      const raw = err instanceof Error ? err.message : `Failed to load ${endpointLabel}`;
+      const is404 = /404|Not Found/i.test(raw);
+      setNotDeployed(is404);
+      setError(
+        is404
+          ? `${endpointLabel} isn't available at ${config.API_BASE_URL} yet.\n\nIt deploys with its backend PR. This view will populate automatically once that's live.`
+          : raw,
+      );
+      setData(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [fetcher, stableParams, endpointLabel]);
+
+  useEffect(() => {
+    if (enabled) {
+      load();
+    }
+  }, [enabled, load]);
+
+  return { data, isLoading, error, notDeployed, refetch: load };
+}

--- a/lib/__tests__/reports-api.test.ts
+++ b/lib/__tests__/reports-api.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { apiFetcher } from '@/lib/api-fetcher';
+import { ReportsAPI } from '@/lib/reports-api';
+
+vi.mock('@/lib/api-fetcher', () => ({ apiFetcher: vi.fn() }));
+
+const mockApiFetcher = vi.mocked(apiFetcher);
+
+describe('reportsAPI', () => {
+  beforeEach(() => {
+    mockApiFetcher.mockReset();
+    mockApiFetcher.mockResolvedValue({} as never);
+  });
+
+  it('hits the reporting paths, not the feedback reports viewset', async () => {
+    // `core/reports/` is the user-feedback Report viewset — a typo here would
+    // silently query tickets instead of analytics.
+    await ReportsAPI.getSummary();
+    await ReportsAPI.getActivity();
+    await ReportsAPI.getMultiplayer();
+    await ReportsAPI.getTopPlayers();
+
+    expect(mockApiFetcher.mock.calls.map(call => call[0])).toEqual([
+      'core/reporting/summary/',
+      'core/reporting/activity/',
+      'core/reporting/multiplayer/',
+      'core/reporting/top-players/',
+    ]);
+  });
+
+  it('serialises params into a query string', async () => {
+    await ReportsAPI.getTopPlayers({ window: 30, include_bots: true, limit: 25 });
+
+    expect(mockApiFetcher).toHaveBeenCalledWith(
+      'core/reporting/top-players/?window=30&include_bots=true&limit=25',
+    );
+  });
+
+  it('sends include_bots=false explicitly rather than dropping it', async () => {
+    // The BE echoes resolved filters back; sending the flag keeps request and
+    // response readable side by side instead of relying on a default.
+    await ReportsAPI.getActivity({ window: 7, include_bots: false });
+
+    expect(mockApiFetcher).toHaveBeenCalledWith(
+      'core/reporting/activity/?window=7&include_bots=false',
+    );
+  });
+
+  it('omits undefined params', async () => {
+    await ReportsAPI.getSummary({ window: 7, game_type: undefined });
+
+    expect(mockApiFetcher).toHaveBeenCalledWith('core/reporting/summary/?window=7');
+  });
+});

--- a/lib/reports-api.ts
+++ b/lib/reports-api.ts
@@ -1,0 +1,54 @@
+import type {
+  ActivityResponse,
+  MultiplayerResponse,
+  ReportParams,
+  SummaryResponse,
+  TopPlayersResponse,
+} from '@/types/reports';
+import { apiFetcher } from '@/lib/api-fetcher';
+
+/**
+ * Build `?key=value&...`, dropping undefined/null/empty. Mirrors `user-hub-api`.
+ * `include_bots` is passed through even when false: the BE echoes the resolved
+ * filters back, and being explicit keeps request and response readable together.
+ */
+function buildQuery(params?: ReportParams): string {
+  if (!params) {
+    return '';
+  }
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null || value === '') {
+      continue;
+    }
+    search.append(key, String(value));
+  }
+  const qs = search.toString();
+  return qs ? `?${qs}` : '';
+}
+
+/**
+ * Staff-only platform reporting (`IsAdminUser` server-side; the Bearer JWT is
+ * attached by `apiFetcher`). Read-only — there is intentionally no write method.
+ */
+export class ReportsAPI {
+  /** GET /core/reporting/summary/ — daily pulse + per-game breakdown. */
+  static async getSummary(params?: ReportParams): Promise<SummaryResponse> {
+    return apiFetcher<SummaryResponse>(`core/reporting/summary/${buildQuery(params)}`);
+  }
+
+  /** GET /core/reporting/activity/ — per-day series, zero-filled. */
+  static async getActivity(params?: ReportParams): Promise<ActivityResponse> {
+    return apiFetcher<ActivityResponse>(`core/reporting/activity/${buildQuery(params)}`);
+  }
+
+  /** GET /core/reporting/multiplayer/ — room funnel (rooms, not participations). */
+  static async getMultiplayer(params?: ReportParams): Promise<MultiplayerResponse> {
+    return apiFetcher<MultiplayerResponse>(`core/reporting/multiplayer/${buildQuery(params)}`);
+  }
+
+  /** GET /core/reporting/top-players/ — busiest players over the window. */
+  static async getTopPlayers(params?: ReportParams): Promise<TopPlayersResponse> {
+    return apiFetcher<TopPlayersResponse>(`core/reporting/top-players/${buildQuery(params)}`);
+  }
+}

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -1,0 +1,103 @@
+// Types for the staff-only Reports section.
+// Field names mirror the Django BE payloads from `/core/reporting/*` — keep them
+// in sync if `core/reporting_views.py` changes.
+
+/** The four metrics every activity payload carries. */
+export type ActivityMetrics = {
+  games_started: number;
+  games_finished: number;
+  distinct_players: number;
+  /** Multiplayer participations (per player). Solo = games_started - this. */
+  mp_player_sessions: number;
+};
+
+export type ActivityDay = { date: string } & ActivityMetrics;
+
+export type ActivityResponse = {
+  start: string;
+  end: string;
+  window: number;
+  game_type: string | null;
+  include_bots: boolean;
+  totals: ActivityMetrics;
+  series: ActivityDay[];
+};
+
+/** One headline metric: today, against the same-weekday baseline. */
+export type PulseMetric = {
+  today: number;
+  yesterday: number;
+  /** Mean of the previous N same weekdays. */
+  baseline_same_weekday: number;
+  /** Null when the baseline is 0 and today is 0 — i.e. no meaningful comparison. */
+  delta_pct_vs_baseline: number | null;
+};
+
+export type Pulse = {
+  date: string;
+  weekday: string;
+  baseline_weeks: number;
+  metrics: Record<keyof ActivityMetrics, PulseMetric>;
+};
+
+export type GameTotals = { game_type: string } & ActivityMetrics;
+
+export type SummaryResponse = {
+  pulse: Pulse;
+  window: number;
+  game_type: string | null;
+  window_totals: ActivityMetrics;
+  by_game: GameTotals[];
+  include_bots: boolean;
+};
+
+export type MultiplayerGameRow = {
+  game_type: string;
+  rooms_created: number;
+  rooms_started: number;
+  rooms_finished: number;
+  rooms_cancelled: number;
+  never_started_pct: number;
+};
+
+export type MultiplayerResponse = {
+  start: string;
+  end: string;
+  window: number;
+  game_type: string | null;
+  include_bots: boolean;
+  /** Always 'rooms' — a reminder this is a different grain from mp_player_sessions. */
+  grain: string;
+  totals: Omit<MultiplayerGameRow, 'game_type'>;
+  by_game: MultiplayerGameRow[];
+};
+
+export type TopPlayer = {
+  user_id: number;
+  username: string;
+  games_played: number;
+  games_finished: number;
+  distinct_games: number;
+  games: string[];
+};
+
+export type TopPlayersResponse = {
+  start: string;
+  end: string;
+  window: number;
+  game_type: string | null;
+  include_bots: boolean;
+  limit: number;
+  players: TopPlayer[];
+};
+
+/** Windows the BE accepts (ALLOWED_WINDOWS in core/reporting_views.py). */
+export const REPORT_WINDOWS = [7, 10, 15, 30, 60, 90] as const;
+export type ReportWindow = (typeof REPORT_WINDOWS)[number];
+
+export type ReportParams = {
+  window?: ReportWindow;
+  game_type?: string;
+  include_bots?: boolean;
+  limit?: number;
+};


### PR DESCRIPTION
Adds **Reports** as its own top-level section, wired to the four `/core/reporting/` endpoints from App [#1427](https://github.com/FootballExtraTime/App/pull/1427) / [#1428](https://github.com/FootballExtraTime/App/pull/1428) / [#1429](https://github.com/FootballExtraTime/App/pull/1429).

| Route | Purpose |
|---|---|
| `/reports` | **Daily Pulse** — landing page: headline tiles, activity chart, per-game table |
| `/reports/multiplayer` | Room funnel: created → started → finished, + never-started rate |
| `/reports/players` | Most active players over a window |

A sibling of the User Hub rather than a page inside it — most of these figures are game- and platform-scoped, not user-scoped, and the hub is already favourites-shaped.

## The Daily Pulse is the point

It exists to answer *"how did the day go"*, which a raw total can't: 400 games means nothing without a reference. Each tile shows **today against the mean of the last four same weekdays**, and says which:

> Compared with the mean of the last 4 Wednesdays — not with yesterday, which would make every Monday look like a crash.

Weekday seasonality on a games platform is strong enough that a "vs yesterday" delta would report a collapse every week. Deltas under 5% render as flat rather than as noise-driven arrows, and a metric with no history yet says "no baseline yet" instead of showing a misleading number.

## Decisions worth a look

- **Gated on `is_staff`, not `is_superuser`** — mirrors the BE, where every `/core/reporting/` endpoint is `IsAdminUser` (DRF's name for `is_staff`). The User Hub gates on superuser because it exposes private per-user data; these are platform aggregates. As with `AdminGate`, the client gate is a friendlier "no access" than silently hitting 403s — the endpoints remain the real boundary.
- **Window options mirror `ALLOWED_WINDOWS`** on the BE, which 400s on anything else — so the picker can't produce a failing request.
- **The multiplayer page counts ROOMS and says so.** `DailyGameActivity.mp_player_sessions` counts per-player participations; one five-player room is 1 room and 5 participations. Keeping the wording explicit stops the two being read as the same number.
- **Solo is shown as `games_started − mp_player_sessions`** in the per-game table. That subtraction is exact by construction — the BE deliberately buckets both by the session's own date (App #1426 review).
- **`useReport` reuses the "not deployed yet" handling** from `use-favourites-usage`: a 404 gets an explanation naming the endpoint and base URL rather than a raw error, so the section degrades gracefully if a BE PR hasn't shipped.

## Verification

| Check | Result |
|---|---|
| `eslint` (new files) | clean — 0 errors, 0 warnings |
| `tsc --noEmit` | **no new errors** — 15 pre-existing in `components/ui/*` on `production`, 15 on this branch |
| `vitest run` | **204 tests pass** (28 files), incl. 4 new |
| `next build` | all three routes render |

The new test guards the one mistake that would be silent: `core/reports/` is the user-feedback `Report` viewset, so a typo'd path would query **tickets instead of analytics** and still return 200.

## Note

The `useCallback` wrappers I first put around the fetchers were pointless — `ReportsAPI` methods are static and therefore already stable references. ESLint flagged it; removed rather than suppressed.