### PR TITLE
feat(reports): clickable game filters, metric toggles and mode breakdown

### DIFF
--- a/app/reports/multiplayer/page.tsx
+++ b/app/reports/multiplayer/page.tsx
@@ -2,11 +2,13 @@
 
 import type { ReportWindow } from '@/types/reports';
 import { useMemo, useState } from 'react';
+import { GameBadge } from '@/components/reports/GameBadge';
 import { ReportError } from '@/components/reports/ReportError';
 import { ReportsShell } from '@/components/reports/ReportsShell';
 import { WindowPicker } from '@/components/reports/WindowPicker';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
+import { useGameMeta } from '@/hooks/use-game-meta';
 import { useReport } from '@/hooks/use-report';
 import { useAuth } from '@/lib/auth';
 import { ReportsAPI } from '@/lib/reports-api';
@@ -18,7 +20,13 @@ export default function MultiplayerReportPage() {
 
   const [window, setWindow] = useState<ReportWindow>(30);
   const [includeBots, setIncludeBots] = useState(false);
-  const params = useMemo(() => ({ window, include_bots: includeBots }), [window, includeBots]);
+  const [game, setGame] = useState<string | null>(null);
+  const params = useMemo(
+    () => ({ window, include_bots: includeBots, ...(game ? { game_type: game } : {}) }),
+    [window, includeBots, game],
+  );
+
+  const { meta } = useGameMeta(enabled);
 
   // ReportsAPI methods are static, so the reference is already stable across
   // renders — no useCallback needed to stop useReport's effect re-firing.
@@ -40,6 +48,13 @@ export default function MultiplayerReportPage() {
         includeBots={includeBots}
         onIncludeBotsChange={setIncludeBots}
       />
+
+      {game && (
+        <div className="flex flex-wrap items-center gap-2 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 dark:border-emerald-900 dark:bg-emerald-900/20">
+          <span className="text-sm text-gray-700 dark:text-gray-200">Filtered to</span>
+          <GameBadge gameKey={game} meta={meta} active onClick={() => setGame(null)} />
+        </div>
+      )}
 
       {error
         ? <ReportError error={error} notDeployed={notDeployed} onRetry={refetch} />

--- a/app/reports/page.tsx
+++ b/app/reports/page.tsx
@@ -1,18 +1,20 @@
 'use client';
 
-import type { ReportWindow } from '@/types/reports';
+import type { MetricKey, ReportWindow } from '@/types/reports';
 import { useMemo, useState } from 'react';
 import { ActivityChart } from '@/components/reports/ActivityChart';
+import { GameBadge } from '@/components/reports/GameBadge';
+import { GameLeaderboard } from '@/components/reports/GameLeaderboard';
+import { MetricToggle } from '@/components/reports/MetricToggle';
 import { PulseTiles } from '@/components/reports/PulseTiles';
 import { ReportError } from '@/components/reports/ReportError';
 import { ReportsShell } from '@/components/reports/ReportsShell';
 import { WindowPicker } from '@/components/reports/WindowPicker';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
+import { useGameMeta } from '@/hooks/use-game-meta';
 import { useReport } from '@/hooks/use-report';
 import { useAuth } from '@/lib/auth';
 import { ReportsAPI } from '@/lib/reports-api';
-import { prettySlug } from '@/lib/user-hub-format';
 
 export default function ReportsPage() {
   const { isAuthenticated, user } = useAuth();
@@ -20,25 +22,50 @@ export default function ReportsPage() {
 
   const [window, setWindow] = useState<ReportWindow>(30);
   const [includeBots, setIncludeBots] = useState(false);
+  const [metric, setMetric] = useState<MetricKey>('games_started');
+  const [game, setGame] = useState<string | null>(null);
 
-  const params = useMemo(() => ({ window, include_bots: includeBots }), [window, includeBots]);
+  // The selected game narrows the pulse, the chart and the tiles together, so
+  // the whole page answers "how is THIS game doing" in one click.
+  const params = useMemo(
+    () => ({ window, include_bots: includeBots, ...(game ? { game_type: game } : {}) }),
+    [window, includeBots, game],
+  );
+  // The leaderboard must always show every game, otherwise selecting one would
+  // hide the row you'd click to unselect it.
+  const allGamesParams = useMemo(
+    () => ({ window, include_bots: includeBots }),
+    [window, includeBots],
+  );
 
-  // ReportsAPI methods are static, so the references are already stable across
-  // renders — no useCallback needed to keep useReport's effect from re-firing.
+  const { meta } = useGameMeta(enabled);
   const summary = useReport(ReportsAPI.getSummary, params, enabled, 'The reporting summary endpoint');
+  const allGames = useReport(ReportsAPI.getSummary, allGamesParams, enabled, 'The reporting summary endpoint');
   const activity = useReport(ReportsAPI.getActivity, params, enabled, 'The reporting activity endpoint');
+
+  const selectedLabel = game ? (meta[game]?.label ?? game) : null;
 
   return (
     <ReportsShell
       title="Daily Pulse"
       description="How today is going, measured against a typical day of the same weekday."
     >
-      <WindowPicker
-        value={window}
-        onChange={setWindow}
-        includeBots={includeBots}
-        onIncludeBotsChange={setIncludeBots}
-      />
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <WindowPicker
+          value={window}
+          onChange={setWindow}
+          includeBots={includeBots}
+          onIncludeBotsChange={setIncludeBots}
+        />
+        <MetricToggle value={metric} onChange={setMetric} />
+      </div>
+
+      {game && (
+        <div className="flex flex-wrap items-center gap-2 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 dark:border-emerald-900 dark:bg-emerald-900/20">
+          <span className="text-sm text-gray-700 dark:text-gray-200">Filtered to</span>
+          <GameBadge gameKey={game} meta={meta} active onClick={() => setGame(null)} />
+        </div>
+      )}
 
       {summary.error
         ? <ReportError error={summary.error} notDeployed={summary.notDeployed} onRetry={summary.refetch} />
@@ -48,7 +75,8 @@ export default function ReportsPage() {
               <>
                 <PulseTiles pulse={summary.data.pulse} />
                 <p className="text-center text-xs text-gray-500 dark:text-gray-400">
-                  Compared with the mean of the last
+                  {selectedLabel ? `${selectedLabel} · ` : ''}
+                  compared with the mean of the last
                   {' '}
                   {summary.data.pulse.baseline_weeks}
                   {' '}
@@ -65,54 +93,21 @@ export default function ReportsPage() {
           : (
               <ActivityChart
                 series={activity.data.series}
-                title={`Activity — last ${activity.data.window} days`}
-                description={`${activity.data.totals.games_started.toLocaleString()} games started, ${activity.data.totals.games_finished.toLocaleString()} finished, ${activity.data.totals.distinct_players.toLocaleString()} distinct players.`}
+                metric={metric}
+                color={game ? meta[game]?.color : undefined}
+                title={`${selectedLabel ?? 'All games'} — last ${activity.data.window} days`}
+                description={`${activity.data.totals.games_started.toLocaleString()} played, ${activity.data.totals.games_finished.toLocaleString()} finished, ${activity.data.totals.distinct_players.toLocaleString()} distinct players.`}
               />
             )}
 
-      {summary.data && (
-        <Card>
-          <CardHeader>
-            <CardTitle>By game</CardTitle>
-            <CardDescription>
-              Busiest first over the last
-              {' '}
-              {summary.data.window}
-              {' '}
-              days. Solo is games started minus multiplayer participations.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b text-left text-gray-600 dark:border-slate-700 dark:text-gray-300">
-                  <th className="py-2 pr-4 font-medium">Game</th>
-                  <th className="py-2 pr-4 text-right font-medium">Started</th>
-                  <th className="py-2 pr-4 text-right font-medium">Finished</th>
-                  <th className="py-2 pr-4 text-right font-medium">Players</th>
-                  <th className="py-2 pr-4 text-right font-medium">Multiplayer</th>
-                  <th className="py-2 text-right font-medium">Solo</th>
-                </tr>
-              </thead>
-              <tbody>
-                {summary.data.by_game.map(row => (
-                  <tr key={row.game_type} className="border-b last:border-0 dark:border-slate-700">
-                    <td className="py-2 pr-4 font-medium text-gray-900 dark:text-white">
-                      {prettySlug(row.game_type)}
-                    </td>
-                    <td className="py-2 pr-4 text-right">{row.games_started.toLocaleString()}</td>
-                    <td className="py-2 pr-4 text-right">{row.games_finished.toLocaleString()}</td>
-                    <td className="py-2 pr-4 text-right">{row.distinct_players.toLocaleString()}</td>
-                    <td className="py-2 pr-4 text-right">{row.mp_player_sessions.toLocaleString()}</td>
-                    <td className="py-2 text-right">
-                      {(row.games_started - row.mp_player_sessions).toLocaleString()}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </CardContent>
-        </Card>
+      {allGames.data && (
+        <GameLeaderboard
+          rows={allGames.data.by_game}
+          meta={meta}
+          metric={metric}
+          selected={game}
+          onSelect={setGame}
+        />
       )}
     </ReportsShell>
   );

--- a/app/reports/players/page.tsx
+++ b/app/reports/players/page.tsx
@@ -2,16 +2,17 @@
 
 import type { ReportWindow } from '@/types/reports';
 import { useMemo, useState } from 'react';
+import { GameBadge } from '@/components/reports/GameBadge';
 import { ReportError } from '@/components/reports/ReportError';
 import { ReportsShell } from '@/components/reports/ReportsShell';
 import { WindowPicker } from '@/components/reports/WindowPicker';
-import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
+import { useGameMeta } from '@/hooks/use-game-meta';
 import { useReport } from '@/hooks/use-report';
 import { useAuth } from '@/lib/auth';
 import { ReportsAPI } from '@/lib/reports-api';
-import { prettySlug } from '@/lib/user-hub-format';
 
 export default function PlayersReportPage() {
   const { isAuthenticated, user } = useAuth();
@@ -19,10 +20,17 @@ export default function PlayersReportPage() {
 
   const [window, setWindow] = useState<ReportWindow>(7);
   const [includeBots, setIncludeBots] = useState(false);
+  const [game, setGame] = useState<string | null>(null);
+  // 'played' ranks by sessions started, 'finished' by ones seen through — the gap
+  // between them is the interesting part, so both are reachable.
+  const [sortBy, setSortBy] = useState<'played' | 'finished'>('played');
+
   const params = useMemo(
-    () => ({ window, include_bots: includeBots, limit: 25 }),
-    [window, includeBots],
+    () => ({ window, include_bots: includeBots, limit: 25, ...(game ? { game_type: game } : {}) }),
+    [window, includeBots, game],
   );
+
+  const { meta } = useGameMeta(enabled);
 
   // ReportsAPI methods are static, so the reference is already stable across
   // renders — no useCallback needed to stop useReport's effect re-firing.
@@ -44,6 +52,23 @@ export default function PlayersReportPage() {
         includeBots={includeBots}
         onIncludeBotsChange={setIncludeBots}
       />
+
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-sm text-gray-600 dark:text-gray-300">Rank by</span>
+        <Button size="sm" variant={sortBy === 'played' ? 'default' : 'outline'} onClick={() => setSortBy('played')}>
+          Played
+        </Button>
+        <Button size="sm" variant={sortBy === 'finished' ? 'default' : 'outline'} onClick={() => setSortBy('finished')}>
+          Finished
+        </Button>
+      </div>
+
+      {game && (
+        <div className="flex flex-wrap items-center gap-2 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 dark:border-emerald-900 dark:bg-emerald-900/20">
+          <span className="text-sm text-gray-700 dark:text-gray-200">Filtered to</span>
+          <GameBadge gameKey={game} meta={meta} active onClick={() => setGame(null)} />
+        </div>
+      )}
 
       {error
         ? <ReportError error={error} notDeployed={notDeployed} onRetry={refetch} />
@@ -85,10 +110,14 @@ export default function PlayersReportPage() {
                           <td className="py-2 pr-4 text-right">{player.games_finished.toLocaleString()}</td>
                           <td className="py-2">
                             <div className="flex flex-wrap gap-1">
-                              {player.games.map(game => (
-                                <Badge key={game} variant="secondary" className="text-xs">
-                                  {prettySlug(game)}
-                                </Badge>
+                              {player.games.map(playedGame => (
+                                <GameBadge
+                                  key={playedGame}
+                                  gameKey={playedGame}
+                                  meta={meta}
+                                  active={game === playedGame}
+                                  onClick={key => setGame(game === key ? null : key)}
+                                />
                               ))}
                             </div>
                           </td>

--- a/components/reports/ActivityChart.tsx
+++ b/components/reports/ActivityChart.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import type { ActivityDay } from '@/types/reports';
+import type { ActivityDay, MetricKey } from '@/types/reports';
 import { CartesianGrid, Legend, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { METRIC_OPTIONS } from '@/types/reports';
 
 /** Day-month tick, in UTC so it renders as the intended day regardless of viewer TZ. */
 function formatDay(iso: string): string {
@@ -12,12 +13,29 @@ function formatDay(iso: string): string {
     : new Intl.DateTimeFormat('en-GB', { day: 'numeric', month: 'short', timeZone: 'UTC' }).format(d);
 }
 
-export function ActivityChart({ series, title, description }: {
+const DEFAULT_COLORS: Record<MetricKey, string> = {
+  games_started: '#059669',
+  games_finished: '#2563eb',
+  distinct_players: '#f59e0b',
+  mp_player_sessions: '#8b5cf6',
+};
+
+/**
+ * Daily activity. The selected metric is drawn boldly and the others stay as
+ * faint context — showing only the selection loses the shape that makes it
+ * meaningful (a "played" line means much more next to "finished"), while giving
+ * four lines equal weight makes none of them readable.
+ */
+export function ActivityChart({ series, title, description, metric, color }: {
   series: ActivityDay[];
   title: string;
   description: string;
+  metric: MetricKey;
+  /** Overrides the metric colour — used to match the selected game's badge. */
+  color?: string;
 }) {
   const data = series.map(row => ({ ...row, label: formatDay(row.date) }));
+  const primaryColor = color ?? DEFAULT_COLORS[metric];
 
   return (
     <Card>
@@ -25,20 +43,30 @@ export function ActivityChart({ series, title, description }: {
         <CardTitle>{title}</CardTitle>
         <CardDescription>{description}</CardDescription>
       </CardHeader>
-      <CardContent className="h-80">
+      <CardContent className="h-72 sm:h-80">
         <ResponsiveContainer width="100%" height="100%">
-          <LineChart data={data} margin={{ top: 8, right: 16, bottom: 8, left: 0 }}>
+          <LineChart data={data} margin={{ top: 8, right: 8, bottom: 8, left: -12 }}>
             <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-slate-700" />
-            <XAxis dataKey="label" tick={{ fontSize: 12 }} interval="preserveStartEnd" />
-            <YAxis tick={{ fontSize: 12 }} allowDecimals={false} />
-            <Tooltip
-              contentStyle={{ fontSize: 12 }}
-              labelFormatter={label => `${label}`}
-            />
+            <XAxis dataKey="label" tick={{ fontSize: 11 }} interval="preserveStartEnd" minTickGap={24} />
+            <YAxis tick={{ fontSize: 11 }} allowDecimals={false} width={44} />
+            <Tooltip contentStyle={{ fontSize: 12 }} />
             <Legend wrapperStyle={{ fontSize: 12 }} />
-            <Line type="monotone" dataKey="games_started" name="Started" stroke="#059669" strokeWidth={2} dot={false} />
-            <Line type="monotone" dataKey="games_finished" name="Finished" stroke="#2563eb" strokeWidth={2} dot={false} />
-            <Line type="monotone" dataKey="distinct_players" name="Players" stroke="#f59e0b" strokeWidth={2} dot={false} />
+            {METRIC_OPTIONS.map((option) => {
+              const isPrimary = option.key === metric;
+              return (
+                <Line
+                  key={option.key}
+                  type="monotone"
+                  dataKey={option.key}
+                  name={option.label}
+                  stroke={isPrimary ? primaryColor : DEFAULT_COLORS[option.key]}
+                  strokeWidth={isPrimary ? 2.5 : 1}
+                  strokeOpacity={isPrimary ? 1 : 0.28}
+                  dot={false}
+                  activeDot={isPrimary ? { r: 4 } : false}
+                />
+              );
+            })}
           </LineChart>
         </ResponsiveContainer>
       </CardContent>

--- a/components/reports/GameBadge.tsx
+++ b/components/reports/GameBadge.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import type { GameMetaMap } from '@/hooks/use-game-meta';
+import { X } from 'lucide-react';
+import { FALLBACK_COLOR } from '@/hooks/use-game-meta';
+import { prettySlug } from '@/lib/user-hub-format';
+import { cn } from '@/lib/utils';
+
+/**
+ * A game chip, coloured from the BE registry.
+ *
+ * Colour is applied inline rather than via Tailwind classes on purpose: the
+ * palette is server-driven, so a class-per-game map would have to be updated by
+ * hand every time a game is added — exactly the drift this endpoint exists to
+ * avoid.
+ */
+export function GameBadge({ gameKey, meta, active, onClick, count }: {
+  gameKey: string;
+  meta: GameMetaMap;
+  /** Renders as selected, with a clear affordance to unselect. */
+  active?: boolean;
+  onClick?: (gameKey: string) => void;
+  count?: number;
+}) {
+  const color = meta[gameKey]?.color ?? FALLBACK_COLOR;
+  const label = meta[gameKey]?.label ?? prettySlug(gameKey);
+  const interactive = !!onClick;
+
+  const style = active
+    ? { backgroundColor: color, borderColor: color, color: '#fff' }
+    : { borderColor: color, color };
+
+  return (
+    <button
+      type="button"
+      disabled={!interactive}
+      aria-pressed={interactive ? !!active : undefined}
+      title={interactive ? (active ? `Clear ${label} filter` : `Show only ${label}`) : label}
+      onClick={() => onClick?.(gameKey)}
+      style={style}
+      className={cn(
+        'inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-medium transition-all',
+        interactive ? 'cursor-pointer hover:opacity-80' : 'cursor-default',
+        !active && 'bg-transparent',
+      )}
+    >
+      <span
+        className="size-2 rounded-full"
+        style={{ backgroundColor: active ? '#fff' : color }}
+        aria-hidden
+      />
+      {label}
+      {count !== undefined && <span className="opacity-70">{count.toLocaleString()}</span>}
+      {active && <X className="size-3" aria-hidden />}
+    </button>
+  );
+}

--- a/components/reports/GameLeaderboard.tsx
+++ b/components/reports/GameLeaderboard.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import type { GameMetaMap } from '@/hooks/use-game-meta';
+import type { GameTotals, MetricKey } from '@/types/reports';
+import { ChevronDown, ChevronRight, Minus, TrendingDown, TrendingUp } from 'lucide-react';
+import { useState } from 'react';
+import { GameBadge } from '@/components/reports/GameBadge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+/** '—' rather than 0 for a null rate: no data is not the same as zero. */
+function rate(value: number | null, suffix = '%'): string {
+  return value === null ? '—' : `${value}${suffix}`;
+}
+
+function Trend({ pct }: { pct: number | null }) {
+  if (pct === null) {
+    return <span className="text-gray-400">—</span>;
+  }
+  const flat = Math.abs(pct) < 5;
+  const Icon = flat ? Minus : pct > 0 ? TrendingUp : TrendingDown;
+  return (
+    <span className={cn(
+      'inline-flex items-center justify-end gap-1 tabular-nums',
+      flat ? 'text-gray-500 dark:text-gray-400' : pct > 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400',
+    )}
+    >
+      <Icon className="size-3" />
+      {pct > 0 ? '+' : ''}
+      {pct}
+      %
+    </span>
+  );
+}
+
+/** Proportional bar so the biggest game is obvious without reading numbers. */
+function VolumeBar({ value, max, color }: { value: number; max: number; color: string }) {
+  const pct = max > 0 ? Math.max(2, (value / max) * 100) : 0;
+  return (
+    <div className="h-1.5 w-full overflow-hidden rounded-full bg-gray-100 dark:bg-slate-700">
+      <div className="h-full rounded-full" style={{ width: `${pct}%`, backgroundColor: color }} />
+    </div>
+  );
+}
+
+/**
+ * Games ranked by volume, with the rates that say whether that volume is
+ * healthy. Volume alone tells you which game is biggest, not which is best — a
+ * game with huge starts and 30% completion is a very different story from a
+ * smaller one people finish and return to.
+ *
+ * Rows expand for the detail that would otherwise make the table unreadable on
+ * a phone.
+ */
+export function GameLeaderboard({ rows, meta, metric, selected, onSelect }: {
+  rows: GameTotals[];
+  meta: GameMetaMap;
+  metric: MetricKey;
+  selected: string | null;
+  onSelect: (gameKey: string | null) => void;
+}) {
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const active = rows.filter(row => row.games_started > 0);
+  const max = Math.max(...active.map(row => row[metric]), 0);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Games</CardTitle>
+        <CardDescription>
+          Ranked by volume. Click a game to filter everything on this page to it, or a
+          row to expand. Completion is how many started games get finished; repeat is
+          how many of its players came back on another day.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-1">
+        {/* Header row — hidden on small screens, where the expanded panel carries it. */}
+        <div className="hidden items-center gap-3 border-b px-2 pb-2 text-xs font-medium text-gray-500 dark:border-slate-700 dark:text-gray-400 md:flex">
+          <span className="w-6" />
+          <span className="flex-1">Game</span>
+          <span className="w-20 text-right">Played</span>
+          <span className="w-24 text-right">Completion</span>
+          <span className="w-20 text-right">Repeat</span>
+          <span className="w-24 text-right">Trend</span>
+        </div>
+
+        {active.length === 0 && (
+          <p className="py-6 text-center text-sm text-gray-500 dark:text-gray-400">
+            No games played in this window.
+          </p>
+        )}
+
+        {active.map((row) => {
+          const color = meta[row.game_type]?.color ?? '#94a3b8';
+          const isOpen = expanded === row.game_type;
+          const isSelected = selected === row.game_type;
+
+          return (
+            <div
+              key={row.game_type}
+              className={cn(
+                'rounded-md border transition-colors',
+                isSelected
+                  ? 'border-emerald-500 bg-emerald-50/50 dark:bg-emerald-900/10'
+                  : 'border-transparent hover:bg-gray-50 dark:hover:bg-slate-800',
+              )}
+            >
+              <div className="flex flex-wrap items-center gap-3 p-2 md:flex-nowrap">
+                <button
+                  type="button"
+                  aria-expanded={isOpen}
+                  aria-label={isOpen ? 'Collapse details' : 'Expand details'}
+                  onClick={() => setExpanded(isOpen ? null : row.game_type)}
+                  className="text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+                >
+                  {isOpen ? <ChevronDown className="size-4" /> : <ChevronRight className="size-4" />}
+                </button>
+
+                <div className="flex min-w-40 flex-1 flex-col gap-1">
+                  <GameBadge
+                    gameKey={row.game_type}
+                    meta={meta}
+                    active={isSelected}
+                    onClick={key => onSelect(isSelected ? null : key)}
+                  />
+                  <VolumeBar value={row[metric]} max={max} color={color} />
+                </div>
+
+                <span className="w-20 text-right text-sm font-medium tabular-nums text-gray-900 dark:text-white">
+                  {row[metric].toLocaleString()}
+                </span>
+                <span className="w-24 text-right text-sm tabular-nums">{rate(row.completion_pct)}</span>
+                <span className="w-20 text-right text-sm tabular-nums">{rate(row.repeat_rate_pct)}</span>
+                <span className="w-24 text-right text-sm">
+                  <Trend pct={row.trend_pct} />
+                </span>
+              </div>
+
+              {isOpen && (
+                <dl className="grid grid-cols-2 gap-3 border-t px-4 py-3 text-sm dark:border-slate-700 sm:grid-cols-3 lg:grid-cols-6">
+                  {[
+                    ['Started', row.games_started.toLocaleString()],
+                    ['Finished', row.games_finished.toLocaleString()],
+                    ['Players', row.distinct_players.toLocaleString()],
+                    ['Sessions / player', row.sessions_per_player ?? '—'],
+                    ['Multiplayer', row.mp_player_sessions.toLocaleString()],
+                    ['Solo', (row.games_started - row.mp_player_sessions).toLocaleString()],
+                    ['Repeat players', row.repeat_players.toLocaleString()],
+                    ['Share of platform', rate(row.share_pct)],
+                    ['Previous window', row.previous_games_started.toLocaleString()],
+                  ].map(([label, value]) => (
+                    <div key={label as string}>
+                      <dt className="text-xs text-gray-500 dark:text-gray-400">{label}</dt>
+                      <dd className="font-medium tabular-nums text-gray-900 dark:text-white">{value}</dd>
+                    </div>
+                  ))}
+                </dl>
+              )}
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/reports/MetricToggle.tsx
+++ b/components/reports/MetricToggle.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import type { MetricKey } from '@/types/reports';
+import { Button } from '@/components/ui/button';
+import { METRIC_OPTIONS } from '@/types/reports';
+
+/**
+ * Chooses which metric the chart/table foregrounds. "Played" counts sessions
+ * started; "Finished" counts the ones played to the end — the gap between them
+ * is the abandonment story, so both need to be reachable rather than one being
+ * baked in.
+ */
+export function MetricToggle({ value, onChange }: {
+  value: MetricKey;
+  onChange: (metric: MetricKey) => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <span className="text-sm text-gray-600 dark:text-gray-300">Show</span>
+      {METRIC_OPTIONS.map(option => (
+        <Button
+          key={option.key}
+          size="sm"
+          variant={option.key === value ? 'default' : 'outline'}
+          onClick={() => onChange(option.key)}
+        >
+          {option.label}
+        </Button>
+      ))}
+    </div>
+  );
+}

--- a/components/reports/ModeBreakdown.tsx
+++ b/components/reports/ModeBreakdown.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import type { GameMetaMap } from '@/hooks/use-game-meta';
+import type { MultiplayerModeRow } from '@/types/reports';
+import { Bar, BarChart, CartesianGrid, Cell, LabelList, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { GameBadge } from '@/components/reports/GameBadge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { FALLBACK_COLOR } from '@/hooks/use-game-meta';
+
+/** Quiz has no mode column, so its rooms arrive as null rather than being dropped. */
+function modeLabel(mode: string | null): string {
+  if (!mode) {
+    return 'No mode';
+  }
+  return mode.split('_').map(part => part.charAt(0) + part.slice(1).toLowerCase()).join(' ');
+}
+
+/**
+ * Modes are shared across games, so the totals answer "is Elimination working
+ * anywhere" — a question the per-game funnel can't. The per-game split below it
+ * then shows which games drive each mode.
+ */
+export function ModeBreakdown({ rows, meta, onSelectGame }: {
+  rows: MultiplayerModeRow[];
+  meta: GameMetaMap;
+  onSelectGame?: (gameKey: string) => void;
+}) {
+  const byMode = new Map<string, { mode: string; rooms_created: number; rooms_started: number; games: MultiplayerModeRow[] }>();
+  for (const row of rows) {
+    const label = modeLabel(row.mode);
+    const bucket = byMode.get(label) ?? { mode: label, rooms_created: 0, rooms_started: 0, games: [] };
+    bucket.rooms_created += row.rooms_created;
+    bucket.rooms_started += row.rooms_started;
+    bucket.games.push(row);
+    byMode.set(label, bucket);
+  }
+  const modes = [...byMode.values()].sort((a, b) => b.rooms_created - a.rooms_created);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>By mode</CardTitle>
+        <CardDescription>
+          Modes are shared across games, so this shows which formats people actually
+          play — not just which games have multiplayer.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {modes.length === 0
+          ? (
+              <p className="py-6 text-center text-sm text-gray-500 dark:text-gray-400">
+                No multiplayer rooms in this window.
+              </p>
+            )
+          : (
+              <>
+                <div className="h-56">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <BarChart data={modes} margin={{ top: 16, right: 8, bottom: 8, left: -12 }}>
+                      <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-slate-700" />
+                      <XAxis dataKey="mode" tick={{ fontSize: 11 }} />
+                      <YAxis tick={{ fontSize: 11 }} allowDecimals={false} width={44} />
+                      <Tooltip contentStyle={{ fontSize: 12 }} cursor={{ fillOpacity: 0.1 }} />
+                      <Bar dataKey="rooms_created" name="Rooms" radius={[4, 4, 0, 0]}>
+                        <LabelList dataKey="rooms_created" position="top" style={{ fontSize: 11 }} />
+                        {modes.map(mode => (
+                          <Cell key={mode.mode} fill={meta[mode.games[0]?.game_type ?? '']?.color ?? FALLBACK_COLOR} />
+                        ))}
+                      </Bar>
+                    </BarChart>
+                  </ResponsiveContainer>
+                </div>
+
+                <div className="space-y-4">
+                  {modes.map(mode => (
+                    <div key={mode.mode} className="space-y-2">
+                      <div className="flex flex-wrap items-baseline justify-between gap-2">
+                        <h4 className="text-sm font-semibold text-gray-900 dark:text-white">{mode.mode}</h4>
+                        <span className="text-xs text-gray-500 dark:text-gray-400">
+                          {mode.rooms_created.toLocaleString()}
+                          {' rooms · '}
+                          {mode.rooms_started.toLocaleString()}
+                          {' started'}
+                        </span>
+                      </div>
+                      <div className="flex flex-wrap gap-2">
+                        {[...mode.games]
+                          .sort((a, b) => b.rooms_created - a.rooms_created)
+                          .map(game => (
+                            <GameBadge
+                              key={`${game.game_type}-${game.mode}`}
+                              gameKey={game.game_type}
+                              meta={meta}
+                              count={game.rooms_created}
+                              onClick={onSelectGame}
+                            />
+                          ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </>
+            )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/hooks/use-game-meta.ts
+++ b/hooks/use-game-meta.ts
@@ -1,0 +1,43 @@
+/**
+ * Game display metadata (label + colour), keyed for O(1) lookup.
+ *
+ * The colours come from the BE registry — the same ones the Django admin
+ * dashboard draws each game with — so a new game is coloured automatically and
+ * the two surfaces can't drift apart.
+ */
+
+import type { GameMeta } from '@/types/reports';
+import { useEffect, useState } from 'react';
+import { ReportsAPI } from '@/lib/reports-api';
+
+export type GameMetaMap = Record<string, GameMeta>;
+
+/** Neutral grey for a game the BE hasn't told us about yet. */
+export const FALLBACK_COLOR = '#94a3b8';
+
+export function useGameMeta(enabled: boolean) {
+  const [meta, setMeta] = useState<GameMetaMap>({});
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    let cancelled = false;
+    ReportsAPI.getGames()
+      .then((res) => {
+        if (!cancelled) {
+          setMeta(Object.fromEntries(res.games.map(game => [game.key, game])));
+        }
+      })
+      // Colours are cosmetic — a failure here must not take the page down, so
+      // callers fall back to FALLBACK_COLOR and a prettified slug. There is
+      // deliberately no isLoading: nothing blocks on this, and badges simply
+      // start neutral and gain colour when it lands.
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled]);
+
+  return { meta };
+}

--- a/lib/__tests__/reports-api.test.ts
+++ b/lib/__tests__/reports-api.test.ts
@@ -29,6 +29,22 @@ describe('reportsAPI', () => {
     ]);
   });
 
+  it('exposes the game-metadata endpoint', async () => {
+    // Colours come from here rather than a frontend palette, which would drift
+    // the first time a game is added.
+    await ReportsAPI.getGames();
+
+    expect(mockApiFetcher).toHaveBeenCalledWith('core/reporting/games/');
+  });
+
+  it('passes game_type through so a badge click filters server-side', async () => {
+    await ReportsAPI.getSummary({ window: 30, game_type: 'team_ties' });
+
+    expect(mockApiFetcher).toHaveBeenCalledWith(
+      'core/reporting/summary/?window=30&game_type=team_ties',
+    );
+  });
+
   it('serialises params into a query string', async () => {
     await ReportsAPI.getTopPlayers({ window: 30, include_bots: true, limit: 25 });
 

--- a/lib/reports-api.ts
+++ b/lib/reports-api.ts
@@ -1,5 +1,6 @@
 import type {
   ActivityResponse,
+  GamesResponse,
   MultiplayerResponse,
   ReportParams,
   SummaryResponse,
@@ -45,6 +46,15 @@ export class ReportsAPI {
   /** GET /core/reporting/multiplayer/ — room funnel (rooms, not participations). */
   static async getMultiplayer(params?: ReportParams): Promise<MultiplayerResponse> {
     return apiFetcher<MultiplayerResponse>(`core/reporting/multiplayer/${buildQuery(params)}`);
+  }
+
+  /**
+   * GET /core/reporting/games/ — key, label and colour per registered game.
+   * Colours come from the BE registry so the frontend never keeps its own
+   * palette, which would drift the first time a game is added.
+   */
+  static async getGames(): Promise<GamesResponse> {
+    return apiFetcher<GamesResponse>('core/reporting/games/');
   }
 
   /** GET /core/reporting/top-players/ — busiest players over the window. */

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -40,7 +40,20 @@ export type Pulse = {
   metrics: Record<keyof ActivityMetrics, PulseMetric>;
 };
 
-export type GameTotals = { game_type: string } & ActivityMetrics;
+export type GameTotals = {
+  game_type: string;
+  /** finished / started. Null when nobody played — 0% would read as "everyone bailed". */
+  completion_pct: number | null;
+  sessions_per_player: number | null;
+  /** Share of platform volume. Null when the platform had no activity at all. */
+  share_pct: number | null;
+  repeat_players: number;
+  /** Share of this game's players who came back on ANOTHER day. */
+  repeat_rate_pct: number | null;
+  previous_games_started: number;
+  /** vs the immediately preceding window. */
+  trend_pct: number | null;
+} & ActivityMetrics;
 
 export type SummaryResponse = {
   pulse: Pulse;
@@ -60,6 +73,15 @@ export type MultiplayerGameRow = {
   never_started_pct: number;
 };
 
+/** One row of the multiplayer funnel split by mode. Quiz has no mode column. */
+export type MultiplayerModeRow = {
+  game_type: string;
+  mode: string | null;
+  rooms_created: number;
+  rooms_started: number;
+  rooms_finished: number;
+};
+
 export type MultiplayerResponse = {
   start: string;
   end: string;
@@ -70,6 +92,7 @@ export type MultiplayerResponse = {
   grain: string;
   totals: Omit<MultiplayerGameRow, 'game_type'>;
   by_game: MultiplayerGameRow[];
+  by_mode: MultiplayerModeRow[];
 };
 
 export type TopPlayer = {
@@ -101,3 +124,23 @@ export type ReportParams = {
   include_bots?: boolean;
   limit?: number;
 };
+
+/** Display metadata from the BE registry — the single source of truth for colours. */
+export type GameMeta = {
+  key: string;
+  label: string;
+  /** Hex, e.g. '#2563eb'. Same colour the Django admin dashboard draws the game with. */
+  color: string;
+};
+
+export type GamesResponse = { games: GameMeta[] };
+
+/** Which activity metric a chart or table is currently showing. */
+export const METRIC_OPTIONS = [
+  { key: 'games_started', label: 'Played' },
+  { key: 'games_finished', label: 'Finished' },
+  { key: 'distinct_players', label: 'Players' },
+  { key: 'mp_player_sessions', label: 'Multiplayer' },
+] as const;
+
+export type MetricKey = (typeof METRIC_OPTIONS)[number]['key'];


### PR DESCRIPTION
Makes everything on Reports filterable and expandable, using the metadata and engagement rates from App [#1431](https://github.com/FootballExtraTime/App/pull/1431).

**No new packages** — recharts and the shadcn primitives were already here.

## Colours come from the backend

`GET /core/reporting/games/` serves the same palette the Django admin dashboard draws each game with. The frontend deliberately keeps **no palette of its own**: a second copy would drift the first time a game is added, and a new game now gets its badge colour with zero frontend change.

Applied inline rather than as Tailwind classes for the same reason — a class-per-game map would need hand-editing on every new game, which is the drift this endpoint exists to prevent.

## Daily Pulse

- **Game leaderboard** replaces the flat table: ranked by volume with a proportional bar, plus **completion / repeat / trend**, and rows **expand** for the nine figures that would otherwise be unreadable on a phone.
- **Clicking a game filters the whole page** — pulse tiles, chart and totals — so it answers *"how is THIS game doing"* in one click.
  The leaderboard itself always shows every game; filtering it too would hide the row you'd click to unselect.
- **Metric toggle** (Played / Finished / Players / Multiplayer) drives both the chart and the leaderboard's headline column.

## Chart

The selected metric is drawn boldly and the others stay **faint rather than hidden**: a "played" line means much more sitting next to "finished", but four equal-weight lines are unreadable. Takes the game's own colour when filtered.

## Multiplayer

- **New by-mode breakdown.** Modes are shared across games, so this answers *"is Elimination working anywhere"* rather than only *"how is Team Ties doing"*. Quiz has no mode column and shows as **"No mode"** rather than vanishing from the chart.
- Per-game rows are coloured, clickable badges that filter the funnel.

## Players

- Game chips are **coloured and clickable** — clicking one filters the leaderboard to that game.
- **Rank-by Played / Finished toggle**, since the gap between the two is the interesting part.

## Small thing that matters

Rates render as **"—" when null, never 0%**. "0% completion" reads as *everyone bailed*; "—" reads as *nobody played*. Same rule the BE follows.

## Responsive

Table headers collapse on small screens (the expanded panel carries the labels), the leaderboard rows wrap, charts drop to a shorter height, and every wide table scrolls in its own container rather than the page.

## Verification

| Check | Result |
|---|---|
| `eslint` | clean — 0 errors, 0 warnings |
| `tsc --noEmit` | no new errors |
| `vitest run` | **206 tests pass** (28 files) |
| `next build` | all three routes render |

Two things I removed rather than suppressed while building: a pointless `isLoading` in `useGameMeta` that nothing consumed (and which tripped `no-direct-set-state-in-use-effect`), and the local `Badge`/`prettySlug` usage now superseded by the server-coloured `GameBadge`.