### PR TITLE
feat(reports): period comparison replaces the pulse for historical ranges

### DIFF
--- a/components/reports/ActivityChart.tsx
+++ b/components/reports/ActivityChart.tsx
@@ -34,14 +34,42 @@ export function ActivityChart({ series, title, description, metric, color }: {
   /** Overrides the metric colour — used to match the selected game's badge. */
   color?: string;
 }) {
-  const data = series.map(row => ({ ...row, label: formatDay(row.date) }));
+  // An uncovered day was never computed. Feeding 0 to the chart draws a
+  // confident dip that never happened, so the value becomes null and recharts
+  // leaves a visible break instead.
+  const data = series.map(row => ({
+    ...row,
+    label: formatDay(row.date),
+    ...(row.covered
+      ? {}
+      : {
+          games_started: null,
+          games_finished: null,
+          distinct_players: null,
+          mp_player_sessions: null,
+        }),
+  }));
+  const uncovered = series.filter(row => !row.covered).length;
   const primaryColor = color ?? DEFAULT_COLORS[metric];
 
   return (
     <Card>
       <CardHeader>
         <CardTitle>{title}</CardTitle>
-        <CardDescription>{description}</CardDescription>
+        <CardDescription>
+          {description}
+          {uncovered > 0 && (
+            <>
+              {' '}
+              <span className="text-amber-700 dark:text-amber-300">
+                {uncovered}
+                {' day'}
+                {uncovered === 1 ? '' : 's'}
+                {' in this range were never computed and are drawn as gaps, not zeroes.'}
+              </span>
+            </>
+          )}
+        </CardDescription>
       </CardHeader>
       <CardContent className="h-72 sm:h-80">
         <ResponsiveContainer width="100%" height="100%">
@@ -64,6 +92,7 @@ export function ActivityChart({ series, title, description, metric, color }: {
                   strokeOpacity={isPrimary ? 1 : 0.28}
                   dot={false}
                   activeDot={isPrimary ? { r: 4 } : false}
+                  connectNulls={false}
                 />
               );
             })}

--- a/components/reports/ComparisonTiles.tsx
+++ b/components/reports/ComparisonTiles.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import type { ActivityMetrics, PeriodComparison } from '@/types/reports';
+import { Minus, TrendingDown, TrendingUp } from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+const TILES: { key: keyof ActivityMetrics; label: string }[] = [
+  { key: 'games_started', label: 'Games played' },
+  { key: 'games_finished', label: 'Games finished' },
+  { key: 'distinct_players', label: 'Players' },
+  { key: 'mp_player_sessions', label: 'Multiplayer' },
+];
+
+/**
+ * The selected period against the one before it.
+ *
+ * Replaces the daily pulse whenever the range doesn't end today: "how is today
+ * going" is not an answer to "how did 1–15 June do", and showing it anyway made
+ * the date picker look broken.
+ */
+export function ComparisonTiles({ comparison }: { comparison: PeriodComparison }) {
+  return (
+    <div className="space-y-2">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {TILES.map(({ key, label }) => {
+          const metric = comparison.metrics[key];
+          const pct = metric.change_pct;
+          const flat = pct !== null && Math.abs(pct) < 5;
+          const up = (pct ?? metric.change) > 0;
+          const Icon = pct === null ? Minus : flat ? Minus : up ? TrendingUp : TrendingDown;
+
+          return (
+            <Card key={key}>
+              <CardContent className="space-y-1 p-4">
+                <p className="text-sm font-medium text-gray-600 dark:text-gray-300">{label}</p>
+                <p className="text-3xl font-bold text-gray-900 dark:text-white">
+                  {metric.current.toLocaleString()}
+                </p>
+                <span
+                  className={cn(
+                    'flex items-center gap-1 text-xs font-medium',
+                    pct === null || flat
+                      ? 'text-gray-500 dark:text-gray-400'
+                      : up
+                        ? 'text-emerald-600 dark:text-emerald-400'
+                        : 'text-red-600 dark:text-red-400',
+                  )}
+                >
+                  <Icon className="size-3" />
+                  {pct === null
+                    ? (metric.previous === 0 ? 'no earlier activity' : 'incomplete data')
+                    : `${pct > 0 ? '+' : ''}${pct}% vs previous`}
+                </span>
+                <p className="pt-1 text-xs text-gray-500 dark:text-gray-400">
+                  {metric.previous.toLocaleString()}
+                  {' previously · '}
+                  {metric.change > 0 ? '+' : ''}
+                  {metric.change.toLocaleString()}
+                </p>
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+
+      <p className="text-center text-xs text-gray-500 dark:text-gray-400">
+        {comparison.current.start}
+        {' → '}
+        {comparison.current.end}
+        {' compared with '}
+        {comparison.previous.start}
+        {' → '}
+        {comparison.previous.end}
+        {' (the '}
+        {comparison.previous.days}
+        {' days immediately before).'}
+        {!comparison.coverage.complete
+          && ' Percentages are hidden because some days in these periods were never computed — run the reporting backfill to fill them.'}
+      </p>
+    </div>
+  );
+}

--- a/components/reports/PulseTiles.tsx
+++ b/components/reports/PulseTiles.tsx
@@ -20,10 +20,17 @@ const TILES: { key: keyof ActivityMetrics; label: string; hint: string }[] = [
  */
 function Delta({ metric }: { metric: PulseMetric }) {
   if (metric.delta_pct_vs_baseline === null) {
+    // Three genuinely different reasons, and saying which one matters: a missing
+    // baseline is a data gap to fix, a zero baseline is real news.
+    const reason = metric.baseline_same_weekday === null
+      ? 'no baseline data'
+      : metric.baseline_same_weekday === 0
+        ? 'new — no usual level'
+        : 'no comparison';
     return (
       <span className="flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
         <Minus className="size-3" />
-        no baseline yet
+        {reason}
       </span>
     );
   }
@@ -54,30 +61,43 @@ function Delta({ metric }: { metric: PulseMetric }) {
 
 export function PulseTiles({ pulse }: { pulse: Pulse }) {
   return (
-    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-      {TILES.map(({ key, label, hint }) => {
-        const metric = pulse.metrics[key];
-        return (
-          <Card key={key}>
-            <CardContent className="space-y-1 p-4">
-              <p className="text-sm font-medium text-gray-600 dark:text-gray-300">{label}</p>
-              <p className="text-3xl font-bold text-gray-900 dark:text-white">
-                {metric.today.toLocaleString()}
-              </p>
-              <Delta metric={metric} />
-              <p className="pt-1 text-xs text-gray-500 dark:text-gray-400">
-                {hint}
-                {' · '}
-                typical
-                {' '}
-                {pulse.weekday}
-                {': '}
-                {metric.baseline_same_weekday.toLocaleString()}
-              </p>
-            </CardContent>
-          </Card>
-        );
-      })}
+    <div className="space-y-2">
+      {!pulse.baseline_covered && (
+        <p className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:border-amber-900 dark:bg-amber-900/20 dark:text-amber-200">
+          No baseline:
+          {' '}
+          {pulse.baseline_missing_days.length}
+          {' of the last '}
+          {pulse.baseline_weeks}
+          {' '}
+          {pulse.weekday}
+          s were never computed, so there is nothing honest to compare today with.
+          Run the reporting backfill to fill them.
+        </p>
+      )}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {TILES.map(({ key, label, hint }) => {
+          const metric = pulse.metrics[key];
+          return (
+            <Card key={key}>
+              <CardContent className="space-y-1 p-4">
+                <p className="text-sm font-medium text-gray-600 dark:text-gray-300">{label}</p>
+                <p className="text-3xl font-bold text-gray-900 dark:text-white">
+                  {metric.today.toLocaleString()}
+                </p>
+                <Delta metric={metric} />
+                <p className="pt-1 text-xs text-gray-500 dark:text-gray-400">
+                  {hint}
+                  {' · '}
+                  {metric.baseline_same_weekday === null
+                    ? `no typical ${pulse.weekday} to compare with yet`
+                    : `typical ${pulse.weekday}: ${metric.baseline_same_weekday.toLocaleString()}`}
+                </p>
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -11,9 +11,20 @@ export type ActivityMetrics = {
   mp_player_sessions: number;
 };
 
-export type ActivityDay = { date: string } & ActivityMetrics;
+export type ActivityDay = {
+  date: string;
+  /** False = never computed. NOT the same as zero activity. */
+  covered: boolean;
+} & ActivityMetrics;
+
+export type Coverage = {
+  complete: boolean;
+  uncovered_days: string[];
+  covered_days: number;
+};
 
 export type ActivityResponse = {
+  coverage: Coverage;
   start: string;
   end: string;
   window: number;
@@ -28,7 +39,8 @@ export type PulseMetric = {
   today: number;
   yesterday: number;
   /** Mean of the previous N same weekdays. */
-  baseline_same_weekday: number;
+  /** Null when the baseline period has uncovered days. */
+  baseline_same_weekday: number | null;
   /** Null when the baseline is 0 and today is 0 — i.e. no meaningful comparison. */
   delta_pct_vs_baseline: number | null;
 };
@@ -37,6 +49,9 @@ export type Pulse = {
   date: string;
   weekday: string;
   baseline_weeks: number;
+  /** False when a baseline day was never rolled up — show "no baseline", not 0. */
+  baseline_covered: boolean;
+  baseline_missing_days: string[];
   metrics: Record<keyof ActivityMetrics, PulseMetric>;
 };
 
@@ -55,8 +70,30 @@ export type GameTotals = {
   trend_pct: number | null;
 } & ActivityMetrics;
 
+export type MetricComparison = {
+  current: number;
+  previous: number;
+  change: number;
+  /** Null when a period has gaps, or the previous period was zero. */
+  change_pct: number | null;
+};
+
+export type PeriodComparison = {
+  current: { start: string; end: string; days: number };
+  previous: { start: string; end: string; days: number };
+  coverage: {
+    complete: boolean;
+    missing_current_days: string[];
+    missing_previous_days: string[];
+  };
+  metrics: Record<keyof ActivityMetrics, MetricComparison>;
+};
+
 export type SummaryResponse = {
   pulse: Pulse;
+  /** False when the range doesn't end today — the pulse describes today only. */
+  pulse_applies: boolean;
+  comparison: PeriodComparison;
   window: number;
   game_type: string | null;
   window_totals: ActivityMetrics;


### PR DESCRIPTION
Fixes the reported confusion — picking a date range changed the charts but **not the headline figures**, because the pulse always described *today* and nothing on screen said so.

Pairs with App [#1435](https://github.com/FootballExtraTime/App/pull/1435) and [#1434](https://github.com/FootballExtraTime/App/pull/1434).

## The pulse now knows when it applies

It renders **only when the range ends today**. Otherwise `ComparisonTiles` answer what was actually asked — the selected period vs the period immediately before it — with both date ranges spelled out underneath so the comparison is never a mystery:

> `2026-06-26 → 2026-07-09` compared with `2026-06-12 → 2026-06-25` (the 14 days immediately before).

## Gaps are drawn as gaps

An uncovered day becomes `null`, not `0`, so recharts leaves a **visible break** rather than a confident dip that never happened. The caption states how many days are affected and why.

This is the visual half of #1434: the backend stopped inventing zeroes, and now the chart stops drawing them.

## Three reasons a delta is missing, said out loud

Previously all rendered as a bare dash — or worse, as `typical Wednesday: 0` with `+100%` beside it. They need different responses:

| Shown | Means |
|---|---|
| *no baseline data* | days were never computed — run the backfill |
| *new — no usual level* | genuinely nothing before; this is real news |
| *incomplete data* | a period has gaps, so no honest percentage exists |

An incomplete baseline is also called out **above** the tiles with the count of missing days and what to do, instead of being inferable only from a suspicious-looking zero.

## Worth noting

TypeScript caught `PulseTiles` not handling the now-nullable baseline — which is precisely the code path that produced the bogus `typical Wednesday: 0`. Making the backend honest made the frontend fail to compile until it was honest too.

## Verification

| Check | Result |
|---|---|
| `eslint` | clean |
| `tsc --noEmit` | no new errors |
| `vitest run` | 211 tests pass |
| `next build` | all 5 report routes |