### PR TITLE
feat(reports): CSV export and shareable filter URLs

### DIFF
--- a/app/reports/page.tsx
+++ b/app/reports/page.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import type { RangeState } from '@/lib/report-range';
-import type { MetricKey } from '@/types/reports';
-import { useMemo, useState } from 'react';
+import type { GameTotals } from '@/types/reports';
+import { useMemo } from 'react';
 import { ActivityChart } from '@/components/reports/ActivityChart';
+import { ExportButton } from '@/components/reports/ExportButton';
 import { GameBadge } from '@/components/reports/GameBadge';
 import { GameLeaderboard } from '@/components/reports/GameLeaderboard';
 import { MetricToggle } from '@/components/reports/MetricToggle';
@@ -14,6 +14,7 @@ import { ReportsShell } from '@/components/reports/ReportsShell';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useGameMeta } from '@/hooks/use-game-meta';
 import { useReport } from '@/hooks/use-report';
+import { useReportFilters } from '@/hooks/use-report-filters';
 import { useAuth } from '@/lib/auth';
 import { rangeToParams } from '@/lib/report-range';
 import { ReportsAPI } from '@/lib/reports-api';
@@ -22,10 +23,14 @@ export default function ReportsPage() {
   const { isAuthenticated, user } = useAuth();
   const enabled = isAuthenticated && !!(user?.is_staff || user?.is_superuser);
 
-  const [range, setRange] = useState<RangeState>({ window: 30 });
-  const [includeBots, setIncludeBots] = useState(false);
-  const [metric, setMetric] = useState<MetricKey>('games_started');
-  const [game, setGame] = useState<string | null>(null);
+  // Filters live in the URL so a view can be bookmarked or shared.
+  const { filters, update } = useReportFilters({
+    range: { window: 30 },
+    includeBots: false,
+    game: null,
+    metric: 'games_started',
+  });
+  const { range, includeBots, metric, game } = filters;
 
   // The selected game narrows the pulse, the chart and the tiles together, so
   // the whole page answers "how is THIS game doing" in one click.
@@ -55,17 +60,17 @@ export default function ReportsPage() {
       <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
         <RangePicker
           value={range}
-          onChange={setRange}
+          onChange={next => update({ range: next })}
           includeBots={includeBots}
-          onIncludeBotsChange={setIncludeBots}
+          onIncludeBotsChange={value => update({ includeBots: value })}
         />
-        <MetricToggle value={metric} onChange={setMetric} />
+        <MetricToggle value={metric} onChange={next => update({ metric: next })} />
       </div>
 
       {game && (
         <div className="flex flex-wrap items-center gap-2 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 dark:border-emerald-900 dark:bg-emerald-900/20">
           <span className="text-sm text-gray-700 dark:text-gray-200">Filtered to</span>
-          <GameBadge gameKey={game} meta={meta} active onClick={() => setGame(null)} />
+          <GameBadge gameKey={game} meta={meta} active onClick={() => update({ game: null })} />
         </div>
       )}
 
@@ -103,12 +108,36 @@ export default function ReportsPage() {
             )}
 
       {allGames.data && (
+        <div className="flex justify-end">
+          <ExportButton<GameTotals>
+            view="games"
+            rows={allGames.data.by_game}
+            filters={{ start: allGames.data.start, end: allGames.data.end, bots: includeBots }}
+            columns={[
+              { header: 'Game', value: row => row.game_type },
+              { header: 'Played', value: row => row.games_started },
+              { header: 'Finished', value: row => row.games_finished },
+              { header: 'Players', value: row => row.distinct_players },
+              { header: 'Multiplayer', value: row => row.mp_player_sessions },
+              { header: 'Solo', value: row => row.games_started - row.mp_player_sessions },
+              { header: 'Completion %', value: row => row.completion_pct },
+              { header: 'Sessions per player', value: row => row.sessions_per_player },
+              { header: 'Repeat %', value: row => row.repeat_rate_pct },
+              { header: 'Share %', value: row => row.share_pct },
+              { header: 'Trend %', value: row => row.trend_pct },
+              { header: 'Previous period played', value: row => row.previous_games_started },
+            ]}
+          />
+        </div>
+      )}
+
+      {allGames.data && (
         <GameLeaderboard
           rows={allGames.data.by_game}
           meta={meta}
           metric={metric}
           selected={game}
-          onSelect={setGame}
+          onSelect={next => update({ game: next })}
         />
       )}
     </ReportsShell>

--- a/components/reports/ExportButton.tsx
+++ b/components/reports/ExportButton.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import type { CsvColumn } from '@/lib/report-csv';
+import { Download } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { csvFilename, downloadCsv, toCsv } from '@/lib/report-csv';
+
+/** Downloads exactly the rows currently rendered, with the filters in the filename. */
+export function ExportButton<T>({ rows, columns, view, filters, label = 'Export CSV' }: {
+  rows: T[];
+  columns: CsvColumn<T>[];
+  view: string;
+  filters: Record<string, string | number | boolean | null | undefined>;
+  label?: string;
+}) {
+  return (
+    <Button
+      size="sm"
+      variant="outline"
+      disabled={rows.length === 0}
+      title={rows.length === 0 ? 'Nothing to export' : `Export ${rows.length} rows`}
+      onClick={() => downloadCsv(csvFilename(view, filters), toCsv(rows, columns))}
+    >
+      <Download className="mr-1 size-3.5" />
+      {label}
+      {rows.length > 0 && <span className="ml-1 opacity-70">{`(${rows.length})`}</span>}
+    </Button>
+  );
+}

--- a/components/reports/RetentionTable.tsx
+++ b/components/reports/RetentionTable.tsx
@@ -2,6 +2,7 @@
 
 import type { RetentionResponse } from '@/types/reports';
 import { AlertTriangle } from 'lucide-react';
+import { ExportButton } from '@/components/reports/ExportButton';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
 
@@ -59,15 +60,36 @@ export function RetentionTable({ data }: { data: RetentionResponse }) {
       </div>
 
       <Card>
-        <CardHeader>
-          <CardTitle>Cohorts</CardTitle>
-          <CardDescription>
-            Each row is the players whose first session in this range fell on that day,
-            and how many came back later.
-            {' '}
-            {data.basis}
-            {' — so someone who has played for months but was picked up mid-range counts as new.'}
-          </CardDescription>
+        <CardHeader className="flex flex-row flex-wrap items-start justify-between gap-2">
+          <div>
+            <CardTitle>Cohorts</CardTitle>
+            <CardDescription>
+              Each row is the players whose first session in this range fell on that day,
+              and how many came back later.
+              {' '}
+              {data.basis}
+              {' — so someone who has played for months but was picked up mid-range counts as new.'}
+            </CardDescription>
+          </div>
+          <ExportButton
+            view="retention"
+            rows={data.cohorts}
+            filters={{ start: data.start, end: data.end, game: data.game_type }}
+            columns={[
+              { header: 'Cohort day', value: row => row.date },
+              { header: 'Players', value: row => row.cohort_size },
+              { header: 'Inflated', value: row => (row.inflated ? 'yes' : 'no') },
+              ...keys.map(key => ({
+                header: `${key.toUpperCase()} %`,
+                // Blank, not 0 — the cohort simply hasn't reached that milestone.
+                value: (row: typeof data.cohorts[number]) => row.retention[key]?.pct ?? null,
+              })),
+              ...keys.map(key => ({
+                header: `${key.toUpperCase()} returned`,
+                value: (row: typeof data.cohorts[number]) => row.retention[key]?.returned ?? null,
+              })),
+            ]}
+          />
         </CardHeader>
         <CardContent className="space-y-3">
           {data.first_cohort_inflated && (

--- a/hooks/use-report-filters.ts
+++ b/hooks/use-report-filters.ts
@@ -1,0 +1,113 @@
+/**
+ * Keeps the report filters in the URL, so a view can be bookmarked, shared or
+ * reloaded without losing what you had selected.
+ *
+ * Uses history.replaceState rather than Next's useSearchParams on purpose: these
+ * pages are statically prerendered, and useSearchParams forces them into
+ * client-side bailout unless every one is wrapped in Suspense. The filters are
+ * a client-only concern — nothing server-rendered reads them — so the simpler
+ * mechanism is also the correct one here.
+ *
+ * replaceState, not pushState: changing a filter shouldn't stack history entries
+ * that make Back walk through every toggle instead of leaving the page.
+ */
+
+import type { RangeState } from '@/lib/report-range';
+import type { MetricKey, ReportWindow } from '@/types/reports';
+import { useCallback, useEffect, useState } from 'react';
+import { REPORT_WINDOWS } from '@/types/reports';
+
+export type ReportFilters = {
+  range: RangeState;
+  includeBots: boolean;
+  game: string | null;
+  metric: MetricKey;
+};
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+function parse(search: string, fallback: ReportFilters): ReportFilters {
+  const params = new URLSearchParams(search);
+
+  const rawWindow = Number(params.get('window'));
+  const window = REPORT_WINDOWS.includes(rawWindow as ReportWindow)
+    ? (rawWindow as ReportWindow)
+    : fallback.range.window;
+
+  const start = params.get('start');
+  const end = params.get('end');
+  // A start without a valid shape is ignored rather than passed on — the API
+  // would 400, and a shared link with a typo should degrade to the default view
+  // rather than to an error panel.
+  const hasRange = !!start && ISO_DATE.test(start) && (!end || ISO_DATE.test(end));
+
+  return {
+    range: hasRange ? { window, start, end: end ?? undefined } : { window },
+    includeBots: params.get('bots') === '1',
+    game: params.get('game') || null,
+    metric: (params.get('metric') as MetricKey) || fallback.metric,
+  };
+}
+
+function serialise(filters: ReportFilters, defaults: ReportFilters): string {
+  const params = new URLSearchParams();
+  if (filters.range.start) {
+    params.set('start', filters.range.start);
+    if (filters.range.end) {
+      params.set('end', filters.range.end);
+    }
+  } else if (filters.range.window !== defaults.range.window) {
+    params.set('window', String(filters.range.window));
+  }
+  if (filters.includeBots) {
+    params.set('bots', '1');
+  }
+  if (filters.game) {
+    params.set('game', filters.game);
+  }
+  // Only non-defaults go in the URL, so a shared link shows the filters that
+  // were actually chosen instead of a wall of noise.
+  if (filters.metric !== defaults.metric) {
+    params.set('metric', filters.metric);
+  }
+  const query = params.toString();
+  return query ? `?${query}` : '';
+}
+
+export function useReportFilters(defaults: ReportFilters) {
+  const [filters, setFilters] = useState<ReportFilters>(defaults);
+  const [hydrated, setHydrated] = useState(false);
+
+  // Read once on mount, deliberately in an effect rather than a lazy initialiser.
+  // These pages are statically prerendered, so a render-time read would produce
+  // markup that disagrees with the server's and trip a hydration mismatch. The
+  // rule below guards against cascading re-renders, which a one-shot mount read
+  // is not.
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks-extra/no-direct-set-state-in-use-effect
+    setFilters(parse(globalThis.location.search, defaults));
+    // eslint-disable-next-line react-hooks-extra/no-direct-set-state-in-use-effect
+    setHydrated(true);
+    // Defaults are a literal at the call site; re-reading on every render would
+    // clobber whatever the user just picked.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (!hydrated) {
+      return;
+    }
+    const query = serialise(filters, defaults);
+    globalThis.history.replaceState(null, '', `${globalThis.location.pathname}${query}`);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filters, hydrated]);
+
+  const update = useCallback((patch: Partial<ReportFilters>) => {
+    setFilters(current => ({ ...current, ...patch }));
+  }, []);
+
+  return { filters, update };
+}
+
+/** Exposed for tests: the pure half of this hook. */
+export const __test = { parse, serialise };

--- a/lib/__tests__/report-csv.test.ts
+++ b/lib/__tests__/report-csv.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { csvFilename, toCsv } from '@/lib/report-csv';
+
+type Row = { name: string; count: number; pct: number | null };
+
+const columns = [
+  { header: 'Name', value: (r: Row) => r.name },
+  { header: 'Count', value: (r: Row) => r.count },
+  { header: 'Pct', value: (r: Row) => r.pct },
+];
+
+describe('toCsv', () => {
+  it('writes a header and one line per row', () => {
+    expect(toCsv([{ name: 'grid', count: 5, pct: 12.5 }], columns))
+      .toBe('Name,Count,Pct\ngrid,5,12.5');
+  });
+
+  it('renders null as empty, not as the string "null"', () => {
+    expect(toCsv([{ name: 'quiz', count: 0, pct: null }], columns))
+      .toBe('Name,Count,Pct\nquiz,0,');
+  });
+
+  it('quotes and doubles embedded quotes, commas and newlines', () => {
+    const rows = [{ name: 'a,b "c"\nd', count: 1, pct: null }];
+
+    expect(toCsv(rows, columns)).toContain('"a,b ""c""\nd"');
+  });
+
+  it('neutralises spreadsheet formula injection', () => {
+    // Usernames land in these exports, so `=cmd()` opening as a formula in Excel
+    // is a real path rather than a theoretical one.
+    const rows = [{ name: '=1+1', count: 1, pct: null }, { name: '@SUM(A1)', count: 2, pct: null }];
+    const csv = toCsv(rows, columns);
+
+    expect(csv).toContain('\'=1+1');
+    expect(csv).toContain('\'@SUM(A1)');
+  });
+});
+
+describe('csvFilename', () => {
+  it('carries the filters so a folder of exports stays interpretable', () => {
+    expect(csvFilename('games', { start: '2026-06-01', end: '2026-06-30', game: 'grid' }))
+      .toBe('extratime-games_start-2026-06-01_end-2026-06-30_game-grid.csv');
+  });
+
+  it('drops empty filters and renders flags as bare names', () => {
+    expect(csvFilename('players', { window: 30, game: null, bots: true, other: false }))
+      .toBe('extratime-players_window-30_bots.csv');
+  });
+});

--- a/lib/__tests__/report-filters.test.ts
+++ b/lib/__tests__/report-filters.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+// The parse/serialise pair is the testable core; the hook around it is just
+// mount + replaceState wiring.
+import { __test } from '@/hooks/use-report-filters';
+
+const defaults = {
+  range: { window: 30 as const },
+  includeBots: false,
+  game: null,
+  metric: 'games_started' as const,
+};
+
+describe('report filter URL state', () => {
+  it('round-trips a custom range', () => {
+    const filters = { ...defaults, range: { window: 30 as const, start: '2026-06-01', end: '2026-06-30' } };
+    const query = __test.serialise(filters, defaults);
+
+    expect(query).toBe('?start=2026-06-01&end=2026-06-30');
+    expect(__test.parse(query, defaults).range).toEqual({ window: 30, start: '2026-06-01', end: '2026-06-30' });
+  });
+
+  it('omits defaults so a shared link shows only what was chosen', () => {
+    expect(__test.serialise(defaults, defaults)).toBe('');
+  });
+
+  it('ignores a malformed date rather than passing it to the API', () => {
+    // The API would 400; a shared link with a typo should degrade to the default
+    // view, not an error panel.
+    expect(__test.parse('?start=not-a-date', defaults).range).toEqual({ window: 30 });
+  });
+
+  it('rejects a window the API would refuse', () => {
+    expect(__test.parse('?window=999', defaults).range.window).toBe(30);
+  });
+
+  it('reads game and bots flags', () => {
+    const parsed = __test.parse('?game=grid&bots=1', defaults);
+
+    expect(parsed.game).toBe('grid');
+    expect(parsed.includeBots).toBe(true);
+  });
+});

--- a/lib/report-csv.ts
+++ b/lib/report-csv.ts
@@ -1,0 +1,61 @@
+/**
+ * CSV export for the reporting tables.
+ *
+ * Exports what is on screen — the same rows, filters and range the user is
+ * looking at — rather than re-querying. A file that quietly contains something
+ * different from the view it came from is worse than no export.
+ */
+
+export type CsvColumn<T> = {
+  header: string;
+  /** Return a primitive; objects are stringified by the caller's choice, not ours. */
+  value: (row: T) => string | number | boolean | null | undefined;
+};
+
+/**
+ * Escape one cell.
+ *
+ * A leading =, +, - or @ is prefixed with an apostrophe: spreadsheets treat those
+ * as formulas, so a username like `=cmd()` would execute on open. Usernames reach
+ * these exports, so this is a real path, not a theoretical one.
+ */
+function escapeCell(value: string | number | boolean | null | undefined): string {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  let text = String(value);
+  if (/^[=+\-@]/.test(text)) {
+    text = `'${text}`;
+  }
+  return /[",\n\r]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
+}
+
+export function toCsv<T>(rows: T[], columns: CsvColumn<T>[]): string {
+  const header = columns.map(column => escapeCell(column.header)).join(',');
+  const body = rows.map(row => columns.map(column => escapeCell(column.value(row))).join(','));
+  return [header, ...body].join('\n');
+}
+
+/** Filename carrying the filters, so a folder of exports stays interpretable. */
+export function csvFilename(view: string, parts: Record<string, string | number | boolean | null | undefined>): string {
+  const suffix = Object.entries(parts)
+    .filter(([, value]) => value !== null && value !== undefined && value !== '' && value !== false)
+    .map(([key, value]) => (value === true ? key : `${key}-${value}`))
+    .join('_');
+  return `extratime-${view}${suffix ? `_${suffix}` : ''}.csv`;
+}
+
+export function downloadCsv(filename: string, csv: string): void {
+  // A UTF-8 BOM so Excel reads the file correctly — without it, accented usernames arrive
+  // mangled, which is exactly the sort of thing nobody reports and everybody
+  // works around.
+  const blob = new Blob([`\uFEFF${csv}`], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.append(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -94,12 +94,9 @@ export type SummaryResponse = {
   /** False when the range doesn't end today — the pulse describes today only. */
   pulse_applies: boolean;
   comparison: PeriodComparison;
-  window: number;
-  game_type: string | null;
   window_totals: ActivityMetrics;
   by_game: GameTotals[];
-  include_bots: boolean;
-};
+} & ResolvedRange;
 
 export type MultiplayerGameRow = {
   game_type: string;


### PR DESCRIPTION
Two things that turn the reports from something you look at into something you can **act on and pass around**.

## CSV export

On the games, players, retention and multiplayer tables.

- **Exports exactly the rows on screen**, with the active filters and range in the filename (`extratime-games_start-2026-06-01_end-2026-06-30_game-grid.csv`). A file that quietly contains something other than the view it came from is worse than no export.
- **Formula injection is neutralised.** Cells starting with `=`, `+`, `-` or `@` get an apostrophe prefix. Usernames reach these exports, so `=cmd()` executing on open in Excel is a real path, not a theoretical one.
- **Null renders as an empty cell**, never `null` or `0` — a retention milestone a cohort hasn't reached must not read as 0% in a spreadsheet either.
- **UTF-8 BOM** so Excel doesn't mangle accented usernames.

## Shareable filter URLs

Filters live in the URL, so a view can be bookmarked or sent to someone.

- **Only non-defaults are serialised**, so a shared link shows what was actually chosen rather than a wall of noise.
- **A malformed date or out-of-range window is ignored**, not passed on. The API would 400, and a shared link with a typo should degrade to the default view rather than an error panel.
- **`replaceState`, not `pushState`** — changing a filter shouldn't stack history entries that make Back walk through every toggle instead of leaving the page.
- **Read on mount, not in a lazy initialiser.** These pages are statically prerendered, so a render-time read would disagree with the server's markup and trip a hydration mismatch. That needs two lint disables, both commented with the reasoning rather than left bare.

## A stale type this surfaced

`SummaryResponse` still declared `window`/`game_type` by hand while the backend had moved to spreading its resolved range into every response. It now extends `ResolvedRange` like the others — which is exactly how the missing `start`/`end` showed up when the export needed them for the filename.

## Verification

| Check | Result |
|---|---|
| `eslint` | clean |
| `tsc --noEmit` | no new errors |
| `vitest run` | **222 tests** (11 new) |
| `next build` | all 6 report routes |

New tests cover CSV escaping, formula injection, null handling, filename composition, URL round-tripping, and rejecting malformed/out-of-range params.