### PR TITLE
feat(reports): session length page and per-game deep dive

### DIFF
--- a/app/reports/duration/page.tsx
+++ b/app/reports/duration/page.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import type { RangeState } from '@/lib/report-range';
+import { useMemo, useState } from 'react';
+import { DurationTable } from '@/components/reports/DurationTable';
+import { RangePicker } from '@/components/reports/RangePicker';
+import { ReportError } from '@/components/reports/ReportError';
+import { ReportsShell } from '@/components/reports/ReportsShell';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useGameMeta } from '@/hooks/use-game-meta';
+import { useReport } from '@/hooks/use-report';
+import { useAuth } from '@/lib/auth';
+import { rangeToParams } from '@/lib/report-range';
+import { ReportsAPI } from '@/lib/reports-api';
+
+export default function DurationPage() {
+  const { isAuthenticated, user } = useAuth();
+  const enabled = isAuthenticated && !!(user?.is_staff || user?.is_superuser);
+
+  const [range, setRange] = useState<RangeState>({ window: 30 });
+  const [includeBots, setIncludeBots] = useState(false);
+  const params = useMemo(
+    () => ({ ...rangeToParams(range), include_bots: includeBots }),
+    [range, includeBots],
+  );
+
+  const { meta } = useGameMeta(enabled);
+  const { data, isLoading, error, notDeployed, refetch } = useReport(
+    ReportsAPI.getDuration,
+    params,
+    enabled,
+    'The duration reporting endpoint',
+  );
+
+  return (
+    <ReportsShell
+      title="Session length"
+      description="How long people stay in a game — the closest proxy we have for what holds attention."
+    >
+      <RangePicker
+        value={range}
+        onChange={setRange}
+        includeBots={includeBots}
+        onIncludeBotsChange={setIncludeBots}
+      />
+
+      {error
+        ? <ReportError error={error} notDeployed={notDeployed} onRetry={refetch} />
+        : isLoading || !data
+          ? <Skeleton className="h-80 w-full" />
+          : <DurationTable data={data} meta={meta} />}
+    </ReportsShell>
+  );
+}

--- a/app/reports/games/[key]/page.tsx
+++ b/app/reports/games/[key]/page.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+import type { RangeState } from '@/lib/report-range';
+import { ArrowLeft } from 'lucide-react';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { useMemo, useState } from 'react';
+import { ActivityChart } from '@/components/reports/ActivityChart';
+import { ComparisonTiles } from '@/components/reports/ComparisonTiles';
+import { DurationTable } from '@/components/reports/DurationTable';
+import { RangePicker } from '@/components/reports/RangePicker';
+import { ReportError } from '@/components/reports/ReportError';
+import { ReportsShell } from '@/components/reports/ReportsShell';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useGameMeta } from '@/hooks/use-game-meta';
+import { useReport } from '@/hooks/use-report';
+import { useAuth } from '@/lib/auth';
+import { rangeToParams } from '@/lib/report-range';
+import { ReportsAPI } from '@/lib/reports-api';
+
+function Stat({ label, value, hint }: { label: string; value: string; hint?: string }) {
+  return (
+    <Card>
+      <CardContent className="space-y-1 p-4">
+        <p className="text-sm font-medium text-gray-600 dark:text-gray-300">{label}</p>
+        <p className="text-2xl font-bold text-gray-900 dark:text-white">{value}</p>
+        {hint && <p className="text-xs text-gray-500 dark:text-gray-400">{hint}</p>}
+      </CardContent>
+    </Card>
+  );
+}
+
+/** Everything about one game in one place, instead of filtering five pages by hand. */
+export default function GameDetailPage() {
+  const { isAuthenticated, user } = useAuth();
+  const enabled = isAuthenticated && !!(user?.is_staff || user?.is_superuser);
+  const routeParams = useParams();
+  const gameKey = String(routeParams?.key ?? '');
+
+  const [range, setRange] = useState<RangeState>({ window: 30 });
+  const [includeBots, setIncludeBots] = useState(false);
+  const params = useMemo(
+    () => ({ ...rangeToParams(range), include_bots: includeBots, game_type: gameKey }),
+    [range, includeBots, gameKey],
+  );
+
+  const { meta } = useGameMeta(enabled);
+  const ready = enabled && !!gameKey;
+  const summary = useReport(ReportsAPI.getSummary, params, ready, 'The reporting summary endpoint');
+  const activity = useReport(ReportsAPI.getActivity, params, ready, 'The reporting activity endpoint');
+  const duration = useReport(ReportsAPI.getDuration, params, ready, 'The duration reporting endpoint');
+  const players = useReport(
+    ReportsAPI.getTopPlayers,
+    useMemo(() => ({ ...params, limit: 10 }), [params]),
+    ready,
+    'The top-players reporting endpoint',
+  );
+
+  const label = meta[gameKey]?.label ?? gameKey;
+  const row = summary.data?.by_game.find(entry => entry.game_type === gameKey);
+
+  return (
+    <ReportsShell
+      title={label}
+      description="Everything about one game: volume, completion, who plays it and how long they stay."
+    >
+      <div className="flex flex-wrap items-center gap-3">
+        <Link
+          href="/reports"
+          className="inline-flex items-center gap-1 text-sm text-emerald-700 hover:underline dark:text-emerald-400"
+        >
+          <ArrowLeft className="size-4" />
+          All games
+        </Link>
+        <RangePicker
+          value={range}
+          onChange={setRange}
+          includeBots={includeBots}
+          onIncludeBotsChange={setIncludeBots}
+        />
+      </div>
+
+      {summary.error
+        ? <ReportError error={summary.error} notDeployed={summary.notDeployed} onRetry={summary.refetch} />
+        : summary.isLoading || !summary.data
+          ? <Skeleton className="h-32 w-full" />
+          : (
+              <>
+                <ComparisonTiles comparison={summary.data.comparison} />
+                {row && (
+                  <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+                    <Stat
+                      label="Completion"
+                      value={row.completion_pct === null ? '—' : `${row.completion_pct}%`}
+                      hint="Of games started"
+                    />
+                    <Stat
+                      label="Repeat rate"
+                      value={row.repeat_rate_pct === null ? '—' : `${row.repeat_rate_pct}%`}
+                      hint="Players who came back another day"
+                    />
+                    <Stat
+                      label="Sessions per player"
+                      value={row.sessions_per_player?.toString() ?? '—'}
+                    />
+                    <Stat
+                      label="Share of platform"
+                      value={row.share_pct === null ? '—' : `${row.share_pct}%`}
+                      hint="Of all games played"
+                    />
+                  </div>
+                )}
+              </>
+            )}
+
+      {activity.data && (
+        <ActivityChart
+          series={activity.data.series}
+          metric="games_started"
+          color={meta[gameKey]?.color}
+          title={`${label} — last ${activity.data.days} days`}
+          description={`${activity.data.totals.games_started.toLocaleString()} played, ${activity.data.totals.games_finished.toLocaleString()} finished.`}
+        />
+      )}
+
+      {duration.data && <DurationTable data={duration.data} meta={meta} />}
+
+      {players.data && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Top players of this game</CardTitle>
+            <CardDescription>Ranked within this game only.</CardDescription>
+          </CardHeader>
+          <CardContent className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b text-left text-gray-600 dark:border-slate-700 dark:text-gray-300">
+                  <th className="py-2 pr-4 font-medium">#</th>
+                  <th className="py-2 pr-4 font-medium">Player</th>
+                  <th className="py-2 pr-4 text-right font-medium">Played</th>
+                  <th className="py-2 text-right font-medium">Finished</th>
+                </tr>
+              </thead>
+              <tbody>
+                {players.data.players.map((player, index) => (
+                  <tr key={player.user_id} className="border-b last:border-0 dark:border-slate-700">
+                    <td className="py-2 pr-4 text-gray-500 dark:text-gray-400">{index + 1}</td>
+                    <td className="py-2 pr-4">
+                      <Link
+                        href={`/reports/players/${player.user_id}`}
+                        className="font-medium text-emerald-700 hover:underline dark:text-emerald-400"
+                      >
+                        {player.username}
+                      </Link>
+                    </td>
+                    <td className="py-2 pr-4 text-right tabular-nums">{player.games_played.toLocaleString()}</td>
+                    <td className="py-2 text-right tabular-nums">{player.games_finished.toLocaleString()}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            {players.data.players.length === 0 && (
+              <p className="py-6 text-center text-sm text-gray-500 dark:text-gray-400">
+                Nobody played this game in the selected range.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      )}
+    </ReportsShell>
+  );
+}

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -16,6 +16,7 @@ import {
   Repeat,
   Search,
   Sparkles,
+  Timer,
   UserCog,
   Users,
   Users2,
@@ -151,6 +152,12 @@ export function Navigation({ className }: NavigationProps) {
           href: '/reports/players',
           icon: Users,
           description: 'Most active players over a window',
+        },
+        {
+          label: 'Session length',
+          href: '/reports/duration',
+          icon: Timer,
+          description: 'How long people stay in each game',
         },
         {
           label: 'Retention',

--- a/components/reports/DurationTable.tsx
+++ b/components/reports/DurationTable.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+import type { GameMetaMap } from '@/hooks/use-game-meta';
+import type { DurationResponse } from '@/types/reports';
+import { Info } from 'lucide-react';
+import { ExportButton } from '@/components/reports/ExportButton';
+import { GameBadge } from '@/components/reports/GameBadge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { formatDuration } from '@/lib/format-duration';
+import { cn } from '@/lib/utils';
+
+/**
+ * Session length per game.
+ *
+ * Deliberately does NOT present one ranking. Conquest's median is 24 hours
+ * because a session there is a day-long campaign; Team Ties' is 5 minutes
+ * because a session is a sitting. Ranking them together would read as "Conquest
+ * holds attention 280x better", which is not what the number means — so the two
+ * shapes are split into separate tables.
+ */
+export function DurationTable({ data, meta }: { data: DurationResponse; meta: GameMetaMap }) {
+  const comparable = data.rows.filter(row => row.supported && row.single_sitting);
+  const longLived = data.rows.filter(row => row.supported && row.single_sitting === false);
+  const unsupported = data.rows.filter(row => !row.supported);
+
+  const maxMedian = Math.max(...comparable.map(row => row.median_seconds ?? 0), 0);
+
+  const renderRows = (rows: typeof data.rows, showBar: boolean) => rows.map(row => (
+    <tr key={row.game_type} className="border-b last:border-0 dark:border-slate-700">
+      <td className="py-2 pr-4">
+        <GameBadge gameKey={row.game_type} meta={meta} />
+      </td>
+      <td className="py-2 pr-4">
+        <div className="flex items-center gap-2">
+          <span className="w-14 text-right font-medium tabular-nums text-gray-900 dark:text-white">
+            {formatDuration(row.median_seconds)}
+          </span>
+          {showBar && (
+            <div className="h-1.5 w-full max-w-32 overflow-hidden rounded-full bg-gray-100 dark:bg-slate-700">
+              <div
+                className="h-full rounded-full"
+                style={{
+                  width: `${maxMedian > 0 ? Math.max(2, ((row.median_seconds ?? 0) / maxMedian) * 100) : 0}%`,
+                  backgroundColor: meta[row.game_type]?.color ?? '#94a3b8',
+                }}
+              />
+            </div>
+          )}
+        </div>
+      </td>
+      <td className="py-2 pr-4 text-right tabular-nums">{formatDuration(row.p90_seconds)}</td>
+      <td className="py-2 pr-4 text-right tabular-nums">{row.measured.toLocaleString()}</td>
+      <td className="py-2 text-right">
+        <span className={cn(
+          'tabular-nums',
+          (row.coverage_pct ?? 100) < 90 ? 'text-amber-700 dark:text-amber-300' : '',
+        )}
+        >
+          {row.coverage_pct === null ? '—' : `${row.coverage_pct}%`}
+        </span>
+      </td>
+    </tr>
+  ));
+
+  const head = (
+    <thead>
+      <tr className="border-b text-left text-gray-600 dark:border-slate-700 dark:text-gray-300">
+        <th className="py-2 pr-4 font-medium">Game</th>
+        <th className="py-2 pr-4 font-medium">Median</th>
+        <th className="py-2 pr-4 text-right font-medium">p90</th>
+        <th className="py-2 pr-4 text-right font-medium">Sessions</th>
+        <th className="py-2 text-right font-medium">Coverage</th>
+      </tr>
+    </thead>
+  );
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader className="flex flex-row flex-wrap items-start justify-between gap-2">
+          <div>
+            <CardTitle>How long a session lasts</CardTitle>
+            <CardDescription>
+              Median, not mean — the long tail is abandoned sessions, not slow players.
+              {data.longest_single_sitting_game && (
+                <>
+                  {' Longest single sitting: '}
+                  <strong>{meta[data.longest_single_sitting_game]?.label ?? data.longest_single_sitting_game}</strong>
+                  .
+                </>
+              )}
+            </CardDescription>
+          </div>
+          <ExportButton
+            view="duration"
+            rows={data.rows}
+            filters={{ start: data.start, end: data.end }}
+            columns={[
+              { header: 'Game', value: row => row.game_type },
+              { header: 'Median seconds', value: row => row.median_seconds },
+              { header: 'p90 seconds', value: row => row.p90_seconds },
+              { header: 'Sessions measured', value: row => row.measured },
+              { header: 'Finished sessions', value: row => row.sessions },
+              { header: 'Coverage %', value: row => row.coverage_pct },
+              { header: 'Long sessions', value: row => row.long_sessions },
+              { header: 'Long sessions %', value: row => row.long_sessions_pct },
+              { header: 'Single sitting', value: row => (row.single_sitting === null ? null : String(row.single_sitting)) },
+            ]}
+          />
+        </CardHeader>
+        <CardContent className="overflow-x-auto">
+          <table className="w-full text-sm">
+            {head}
+            <tbody>{renderRows(comparable, true)}</tbody>
+          </table>
+          {comparable.length === 0 && (
+            <p className="py-6 text-center text-sm text-gray-500 dark:text-gray-400">
+              No comparable games in this range.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      {longLived.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Long-lived sessions</CardTitle>
+            <CardDescription className="flex items-start gap-2">
+              <Info className="mt-0.5 size-3.5 shrink-0" />
+              <span>
+                A session in these games spans a day or more by design, so their length
+                isn't comparable with per-round games — listed separately rather than
+                ranked alongside them, where they'd win by definition.
+              </span>
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="overflow-x-auto">
+            <table className="w-full text-sm">
+              {head}
+              <tbody>{renderRows(longLived, false)}</tbody>
+            </table>
+          </CardContent>
+        </Card>
+      )}
+
+      {unsupported.length > 0 && (
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          No session length available for
+          {' '}
+          {unsupported.map(row => meta[row.game_type]?.label ?? row.game_type).join(' and ')}
+          {' — '}
+          {unsupported[0]?.reason}
+          .
+        </p>
+      )}
+    </div>
+  );
+}

--- a/components/reports/GameLeaderboard.tsx
+++ b/components/reports/GameLeaderboard.tsx
@@ -3,6 +3,7 @@
 import type { GameMetaMap } from '@/hooks/use-game-meta';
 import type { GameTotals, MetricKey } from '@/types/reports';
 import { ChevronDown, ChevronRight, Minus, TrendingDown, TrendingUp } from 'lucide-react';
+import Link from 'next/link';
 import { useState } from 'react';
 import { GameBadge } from '@/components/reports/GameBadge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -154,6 +155,14 @@ export function GameLeaderboard({ rows, meta, metric, selected, onSelect }: {
                       <dd className="font-medium tabular-nums text-gray-900 dark:text-white">{value}</dd>
                     </div>
                   ))}
+                  <div className="col-span-2 sm:col-span-3 lg:col-span-6">
+                    <Link
+                      href={`/reports/games/${row.game_type}`}
+                      className="text-sm font-medium text-emerald-700 hover:underline dark:text-emerald-400"
+                    >
+                      Open full report for this game →
+                    </Link>
+                  </div>
                 </dl>
               )}
             </div>

--- a/components/reports/ReportsNav.tsx
+++ b/components/reports/ReportsNav.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { BarChart3, Clock, Gamepad2, Repeat, Users } from 'lucide-react';
+import { BarChart3, Clock, Gamepad2, Repeat, Timer, Users } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { cn } from '@/lib/utils';
@@ -9,6 +9,7 @@ const TABS = [
   { href: '/reports', label: 'Daily Pulse', icon: BarChart3 },
   { href: '/reports/multiplayer', label: 'Multiplayer', icon: Gamepad2 },
   { href: '/reports/patterns', label: 'Patterns', icon: Clock },
+  { href: '/reports/duration', label: 'Session length', icon: Timer },
   { href: '/reports/players', label: 'Players', icon: Users },
   { href: '/reports/retention', label: 'Retention', icon: Repeat },
 ];

--- a/lib/__tests__/footballer-api.test.ts
+++ b/lib/__tests__/footballer-api.test.ts
@@ -1,12 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { apiFetcher } from '@/lib/api-fetcher';
+
 import { FootballerAPI } from '@/lib/footballer-api';
 
 // Mock the apiFetcher module
 vi.mock('@/lib/api-fetcher', () => ({
   apiFetcher: vi.fn(),
 }));
-
-import { apiFetcher } from '@/lib/api-fetcher';
 
 const mockApiFetcher = vi.mocked(apiFetcher);
 
@@ -52,10 +52,17 @@ describe('FootballerAPI — Position Methods', () => {
     it('calls GET with footballer query param', async () => {
       const mockPositions = [
         {
-          id: 10, footballer_id: 42, footballer_name: 'Lionel Messi',
-          position_id: 16, position_name: 'RW', position_full_name: 'Right Winger',
-          position_role: 'FWD', is_primary: true, sort_order: 0,
-          created_at: '2026-01-01', updated_at: '2026-01-01',
+          id: 10,
+          footballer_id: 42,
+          footballer_name: 'Lionel Messi',
+          position_id: 16,
+          position_name: 'RW',
+          position_full_name: 'Right Winger',
+          position_role: 'FWD',
+          is_primary: true,
+          sort_order: 0,
+          created_at: '2026-01-01',
+          updated_at: '2026-01-01',
         },
       ];
       mockApiFetcher.mockResolvedValue(mockPositions);
@@ -86,16 +93,30 @@ describe('FootballerAPI — Position Methods', () => {
       };
       const mockResponse = [
         {
-          id: 10, footballer_id: 42, footballer_name: 'Lionel Messi',
-          position_id: 16, position_name: 'RW', position_full_name: 'Right Winger',
-          position_role: 'FWD', is_primary: true, sort_order: 0,
-          created_at: '2026-01-01', updated_at: '2026-01-01',
+          id: 10,
+          footballer_id: 42,
+          footballer_name: 'Lionel Messi',
+          position_id: 16,
+          position_name: 'RW',
+          position_full_name: 'Right Winger',
+          position_role: 'FWD',
+          is_primary: true,
+          sort_order: 0,
+          created_at: '2026-01-01',
+          updated_at: '2026-01-01',
         },
         {
-          id: 11, footballer_id: 42, footballer_name: 'Lionel Messi',
-          position_id: 5, position_name: 'CF', position_full_name: 'Centre-Forward',
-          position_role: 'FWD', is_primary: false, sort_order: 1,
-          created_at: '2026-01-01', updated_at: '2026-01-01',
+          id: 11,
+          footballer_id: 42,
+          footballer_name: 'Lionel Messi',
+          position_id: 5,
+          position_name: 'CF',
+          position_full_name: 'Centre-Forward',
+          position_role: 'FWD',
+          is_primary: false,
+          sort_order: 1,
+          created_at: '2026-01-01',
+          updated_at: '2026-01-01',
         },
       ];
       mockApiFetcher.mockResolvedValue(mockResponse);

--- a/lib/__tests__/format-duration.test.ts
+++ b/lib/__tests__/format-duration.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { formatDuration } from '@/lib/format-duration';
+
+describe('formatDuration', () => {
+  it('picks a unit that stays readable across five orders of magnitude', () => {
+    // Real medians range from Avatar of Football's 12s to Conquest's 24h.
+    expect(formatDuration(12)).toBe('12s');
+    expect(formatDuration(312)).toBe('5.2m');
+    expect(formatDuration(3600 * 4.1)).toBe('4.1h');
+    expect(formatDuration(86_400)).toBe('1.0d');
+  });
+
+  it('drops the decimal once the number is big enough not to need it', () => {
+    expect(formatDuration(60 * 42)).toBe('42m');
+  });
+
+  it('renders null as a dash, never 0s', () => {
+    // 0s would read as "instant", not "not measured".
+    expect(formatDuration(null)).toBe('—');
+  });
+});

--- a/lib/__tests__/team-api.test.ts
+++ b/lib/__tests__/team-api.test.ts
@@ -1,16 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { apiFetcher } from '@/lib/api-fetcher';
+import { TeamAPI } from '@/lib/team-api';
+
 vi.mock('@/lib/api-fetcher', () => ({
   apiFetcher: vi.fn(),
 }));
-
-import { apiFetcher } from '@/lib/api-fetcher';
-import { TeamAPI } from '@/lib/team-api';
 
 const mockApiFetcher = vi.mocked(apiFetcher);
 
 describe('TeamAPI', () => {
   beforeEach(() => mockApiFetcher.mockReset());
+
   afterEach(() => vi.restoreAllMocks());
 
   // ---- searchTeams ----------------------------------------------------
@@ -27,6 +28,7 @@ describe('TeamAPI', () => {
 
     it('returns [] without hitting the network for empty queries', async () => {
       const result = await TeamAPI.searchTeams('   ');
+
       expect(result).toEqual([]);
       expect(mockApiFetcher).not.toHaveBeenCalled();
     });
@@ -34,6 +36,7 @@ describe('TeamAPI', () => {
     it('encodes special characters in the query', async () => {
       mockApiFetcher.mockResolvedValue([]);
       await TeamAPI.searchTeams('Real Madrid & Co');
+
       expect(mockApiFetcher).toHaveBeenCalledWith(
         'data/team/search/?name=Real%20Madrid%20%26%20Co',
       );
@@ -45,9 +48,14 @@ describe('TeamAPI', () => {
   describe('getTeamPlayers', () => {
     const happy = {
       team: {
-        id: 7, name: 'AC Milan', nation_name: 'Italy', nation_short: 'ITA',
-        founding_year: 1899, parent_team_name: null,
-        total_players: 100, total_managers: 20,
+        id: 7,
+        name: 'AC Milan',
+        nation_name: 'Italy',
+        nation_short: 'ITA',
+        founding_year: 1899,
+        parent_team_name: null,
+        total_players: 100,
+        total_managers: 20,
       },
       players: { count: 0, next: null, previous: null, results: [] },
     };
@@ -55,6 +63,7 @@ describe('TeamAPI', () => {
     it('builds /data/team/<id>/players/ with no params', async () => {
       mockApiFetcher.mockResolvedValue(happy);
       await TeamAPI.getTeamPlayers(7);
+
       expect(mockApiFetcher).toHaveBeenCalledWith('data/team/7/players/');
     });
 
@@ -62,16 +71,17 @@ describe('TeamAPI', () => {
       mockApiFetcher.mockResolvedValue(happy);
       await TeamAPI.getTeamPlayers(7, {
         role: 'player',
-        transfer_type: 'all',     // dropped
+        transfer_type: 'all', // dropped
         status: 'retired',
-        q: '',                    // dropped
+        q: '', // dropped
         ordering: '-start_year',
         page: 2,
         page_size: 50,
-        nation_id: undefined,     // dropped
+        nation_id: undefined, // dropped
       });
 
       const url = mockApiFetcher.mock.calls[0][0] as string;
+
       // Order is set by URLSearchParams insertion order; assert key/value pairs.
       expect(url.startsWith('data/team/7/players/?')).toBe(true);
       expect(url).toContain('role=player');
@@ -86,6 +96,7 @@ describe('TeamAPI', () => {
 
     it('propagates apiFetcher errors', async () => {
       mockApiFetcher.mockRejectedValueOnce(new Error('Forbidden — staff only.'));
+
       await expect(TeamAPI.getTeamPlayers(7)).rejects.toThrow('Forbidden — staff only.');
     });
   });

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -5,8 +5,8 @@
 //   2. `http://localhost:8000` when running `next dev` so the
 //      automation app talks to a local Django by default.
 //   3. The hosted prod API for production builds.
-const DEFAULT_API_BASE_URL =
-  process.env.NODE_ENV === 'development'
+const DEFAULT_API_BASE_URL
+  = process.env.NODE_ENV === 'development'
     ? 'http://localhost:8000'
     : 'https://api.extratime.world';
 

--- a/lib/footballer-api.ts
+++ b/lib/footballer-api.ts
@@ -16,8 +16,8 @@ import type {
   Position,
   SetPositionsRequest,
 } from '@/types/player';
-import config from '@/lib/config';
 import { apiFetcher } from '@/lib/api-fetcher';
+import config from '@/lib/config';
 
 /**
  * API service for Django footballer endpoints
@@ -288,7 +288,9 @@ export class FootballerAPI {
     onlyActive = false,
   ): Promise<FootballerPicture[]> {
     const params = new URLSearchParams({ footballer: String(footballerId) });
-    if (onlyActive) params.set('is_active', 'true');
+    if (onlyActive) {
+      params.set('is_active', 'true');
+    }
     return apiFetcher<FootballerPicture[]>(`data/footballer-pictures/?${params.toString()}`);
   }
 
@@ -322,8 +324,11 @@ export class FootballerAPI {
       let message = `HTTP ${response.status}: ${response.statusText} (POST data/footballer-pictures/)`;
       try {
         const data = await response.json();
-        if (typeof data?.detail === 'string') message = data.detail;
-        else if (typeof data?.error === 'string') message = data.error;
+        if (typeof data?.detail === 'string') {
+          message = data.detail;
+        } else if (typeof data?.error === 'string') {
+          message = data.error;
+        }
       } catch {
         // keep the default message
       }

--- a/lib/format-duration.ts
+++ b/lib/format-duration.ts
@@ -1,0 +1,25 @@
+/**
+ * Human-readable durations.
+ *
+ * Session lengths here span five orders of magnitude — Avatar of Football's
+ * median is 12 seconds, Conquest's is 24 hours — so a single unit is unreadable
+ * at one end or the other.
+ */
+export function formatDuration(seconds: number | null): string {
+  if (seconds === null) {
+    return '—';
+  }
+  if (seconds < 60) {
+    return `${Math.round(seconds)}s`;
+  }
+  if (seconds < 3600) {
+    const minutes = seconds / 60;
+    return `${minutes < 10 ? minutes.toFixed(1) : Math.round(minutes)}m`;
+  }
+  if (seconds < 86_400) {
+    const hours = seconds / 3600;
+    return `${hours < 10 ? hours.toFixed(1) : Math.round(hours)}h`;
+  }
+  const days = seconds / 86_400;
+  return `${days < 10 ? days.toFixed(1) : Math.round(days)}d`;
+}

--- a/lib/reports-api.ts
+++ b/lib/reports-api.ts
@@ -1,5 +1,6 @@
 import type {
   ActivityResponse,
+  DurationResponse,
   GamesResponse,
   MultiplayerResponse,
   PatternsResponse,
@@ -58,6 +59,11 @@ export class ReportsAPI {
    */
   static async getGames(): Promise<GamesResponse> {
     return apiFetcher<GamesResponse>('core/reporting/games/');
+  }
+
+  /** GET /core/reporting/duration/ — median session length per game. */
+  static async getDuration(params?: ReportParams): Promise<DurationResponse> {
+    return apiFetcher<DurationResponse>(`core/reporting/duration/${buildQuery(params)}`);
   }
 
   /** GET /core/reporting/patterns/ — when people play + new vs returning. */

--- a/lib/team-api.ts
+++ b/lib/team-api.ts
@@ -1,14 +1,18 @@
-import { apiFetcher } from '@/lib/api-fetcher';
 import type {
   TeamPlayersParams,
   TeamPlayersResponse,
   TeamSearchResult,
 } from '@/types/team';
+import { apiFetcher } from '@/lib/api-fetcher';
 
-/** Build a `?key=value&...` string from a params object, dropping `undefined`,
- *  `null`, the literal string `'all'`, and empty strings. */
+/**
+ * Build a `?key=value&...` string from a params object, dropping `undefined`,
+ *  `null`, the literal string `'all'`, and empty strings.
+ */
 function buildQuery(params: Record<string, unknown> | undefined): string {
-  if (!params) return '';
+  if (!params) {
+    return '';
+  }
   const search = new URLSearchParams();
   for (const [key, value] of Object.entries(params)) {
     if (value === undefined || value === null || value === '' || value === 'all') {
@@ -34,7 +38,9 @@ export class TeamAPI {
   /** GET /data/team/search/?name=<query> */
   static async searchTeams(name: string): Promise<TeamSearchResult[]> {
     const query = name.trim();
-    if (!query) return [];
+    if (!query) {
+      return [];
+    }
     return apiFetcher<TeamSearchResult[]>(
       `data/team/search/?name=${encodeURIComponent(query)}`,
     );

--- a/types/player.ts
+++ b/types/player.ts
@@ -176,8 +176,10 @@ export type CreateFootballerRequest = {
   additional_info?: string | null;
 };
 
-/** Fields the bulk-update endpoint accepts. Subset of CreateFootballerRequest
- *  — admin-tweakable flags, no identity / DoB / nation. */
+/**
+ * Fields the bulk-update endpoint accepts. Subset of CreateFootballerRequest
+ *  — admin-tweakable flags, no identity / DoB / nation.
+ */
 export type FootballerBulkUpdates = Partial<{
   status: FootballerStatus;
   retired: boolean;

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -25,14 +25,9 @@ export type Coverage = {
 
 export type ActivityResponse = {
   coverage: Coverage;
-  start: string;
-  end: string;
-  window: number;
-  game_type: string | null;
-  include_bots: boolean;
   totals: ActivityMetrics;
   series: ActivityDay[];
-};
+} & ResolvedRange;
 
 /** One headline metric: today, against the same-weekday baseline. */
 export type PulseMetric = {
@@ -266,4 +261,30 @@ export type RetentionResponse = {
   offsets: number[];
   summary: Record<string, RetentionSummaryCell>;
   cohorts: RetentionCohort[];
+} & ResolvedRange;
+
+export type DurationRow = {
+  game_type: string;
+  /** False when the game records no session end time at all. */
+  supported: boolean;
+  reason: string | null;
+  sessions: number;
+  measured: number;
+  /** Share of finished sessions that could be measured — varies 69%-100%. */
+  coverage_pct: number | null;
+  median_seconds: number | null;
+  p90_seconds: number | null;
+  long_sessions: number;
+  long_sessions_pct: number | null;
+  /** False for campaign-shaped games whose "session" spans a day, not a sitting. */
+  single_sitting: boolean | null;
+};
+
+export type DurationResponse = {
+  long_session_seconds: number;
+  games_without_duration: string[];
+  long_lived_session_games: string[];
+  /** Longest among comparable games only — a campaign game would win by default. */
+  longest_single_sitting_game: string | null;
+  rows: DurationRow[];
 } & ResolvedRange;

--- a/types/team.ts
+++ b/types/team.ts
@@ -23,7 +23,7 @@ export type TransferType = 'permanent' | 'loan';
 export type CareerPathDifficulty = 'EASY' | 'NORMAL' | 'HARD' | 'EXTREME';
 
 export type TeamPlayerRow = {
-  id: number;            // FootballerTeam (stint) id
+  id: number; // FootballerTeam (stint) id
   footballer_id: number;
   full_name: string;
   nation_id: number | null;
@@ -55,11 +55,11 @@ export type RoleFilter = PlayerRole | 'all';
 export type TransferFilter = TransferType | 'all';
 export type StatusFilter = 'active' | 'retired' | 'all';
 
-export type TeamPlayersOrdering =
-  | 'start_year' | '-start_year'
-  | 'full_name' | '-full_name'
-  | 'apps' | '-apps'
-  | 'goals' | '-goals';
+export type TeamPlayersOrdering
+  = | 'start_year' | '-start_year'
+    | 'full_name' | '-full_name'
+    | 'apps' | '-apps'
+    | 'goals' | '-goals';
 
 export type TeamPlayersParams = {
   role?: RoleFilter;


### PR DESCRIPTION
Clears the UI debt for App [#1437](https://github.com/FootballExtraTime/App/pull/1437) and adds the per-game view.

## `/reports/duration` — two tables, not one ranking

Conquest's median is **24 hours** because a session there is a day-long campaign. Team Ties' is **5 minutes** because a session is a sitting. A single ranking would read as *"Conquest holds attention 280× better"*, which is not what the number means.

So long-lived games get their own table with that explanation, and games with no end time at all (Quiz, MissingTeam) **say so** rather than showing zeroes.

**Coverage below 90% is highlighted amber** — CareerPath measures 68.8% of its sessions, and a partial sample sitting next to a complete one invites an invalid comparison.

## `/reports/games/[key]` — one game, everything

Period comparison · completion · repeat rate · sessions per player · share of platform · activity chart in the game's own colour · its session length · its top ten players, each linking through to their own report.

Reached from the expanded row in the games leaderboard, so the drill-down path is now: **all games → one game → one player**.

## `formatDuration`

Real medians span **12 seconds to 24 hours** — five orders of magnitude — so any single unit is unreadable at one end. It picks per value and drops the decimal once the number no longer needs it.

Null renders as `—`, never `0s`: *"instant"* and *"not measured"* are different claims.

## A stale type this surfaced

`ActivityResponse` still hand-declared its range fields and was missing `days` — the same drift `SummaryResponse` had in #36. It now extends `ResolvedRange` like the rest, so the next backend field arrives everywhere at once instead of one response at a time.

## Verification

| Check | Result |
|---|---|
| `eslint` | clean |
| `tsc --noEmit` | no new errors |
| `vitest run` | **225 tests** (3 new) |
| `next build` | all **8** report routes |