### PR TITLE
feat(reports): anomalies panel at the top of the Daily Pulse

### DIFF
--- a/app/reports/page.tsx
+++ b/app/reports/page.tsx
@@ -3,6 +3,7 @@
 import type { GameTotals } from '@/types/reports';
 import { useMemo } from 'react';
 import { ActivityChart } from '@/components/reports/ActivityChart';
+import { AnomalyPanel } from '@/components/reports/AnomalyPanel';
 import { ExportButton } from '@/components/reports/ExportButton';
 import { GameBadge } from '@/components/reports/GameBadge';
 import { GameLeaderboard } from '@/components/reports/GameLeaderboard';
@@ -49,6 +50,9 @@ export default function ReportsPage() {
   const summary = useReport(ReportsAPI.getSummary, params, enabled, 'The reporting summary endpoint');
   const allGames = useReport(ReportsAPI.getSummary, allGamesParams, enabled, 'The reporting summary endpoint');
   const activity = useReport(ReportsAPI.getActivity, params, enabled, 'The reporting activity endpoint');
+  // Unfiltered on purpose: "what needs attention" must surface a game you
+  // haven't selected, which is exactly the one you'd otherwise miss.
+  const anomalies = useReport(ReportsAPI.getAnomalies, allGamesParams, enabled, 'The anomalies reporting endpoint');
 
   const selectedLabel = game ? (meta[game]?.label ?? game) : null;
 
@@ -73,6 +77,8 @@ export default function ReportsPage() {
           <GameBadge gameKey={game} meta={meta} active onClick={() => update({ game: null })} />
         </div>
       )}
+
+      {anomalies.data && <AnomalyPanel data={anomalies.data} meta={meta} />}
 
       {summary.error
         ? <ReportError error={summary.error} notDeployed={summary.notDeployed} onRetry={summary.refetch} />

--- a/components/reports/AnomalyPanel.tsx
+++ b/components/reports/AnomalyPanel.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import type { GameMetaMap } from '@/hooks/use-game-meta';
+import type { AnomaliesResponse } from '@/types/reports';
+import { AlertTriangle, ArrowDownRight, ArrowUpRight, Check, HelpCircle } from 'lucide-react';
+import Link from 'next/link';
+import { GameBadge } from '@/components/reports/GameBadge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+/**
+ * "What needs attention" — the first thing on the page.
+ *
+ * Everything here is derivable from the panels below it; the point is that
+ * nobody scans eleven games looking for the one that moved. Placing it anywhere
+ * other than the top would defeat that.
+ */
+export function AnomalyPanel({ data, meta }: { data: AnomaliesResponse; meta: GameMetaMap }) {
+  const { findings, coverage, thresholds } = data;
+
+  // "Nothing moved" and "we couldn't tell" look identical as an empty list, so
+  // they get different treatments.
+  if (findings.length === 0) {
+    return (
+      <Card>
+        <CardContent className="flex items-start gap-3 p-4">
+          {coverage.complete
+            ? <Check className="mt-0.5 size-5 shrink-0 text-emerald-600" />
+            : <HelpCircle className="mt-0.5 size-5 shrink-0 text-amber-600" />}
+          <div>
+            <p className="font-medium text-gray-900 dark:text-white">
+              {coverage.complete ? 'Nothing unusual' : 'Not enough data to tell'}
+            </p>
+            <p className="text-sm text-gray-600 dark:text-gray-300">
+              {coverage.complete
+                ? `No game moved more than ${thresholds.min_change_pct}% against the previous ${data.window_days} days, above ${thresholds.min_volume} sessions.`
+                : `${coverage.missing_days.length} day(s) in this comparison were never computed, so a quiet result here can't be trusted. Run the reporting backfill.`}
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <AlertTriangle className="size-5 text-amber-600" />
+          Needs attention
+          <span className="text-sm font-normal text-gray-500 dark:text-gray-400">
+            {`(${findings.length})`}
+          </span>
+        </CardTitle>
+        <CardDescription>
+          Compared with
+          {' '}
+          {data.compared_with.start}
+          {' → '}
+          {data.compared_with.end}
+          {`. Only moves over ${thresholds.min_change_pct}% on at least ${thresholds.min_volume} sessions are listed — smaller swings are ordinary variation.`}
+          {!coverage.complete && ' Some days in this comparison were never computed, so this list may be incomplete.'}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {findings.map((finding) => {
+          const up = (finding.change_pct ?? 0) > 0;
+          const Icon = finding.change_pct === null ? AlertTriangle : up ? ArrowUpRight : ArrowDownRight;
+          return (
+            <div
+              key={`${finding.scope}-${finding.game_type}-${finding.metric}`}
+              className={cn(
+                'flex flex-wrap items-start gap-3 rounded-md border p-3',
+                finding.severity === 'high'
+                  ? 'border-amber-300 bg-amber-50 dark:border-amber-800 dark:bg-amber-900/20'
+                  : 'border-gray-200 dark:border-slate-700',
+              )}
+            >
+              <Icon
+                className={cn(
+                  'mt-0.5 size-4 shrink-0',
+                  finding.change_pct === null
+                    ? 'text-amber-600'
+                    : up
+                      ? 'text-emerald-600 dark:text-emerald-400'
+                      : 'text-red-600 dark:text-red-400',
+                )}
+              />
+              <div className="min-w-0 flex-1">
+                <p className="font-medium text-gray-900 dark:text-white">{finding.headline}</p>
+                <p className="text-sm text-gray-600 dark:text-gray-300">{finding.detail}</p>
+              </div>
+              {finding.game_type && (
+                <div className="flex items-center gap-2">
+                  <GameBadge gameKey={finding.game_type} meta={meta} />
+                  <Link
+                    href={`/reports/games/${finding.game_type}`}
+                    className="whitespace-nowrap text-sm font-medium text-emerald-700 hover:underline dark:text-emerald-400"
+                  >
+                    Investigate →
+                  </Link>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/reports/__tests__/AnomalyPanel.test.tsx
+++ b/components/reports/__tests__/AnomalyPanel.test.tsx
@@ -1,0 +1,76 @@
+import type { AnomaliesResponse } from '@/types/reports';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { AnomalyPanel } from '@/components/reports/AnomalyPanel';
+
+const META = { grid: { key: 'grid', label: 'Grid', color: '#10b981' } };
+
+function build(overrides: Partial<AnomaliesResponse> = {}): AnomaliesResponse {
+  return {
+    start: '2026-08-01',
+    end: '2026-08-14',
+    days: 14,
+    game_type: null,
+    include_bots: false,
+    window_days: 14,
+    compared_with: { start: '2026-07-18', end: '2026-07-31' },
+    thresholds: { min_volume: 30, min_change_pct: 25, severe_change_pct: 50 },
+    coverage: { complete: true, missing_days: [] },
+    findings: [],
+    ...overrides,
+  };
+}
+
+describe('anomalyPanel', () => {
+  // The bug this class of test exists to stop: an empty list rendering as
+  // reassurance when the real reason is that the days were never computed.
+  it('does not claim things are fine when the data is incomplete', () => {
+    render(
+      <AnomalyPanel
+        data={build({ coverage: { complete: false, missing_days: ['2026-08-03'] } })}
+        meta={META}
+      />,
+    );
+
+    expect(screen.queryByText(/nothing unusual/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/not enough data to tell/i)).toBeInTheDocument();
+  });
+
+  it('says nothing is wrong only when the window is fully computed', () => {
+    render(<AnomalyPanel data={build()} meta={META} />);
+
+    expect(screen.getByText(/nothing unusual/i)).toBeInTheDocument();
+  });
+
+  it('warns that a findings list may be incomplete when days are missing', () => {
+    render(
+      <AnomalyPanel
+        data={build({
+          coverage: { complete: false, missing_days: ['2026-08-03'] },
+          findings: [{
+            scope: 'game',
+            game_type: 'grid',
+            metric: 'games_started',
+            change_pct: -47,
+            current: 637,
+            previous: 1203,
+            severity: 'medium',
+            headline: 'Grid down 47.0%',
+            detail: '637 games started, down from 1,203.',
+          }],
+        })}
+        meta={META}
+      />,
+    );
+
+    expect(screen.getByText(/may be incomplete/i)).toBeInTheDocument();
+  });
+
+  it('surfaces the thresholds so a reader knows what was filtered out', () => {
+    render(<AnomalyPanel data={build()} meta={META} />);
+
+    // Without these numbers, "nothing unusual" is an unfalsifiable claim.
+    expect(screen.getByText(/25%/)).toBeInTheDocument();
+    expect(screen.getByText(/30 sessions/)).toBeInTheDocument();
+  });
+});

--- a/lib/reports-api.ts
+++ b/lib/reports-api.ts
@@ -1,5 +1,6 @@
 import type {
   ActivityResponse,
+  AnomaliesResponse,
   DurationResponse,
   GamesResponse,
   MultiplayerResponse,
@@ -59,6 +60,11 @@ export class ReportsAPI {
    */
   static async getGames(): Promise<GamesResponse> {
     return apiFetcher<GamesResponse>('core/reporting/games/');
+  }
+
+  /** GET /core/reporting/anomalies/ — what moved enough to be worth attention. */
+  static async getAnomalies(params?: ReportParams): Promise<AnomaliesResponse> {
+    return apiFetcher<AnomaliesResponse>(`core/reporting/anomalies/${buildQuery(params)}`);
   }
 
   /** GET /core/reporting/duration/ — median session length per game. */

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -288,3 +288,30 @@ export type DurationResponse = {
   longest_single_sitting_game: string | null;
   rows: DurationRow[];
 } & ResolvedRange;
+
+export type AnomalyFinding = {
+  scope: 'platform' | 'game';
+  game_type: string | null;
+  metric: string;
+  /** Null for findings that aren't a change (e.g. a low completion rate). */
+  change_pct: number | null;
+  current: number;
+  previous: number | null;
+  severity: 'high' | 'medium';
+  headline: string;
+  detail: string;
+};
+
+export type AnomaliesResponse = {
+  window_days: number;
+  compared_with: { start: string; end: string };
+  /** Returned so a reader can see what was filtered out, not just what survived. */
+  thresholds: {
+    min_volume: number;
+    min_change_pct: number;
+    severe_change_pct: number;
+  };
+  /** Lets an empty list mean "nothing moved" rather than "we couldn't tell". */
+  coverage: { complete: boolean; missing_days: string[] };
+  findings: AnomalyFinding[];
+} & ResolvedRange;


### PR DESCRIPTION
Consumes the `/core/reporting/anomalies/` endpoint from [App #1438](https://github.com/FootballExtraTime/App/pull/1438) — merge that first.

## Why it's at the top

Everything this panel shows is derivable from the panels below it. The value isn't the data, it's that **nobody scans eleven games looking for the one that moved**. Placed anywhere other than first, it would be a page you visit after you already suspect something — which is exactly when you don't need it.

## Two decisions worth reviewing

**It ignores the page's game filter.** If you're filtered to Grid, the game you most need to hear about is the one you *didn't* select. A filtered attention panel can only ever confirm what you already suspected.

**An empty list is ambiguous, so it isn't rendered as one thing.** "No game moved more than 25%" is reassurance. "We never computed 3 of these days" is not — and rendering them identically converts a data gap into a false all-clear, which is worse than showing nothing. Different icon, colour and wording; a *non-empty* list carries the same warning when coverage is partial, because a partial window can hide findings too.

Thresholds are rendered rather than hidden in the backend, so the quiet state says what it actually checked (">25% on at least 30 sessions") instead of asking you to trust it.

## Guard

4 tests, mutation-verified: stubbing coverage to always-complete fails 2 of them. Without that check the tests would have passed either way.

229 FE tests pass · lint + tsc clean.