### PR TITLE
fix(reports): compile-time guard so response types can't drift from the BE echo

### DIFF
--- a/components/reports/__tests__/AnomalyPanel.test.tsx
+++ b/components/reports/__tests__/AnomalyPanel.test.tsx
@@ -10,6 +10,7 @@ function build(overrides: Partial<AnomaliesResponse> = {}): AnomaliesResponse {
     start: '2026-08-01',
     end: '2026-08-14',
     days: 14,
+    window: 14,
     game_type: null,
     include_bots: false,
     window_days: 14,

--- a/lib/api-fetcher.ts
+++ b/lib/api-fetcher.ts
@@ -11,7 +11,6 @@ type ApiOptions = {
  * `as MyResponse` cast. Defaults to `any` to preserve the previous
  * behaviour for untyped callers — new code should pass an explicit `T`.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function apiFetcher<T = any>(url: string, options: ApiOptions = {}): Promise<T> {
   const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
   const refreshToken = typeof window !== 'undefined' ? localStorage.getItem('refresh_token') : null;

--- a/types/reports.guard.ts
+++ b/types/reports.guard.ts
@@ -1,0 +1,72 @@
+import type { ReportsAPI } from '@/lib/reports-api';
+/**
+ * Compile-time guard: every range-filtered reporting response must carry the
+ * full filter echo the backend sends.
+ *
+ * This exists because the same bug happened three times: a response type
+ * hand-declares `start`/`end`/`window`/... instead of composing `ResolvedRange`,
+ * the backend adds a field to `as_payload()`, and the copy quietly rots. It
+ * fails open — the UI reads a field that is typed as absent, so nothing errors,
+ * it just silently can't be used.
+ *
+ * The list is DERIVED from `ReportsAPI` rather than written out, because a
+ * hand-maintained list of "types to check" is the same debt in a new place.
+ * Any method taking `ReportParams` is range-filtered by definition, so a new
+ * endpoint is covered the moment it is added — nobody has to remember this file.
+ *
+ * There is nothing to run: `npm run check-types` fails if it regresses.
+ */
+import type { ReportParams, ResolvedRange, WindowEcho } from '@/types/reports';
+
+/** The response of `T`, but only if `T` accepts `ReportParams`. */
+type RangeFilteredResponse<T>
+  = T extends (...args: any[]) => Promise<infer Response>
+    ? ReportParams extends Parameters<T>[number] ? Response : never
+    : never;
+
+/**
+ * Endpoints that legitimately echo less than the full filter set, with the
+ * reason. Typed as a record so adding one is a deliberate, reviewed act rather
+ * than something that can drift in — and every entry still has to satisfy
+ * `WindowEcho` below, so an exemption narrows the check without removing it.
+ */
+type DocumentedExemptions = {
+  /**
+   * Scoped to one user; `game_type`/`include_bots` don't apply and the BE
+   *  deliberately doesn't echo them (they'd read as accepted-but-ignored).
+   */
+  getPlayerDetail: 'scoped to a single user, no game/bot filter to echo';
+};
+
+/**
+ * The method names whose response is missing part of the range echo.
+ *
+ * Built as a key-remapped type rather than a union of responses so the compiler
+ * error names the offenders ("getMultiplayer" | "getTopPlayers") instead of
+ * saying a union isn't assignable and leaving you to find which member.
+ */
+type MethodsMissingRangeEcho = keyof {
+  [K in keyof typeof ReportsAPI as
+  K extends keyof DocumentedExemptions
+    ? never
+    : RangeFilteredResponse<(typeof ReportsAPI)[K]> extends ResolvedRange ? never : K
+  ]: true;
+};
+
+/** No exemption may skip the window echo — that part applies to every endpoint. */
+type MethodsMissingWindowEcho = keyof {
+  [K in keyof typeof ReportsAPI as
+  RangeFilteredResponse<(typeof ReportsAPI)[K]> extends WindowEcho ? never : K
+  ]: true;
+};
+
+/** Applies to exempt endpoints too, so an exemption can't become a blank cheque. */
+export const WINDOW_ECHO_IS_COMPLETE: never
+  = undefined as unknown as MethodsMissingWindowEcho;
+
+/**
+ * The assertion: no method may be missing the echo. If one is, this fails to
+ * compile with the method name in the error.
+ */
+export const RANGE_ECHO_IS_COMPLETE: never
+  = undefined as unknown as MethodsMissingRangeEcho;

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -112,17 +112,12 @@ export type MultiplayerModeRow = {
 };
 
 export type MultiplayerResponse = {
-  start: string;
-  end: string;
-  window: number;
-  game_type: string | null;
-  include_bots: boolean;
   /** Always 'rooms' — a reminder this is a different grain from mp_player_sessions. */
   grain: string;
   totals: Omit<MultiplayerGameRow, 'game_type'>;
   by_game: MultiplayerGameRow[];
   by_mode: MultiplayerModeRow[];
-};
+} & ResolvedRange;
 
 export type TopPlayer = {
   user_id: number;
@@ -134,14 +129,9 @@ export type TopPlayer = {
 };
 
 export type TopPlayersResponse = {
-  start: string;
-  end: string;
-  window: number;
-  game_type: string | null;
-  include_bots: boolean;
   limit: number;
   players: TopPlayer[];
-};
+} & ResolvedRange;
 
 /** Windows the BE accepts (ALLOWED_WINDOWS in core/reporting_views.py). */
 export const REPORT_WINDOWS = [7, 10, 15, 30, 60, 90] as const;
@@ -158,7 +148,18 @@ export type ReportParams = {
   limit?: number;
 };
 
-/** Filter echo every reporting response carries. */
+/**
+ * The part of the echo every range-filtered response carries, including the
+ * player drill-down (which has no game/bot filter to echo back).
+ */
+export type WindowEcho = {
+  start: string;
+  end: string;
+  days: number;
+  window: number;
+};
+
+/** Filter echo every game-filtered reporting response carries. */
 export type ResolvedRange = {
   start: string;
   end: string;
@@ -198,10 +199,6 @@ export type PlayerDetailResponse = {
   username: string;
   is_bot: boolean;
   date_joined: string;
-  start: string;
-  end: string;
-  days: number;
-  window: number;
   totals: {
     games_played: number;
     games_finished: number;
@@ -214,7 +211,7 @@ export type PlayerDetailResponse = {
   favourite_game: string | null;
   by_game: PlayerGameRow[];
   series: { date: string; games_started: number; games_finished: number }[];
-};
+} & WindowEcho;
 
 /** Display metadata from the BE registry — the single source of truth for colours. */
 export type GameMeta = {


### PR DESCRIPTION
Third time is a pattern, so this fixes the class rather than the instance.

## The drift

Response types that hand-declare `start`/`end`/`window`/… instead of composing `ResolvedRange` rot when the backend adds a field. Going looking, **two were already drifted**: `MultiplayerResponse` and `TopPlayersResponse` both omit `days`, which `as_payload()` has been sending all along.

It **fails open**, which is exactly why it keeps recurring — the field arrives at runtime, the UI simply can't read it, nothing throws, no test notices.

## The guard

`types/reports.guard.ts` — no test to run, `npm run check-types` fails.

The list of types to check is **derived from `ReportsAPI`**, not written down: any method accepting `ReportParams` is range-filtered by definition, so a new endpoint is covered the moment it exists. A hand-maintained list of "types to remember to check" would be the same debt wearing a different hat.

It's a key-remapped type rather than a union assignment so the error **names the method** (`"getMultiplayer" | "getTopPlayers"`) instead of reporting that some union member didn't fit and leaving you to bisect.

## The one exemption

`getPlayerDetail` legitimately echoes less — scoped to a single user, so `game_type`/`include_bots` don't apply, and the BE deliberately omits them because echoing an accepted-but-ignored filter is [what Copilot caught in #1434](https://github.com/FootballExtraTime/App/pull/1434). It's exempted **in the type, with the reason**, and still must satisfy `WindowEcho` — so an exemption narrows the check instead of voiding it.

## What this does NOT cover — worth knowing

Mutation testing found one case that doesn't fail: adding a field to `ResolvedRange` itself. That's structural — once a type *composes* `ResolvedRange`, it can't drift from it, which is the entire point.

But it means **`ResolvedRange` matching the backend's `as_payload()` is still enforced by a human**. Closing that needs a BE-side test pinning the key set with a pointer to this type; filing that next. I'd rather state the remaining gap than let the guard imply more coverage than it has.

Verified: re-hand-declaring a range fails by name; letting the exempt endpoint drop `WindowEcho` fails by name.

Also removes two `eslint-disable` directives for a rule this config doesn't enable — one pre-existing in `api-fetcher.ts` that **errors on any full-repo lint**, invisible because lint-staged only sees staged files.

229 tests · lint + tsc clean. Touches `types/reports.ts` alongside #38 — merge that first and I'll rebase.