### PR TITLE
chore: gate typechecking so type errors stop reaching production

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -7,4 +7,5 @@
 set -e
 
 npx lint-staged
+npm run check-types:app
 npm run test:run

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "next build",
     "start": "next start",
     "check-types": "tsc --noEmit",
+    "check-types:app": "node scripts/check-types.mjs",
     "type-check": "npm run check-types",
     "lint": "next lint",
     "test": "vitest",

--- a/scripts/check-types.mjs
+++ b/scripts/check-types.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+/**
+ * Typecheck gate for first-party code.
+ *
+ * `tsc --noEmit` can't be gated directly: the v0-generated components in
+ * components/ui/ carry 15 pre-existing errors from library version drift
+ * (react-resizable-panels, recharts). Because the whole check was red, nothing
+ * ran it on commit — and a type error in reporting code reached production,
+ * since vitest doesn't typecheck and Next excludes tests from the build.
+ *
+ * So this reports every error outside the ignored paths and fails on them.
+ * It's path-scoped, not a blanket suppression: fix a file under components/ui
+ * and the ignore list shrinks. Ignored-path errors are still counted and
+ * printed, so the debt stays visible rather than quietly becoming permanent.
+ */
+import { spawnSync } from 'node:child_process';
+
+/** Generated/vendored code we don't hand-edit. Keep this list shrinking. */
+const IGNORED_PREFIXES = ['components/ui/'];
+
+const result = spawnSync('npx', ['tsc', '--noEmit', '--pretty', 'false'], {
+  encoding: 'utf8',
+  shell: process.platform === 'win32',
+});
+
+const stdout = result.stdout || '';
+
+const errors = (stdout || '').split('\n').filter(line => / error TS\d+:/.test(line));
+const ours = errors.filter(line => !IGNORED_PREFIXES.some(prefix => line.startsWith(prefix)));
+const ignored = errors.length - ours.length;
+
+if (ignored > 0) {
+  console.warn(`note: ${ignored} pre-existing error(s) in ${IGNORED_PREFIXES.join(', ')} — not gated, still owed.`);
+}
+
+// A gate that can't run must fail, not pass quietly. Without this, anything
+// that stops tsc producing output (missing binary, OOM, a config error) reads
+// as zero errors — which is the exact fail-open shape this gate exists to stop.
+if (result.error || (result.status !== 0 && errors.length === 0)) {
+  console.error('Could not run tsc, so types are unverified — failing closed.');
+  if (result.error) console.error(String(result.error));
+  if (result.stderr) console.error(result.stderr);
+  process.exit(1);
+}
+
+if (ours.length > 0) {
+  console.error(`\n${ours.length} type error(s):\n`);
+  for (const line of ours) console.error(`  ${line}`);
+  process.exit(1);
+}
+
+console.log('Types OK.');


### PR DESCRIPTION
One did, in my own reporting work — this closes the hole that let it.

## What happened

`AnomaliesResponse` composes `ResolvedRange`, which includes `window`. The test fixture I added in #38 omitted it. It merged anyway, because **no stage in the pipeline typechecks**:

| Stage | Typechecks? |
|---|---|
| lint-staged (eslint) | no |
| pre-commit vitest | no — vitest strips types, doesn't check them |
| Vercel build | no — Next excludes test files |

`npm run check-types` would have caught it instantly. Nobody runs it, because it's been red for a while.

## Why it's been red

`components/ui/` carries **15 pre-existing errors** — v0-generated shadcn components drifted against `react-resizable-panels` and `recharts`. A check that's always red is a check nobody can gate on, so the whole thing went unenforced and the vendored debt quietly took first-party code down with it.

## The gate

`scripts/check-types.mjs` → `npm run check-types:app`, wired into pre-commit. Runs in ~1.3s.

**Path-scoped, not suppressed.** Errors under `components/ui/` aren't gated but are still counted and printed on every run, so the debt stays visible instead of becoming permanent. Fix one of those files and the ignore list shrinks. I deliberately didn't fix the 15 here — they're library-version work with nothing to do with reporting, and bundling them would make this unreviewable.

**It fails closed.** If anything stops `tsc` producing output — missing binary, OOM, bad config — it exits 1 rather than parsing zero errors and printing "Types OK". That's the same fail-open shape as the drift bug in #39, and it would have been easy to ship by accident; verified by pointing it at a nonexistent binary.

Verified against the real defect: on the pre-#39 tree the gate fails naming the exact file and line.

Next: the 15 `components/ui/` errors are worth their own PR.