### PR TITLE
feat(reports): weekday × hour heatmap on Patterns

### DIFF
--- a/app/reports/patterns/page.tsx
+++ b/app/reports/patterns/page.tsx
@@ -3,6 +3,7 @@
 import type { RangeState } from '@/lib/report-range';
 import { useMemo, useState } from 'react';
 import { Area, AreaChart, Bar, BarChart, CartesianGrid, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { ActivityHeatmap } from '@/components/reports/ActivityHeatmap';
 import { RangePicker } from '@/components/reports/RangePicker';
 import { ReportError } from '@/components/reports/ReportError';
 import { ReportsShell } from '@/components/reports/ReportsShell';
@@ -64,7 +65,18 @@ export default function PatternsPage() {
           ? <Skeleton className="h-96 w-full" />
           : (
               <>
-                <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-4">
+                  <Tile
+                    label="Busiest slot"
+                    value={data.peak_cell
+                      ? `${data.peak_cell.name.slice(0, 3)} ${String(data.peak_cell.hour).padStart(2, '0')}:00`
+                      : '—'}
+                    // The marginals give a different, wrong answer here — the
+                    // peak day and peak hour need not intersect at a busy cell.
+                    hint={data.peak_cell
+                      ? `${data.peak_cell.games_started.toLocaleString()} games · busiest single hour`
+                      : 'No activity in this window'}
+                  />
                   <Tile
                     label="Peak hour"
                     value={data.peak_hour === null ? '—' : `${String(data.peak_hour).padStart(2, '0')}:00`}
@@ -81,6 +93,16 @@ export default function PatternsPage() {
                     hint={quietestDay ? `${quietestDay.games_started.toLocaleString()} games` : '—'}
                   />
                 </div>
+
+                {/* Above the two bar charts: it answers the scheduling question
+                    they can only approximate, so reading them first would mean
+                    forming a wrong answer and then correcting it. */}
+                <ActivityHeatmap
+                  rows={data.by_hour_weekday}
+                  peakCell={data.peak_cell}
+                  busiest={data.busiest_cell_games}
+                  timezone={data.timezone}
+                />
 
                 <Card>
                   <CardHeader>

--- a/components/reports/ActivityHeatmap.tsx
+++ b/components/reports/ActivityHeatmap.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import type { HourWeekdayRow, PeakCell } from '@/types/reports';
+import { useMemo, useState } from 'react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+/** Every third hour, so the axis stays readable on a phone. */
+const HOUR_TICKS = [0, 3, 6, 9, 12, 15, 18, 21];
+
+/**
+ * Sessions by weekday × hour.
+ *
+ * The point of the grid over the two bar charts: a peak weekday and a peak hour
+ * don't have to intersect at a busy cell. On real data they don't — so "when is
+ * it busiest" is only answerable here.
+ */
+export function ActivityHeatmap({
+  rows,
+  peakCell,
+  busiest,
+  timezone,
+}: {
+  rows: HourWeekdayRow[];
+  peakCell: PeakCell | null;
+  busiest: number;
+  timezone: string;
+}) {
+  const [hovered, setHovered] = useState<{ row: HourWeekdayRow; hour: number } | null>(null);
+
+  const total = useMemo(
+    () => rows.reduce((sum, row) => sum + row.hours.reduce((a, b) => a + b, 0), 0),
+    [rows],
+  );
+
+  /**
+   * Square-root scale, not linear. Play is heavily peaked, so a linear ramp
+   * renders everything except the top few cells as near-empty and hides the
+   * shape of an ordinary week — which is the thing you're looking at.
+   */
+  function intensity(value: number) {
+    if (value <= 0 || busiest <= 0) {
+      return 0;
+    }
+    return Math.sqrt(value / busiest);
+  }
+
+  if (total === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>When people play</CardTitle>
+          <CardDescription>No activity in this window.</CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>When people play</CardTitle>
+        <CardDescription>
+          Sessions started by weekday and hour, in
+          {' '}
+          {timezone}
+          .
+          {peakCell
+            ? ` Busiest slot is ${peakCell.name} at ${String(peakCell.hour).padStart(2, '0')}:00 (${peakCell.games_started.toLocaleString()}).`
+            : ''}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto">
+          <div className="min-w-[520px]">
+            <div className="mb-1 flex pl-10">
+              {Array.from({ length: 24 }, (_, hour) => (
+                <div key={hour} className="flex-1 text-center text-[10px] text-gray-500 dark:text-gray-400">
+                  {HOUR_TICKS.includes(hour) ? String(hour).padStart(2, '0') : ''}
+                </div>
+              ))}
+            </div>
+
+            {rows.map(row => (
+              <div key={row.weekday} className="mb-0.5 flex items-center">
+                <div className="w-10 shrink-0 pr-1 text-right text-[11px] text-gray-600 dark:text-gray-300">
+                  {row.name.slice(0, 3)}
+                </div>
+                {row.hours.map((value, hour) => {
+                  const isPeak = peakCell?.weekday === row.weekday && peakCell?.hour === hour;
+                  return (
+                    <button
+                      type="button"
+                      // eslint-disable-next-line react/no-array-index-key
+                      key={hour}
+                      onMouseEnter={() => setHovered({ row, hour })}
+                      onMouseLeave={() => setHovered(null)}
+                      onFocus={() => setHovered({ row, hour })}
+                      onBlur={() => setHovered(null)}
+                      // Screen readers get the number outright; colour alone
+                      // carries no information here.
+                      aria-label={`${row.name} ${String(hour).padStart(2, '0')}:00 — ${value} sessions`}
+                      className={cn(
+                        'mx-px h-5 flex-1 rounded-[2px] transition-transform hover:scale-125',
+                        isPeak && 'ring-1 ring-emerald-500 ring-offset-1 dark:ring-offset-slate-900',
+                      )}
+                      style={{
+                        backgroundColor: value > 0
+                          ? `rgba(16, 185, 129, ${0.12 + intensity(value) * 0.88})`
+                          : undefined,
+                      }}
+                    />
+                  );
+                })}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="mt-3 flex flex-wrap items-center justify-between gap-2 text-xs text-gray-600 dark:text-gray-300">
+          <span className="min-h-4">
+            {hovered
+              ? `${hovered.row.name} ${String(hovered.hour).padStart(2, '0')}:00 — ${hovered.row.hours[hovered.hour].toLocaleString()} sessions`
+              : 'Hover a cell for the exact count.'}
+          </span>
+          <span className="flex items-center gap-1">
+            0
+            {[0.15, 0.4, 0.65, 1].map(step => (
+              <span
+                key={step}
+                className="size-3 rounded-[2px]"
+                style={{ backgroundColor: `rgba(16, 185, 129, ${0.12 + step * 0.88})` }}
+              />
+            ))}
+            {busiest.toLocaleString()}
+          </span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/reports/__tests__/ActivityHeatmap.test.tsx
+++ b/components/reports/__tests__/ActivityHeatmap.test.tsx
@@ -1,0 +1,74 @@
+import type { HourWeekdayRow } from '@/types/reports';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ActivityHeatmap } from '@/components/reports/ActivityHeatmap';
+
+/** Monday 09:00 = 6 is busiest; the peak day (Mon) x peak hour (20:00) cell holds 2. */
+const ROWS: HourWeekdayRow[] = [
+  { weekday: 1, name: 'Monday', hours: Array.from({ length: 24 }, (_, h) => (h === 9 ? 6 : h === 20 ? 2 : 0)) },
+  { weekday: 3, name: 'Wednesday', hours: Array.from({ length: 24 }, (_, h) => (h === 20 ? 5 : 0)) },
+];
+
+describe('activityHeatmap', () => {
+  it('names the busiest slot rather than leaving it to be read off the colours', () => {
+    render(
+      <ActivityHeatmap
+        rows={ROWS}
+        peakCell={{ weekday: 1, name: 'Monday', hour: 9, games_started: 6 }}
+        busiest={6}
+        timezone="Europe/Sofia"
+      />,
+    );
+
+    expect(screen.getByText(/Busiest slot is Monday at 09:00/)).toBeInTheDocument();
+  });
+
+  it('gives every cell an accessible count, so colour is never the only signal', () => {
+    render(<ActivityHeatmap rows={ROWS} peakCell={null} busiest={6} timezone="Europe/Sofia" />);
+
+    expect(screen.getByLabelText('Monday 09:00 — 6 sessions')).toBeInTheDocument();
+    // Quiet cells must be labelled too — a screen reader user can't see "empty".
+    expect(screen.getByLabelText('Wednesday 03:00 — 0 sessions')).toBeInTheDocument();
+    expect(screen.getAllByRole('button')).toHaveLength(48);
+  });
+
+  it('says there is no activity instead of drawing an all-blank grid', () => {
+    const empty: HourWeekdayRow[] = [
+      { weekday: 1, name: 'Monday', hours: Array.from({ length: 24 }, () => 0) },
+    ];
+
+    render(<ActivityHeatmap rows={empty} peakCell={null} busiest={0} timezone="Europe/Sofia" />);
+
+    expect(screen.getByText(/no activity in this window/i)).toBeInTheDocument();
+    expect(screen.queryAllByRole('button')).toHaveLength(0);
+  });
+
+  it('keeps ordinary cells visible against a heavy peak', () => {
+    // Play is heavily peaked: a linear ramp renders a cell at 10% of the peak at
+    // ~0.21 opacity, which reads as empty and hides the shape of a normal week.
+    // A compressive scale keeps it legible. This pins the property, not the
+    // exact curve — any scale that stays visible here passes.
+    const rows: HourWeekdayRow[] = [
+      { weekday: 1, name: 'Monday', hours: Array.from({ length: 24 }, (_, h) => (h === 0 ? 100 : h === 1 ? 10 : 0)) },
+    ];
+
+    render(<ActivityHeatmap rows={rows} peakCell={null} busiest={100} timezone="Europe/Sofia" />);
+
+    const ordinary = screen.getByLabelText('Monday 01:00 — 10 sessions');
+    const opacity = Number(/rgba\(16, 185, 129, ([\d.]+)\)/.exec(ordinary.getAttribute('style') ?? '')?.[1]);
+
+    expect(opacity).toBeGreaterThan(0.3);
+  });
+
+  it('does not divide by zero when the window is empty but rows are present', () => {
+    const rows: HourWeekdayRow[] = [
+      { weekday: 1, name: 'Monday', hours: Array.from({ length: 24 }, (_, h) => (h === 1 ? 1 : 0)) },
+    ];
+
+    // busiest of 0 is inconsistent with the rows, but a NaN opacity would render
+    // the grid invisible rather than fail loudly, so it must be handled.
+    expect(() =>
+      render(<ActivityHeatmap rows={rows} peakCell={null} busiest={0} timezone="Europe/Sofia" />),
+    ).not.toThrow();
+  });
+});

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -178,10 +178,34 @@ export type NewReturningRow = {
   total_players: number;
 };
 
+/**
+ * One weekday of the heatmap. `hours` is always 24 long — the BE sends it
+ *  dense so a gap can never be misread as a quiet hour.
+ */
+export type HourWeekdayRow = {
+  weekday: number;
+  name: string;
+  hours: number[];
+};
+
+export type PeakCell = {
+  weekday: number;
+  name: string;
+  hour: number;
+  games_started: number;
+};
+
 export type PatternsResponse = {
   timezone: string;
   by_hour: HourRow[];
   by_weekday: WeekdayRow[];
+  by_hour_weekday: HourWeekdayRow[];
+  /**
+   * Busiest single slot. Null when the window has no activity at all — the
+   *  argmax of an all-zero grid would otherwise render as a real finding.
+   */
+  peak_cell: PeakCell | null;
+  busiest_cell_games: number;
   peak_hour: number | null;
   peak_weekday: string | null;
   new_vs_returning: NewReturningRow[];


### PR DESCRIPTION
Consumes `by_hour_weekday` / `peak_cell` from [App #1441](https://github.com/FootballExtraTime/App/pull/1441) — merge that first.

## Placement

Above the two bar charts, because it answers the scheduling question they can only approximate. On real data the marginals point at **Thursday** and **15:00**; the busiest slot is **Tuesday 16:00**. Reading the bars first means forming a wrong answer and then having it corrected.

Also adds a **"Busiest slot"** tile next to "Peak hour" / "Busiest day" — the two existing tiles invite exactly the multiplication that doesn't work.

## Square-root colour scale

Play is heavily peaked. A linear ramp puts a cell at 10% of the peak at ~0.21 opacity — reads as empty, and hides the shape of an ordinary week, which is the thing you're actually looking at. Square root keeps it legible at ~0.40.

The test pins **the property** ("an ordinary cell stays visible against a heavy peak"), not the curve, so any compressive scale passes and this doesn't become a change-detector.

## Accessibility

Colour is the primary encoding, so every cell carries an `aria-label` with its count — **including the zeros**, since a screen reader user can't perceive "blank". Cells are focusable and the hover readout also fires on focus.

## Empty windows

Says "No activity in this window" rather than drawing an all-blank grid, which is visually indistinguishable from a rendering failure.

## Mutation-verified

| Mutation | Result |
|---|---|
| Remove `aria-label`s | fails |
| Draw blank grid instead of the message | fails |
| Linear instead of sqrt scale | fails (`0.208 > 0.3`) |

The scale test **only exists because mutation testing found nothing pinned it** — the first four tests all passed with the scale swapped.

234 tests · types clean.