### PR TITLE
feat(reports): games comparison index

### DIFF
--- a/app/reports/games/page.tsx
+++ b/app/reports/games/page.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import type { RangeState } from '@/lib/report-range';
+import type { GameSortKey } from '@/lib/report-sort';
+import type { GameTotals } from '@/types/reports';
+import { ArrowDown, ArrowUp } from 'lucide-react';
+import Link from 'next/link';
+import { useMemo, useState } from 'react';
+import { GameBadge } from '@/components/reports/GameBadge';
+import { RangePicker } from '@/components/reports/RangePicker';
+import { ReportError } from '@/components/reports/ReportError';
+import { ReportsShell } from '@/components/reports/ReportsShell';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useGameMeta } from '@/hooks/use-game-meta';
+import { useReport } from '@/hooks/use-report';
+import { useAuth } from '@/lib/auth';
+import { rangeToParams } from '@/lib/report-range';
+import { ReportsAPI } from '@/lib/reports-api';
+
+const COLUMNS: { key: GameSortKey; label: string; hint: string }[] = [
+  { key: 'games_started', label: 'Played', hint: 'Sessions started in the window' },
+  { key: 'completion_pct', label: 'Finished', hint: 'Share of started sessions that were completed' },
+  { key: 'sessions_per_player', label: 'Per player', hint: 'Sessions per distinct player — depth of engagement' },
+  { key: 'repeat_rate_pct', label: 'Came back', hint: 'Share of players who returned on another day' },
+  { key: 'trend_pct', label: 'Trend', hint: 'vs the immediately preceding window of equal length' },
+];
+
+/**
+ * Null means "not measurable", never zero — a game nobody played has no
+ *  completion rate, and rendering 0% would read as "everyone abandoned it".
+ */
+function num(value: number | null, suffix = '') {
+  return value === null ? '—' : `${value.toLocaleString()}${suffix}`;
+}
+
+export default function GamesIndexPage() {
+  const { isAuthenticated, user } = useAuth();
+  const enabled = isAuthenticated && !!(user?.is_staff || user?.is_superuser);
+
+  const [range, setRange] = useState<RangeState>({ window: 30 });
+  const [includeBots, setIncludeBots] = useState(false);
+  const [sortBy, setSortBy] = useState<GameSortKey>('games_started');
+
+  const params = useMemo(
+    () => ({ ...rangeToParams(range), include_bots: includeBots }),
+    [range, includeBots],
+  );
+
+  const { meta } = useGameMeta(enabled);
+  const { data, isLoading, error, notDeployed, refetch } = useReport(
+    ReportsAPI.getSummary,
+    params,
+    enabled,
+    'The reporting summary endpoint',
+  );
+
+  const rows = useMemo(() => {
+    if (!data) {
+      return [];
+    }
+    // Nulls sort last regardless of direction: a game with no measurable rate
+    // isn't "worst", it's unmeasured, and floating it to either end of a
+    // ranking makes a claim the data doesn't support.
+    return [...data.by_game].sort((a, b) => {
+      const left = a[sortBy];
+      const right = b[sortBy];
+      if (left === null && right === null) {
+        return 0;
+      }
+      if (left === null) {
+        return 1;
+      }
+      if (right === null) {
+        return -1;
+      }
+      return right - left;
+    });
+  }, [data, sortBy]);
+
+  return (
+    <ReportsShell
+      title="Games"
+      description="Every game side by side. Click one for its own report."
+    >
+      <RangePicker
+        value={range}
+        onChange={setRange}
+        includeBots={includeBots}
+        onIncludeBotsChange={setIncludeBots}
+      />
+
+      {error
+        ? <ReportError error={error} notDeployed={notDeployed} onRetry={refetch} />
+        : isLoading || !data
+          ? <Skeleton className="h-96 w-full" />
+          : (
+              <Card>
+                <CardHeader>
+                  <CardTitle>Comparison</CardTitle>
+                  <CardDescription>
+                    Sorted by
+                    {' '}
+                    {COLUMNS.find(column => column.key === sortBy)?.label.toLowerCase()}
+                    . Games with nothing to measure sort last rather than bottom —
+                    unmeasured is not the same as worst.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b text-left text-gray-600 dark:border-slate-700 dark:text-gray-300">
+                        <th className="py-2 pr-4 font-medium">Game</th>
+                        {COLUMNS.map(column => (
+                          <th key={column.key} className="py-2 pr-4 text-right font-medium">
+                            <button
+                              type="button"
+                              title={column.hint}
+                              onClick={() => setSortBy(column.key)}
+                              className={sortBy === column.key
+                                ? 'font-semibold text-emerald-700 dark:text-emerald-400'
+                                : 'hover:text-gray-900 dark:hover:text-white'}
+                            >
+                              {column.label}
+                            </button>
+                          </th>
+                        ))}
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {rows.map((row: GameTotals) => (
+                        <tr key={row.game_type} className="border-b last:border-0 dark:border-slate-700">
+                          <td className="py-2 pr-4">
+                            <Link href={`/reports/games/${row.game_type}`}>
+                              <GameBadge gameKey={row.game_type} meta={meta} />
+                            </Link>
+                          </td>
+                          <td className="py-2 pr-4 text-right font-medium text-gray-900 dark:text-white">
+                            {row.games_started.toLocaleString()}
+                          </td>
+                          <td className="py-2 pr-4 text-right">{num(row.completion_pct, '%')}</td>
+                          <td className="py-2 pr-4 text-right">{num(row.sessions_per_player)}</td>
+                          <td className="py-2 pr-4 text-right">{num(row.repeat_rate_pct, '%')}</td>
+                          <td className="py-2 pr-4 text-right">
+                            {row.trend_pct === null
+                              ? <span className="text-gray-400">—</span>
+                              : (
+                                  <span className={row.trend_pct >= 0
+                                    ? 'inline-flex items-center gap-1 text-emerald-600 dark:text-emerald-400'
+                                    : 'inline-flex items-center gap-1 text-red-600 dark:text-red-400'}
+                                  >
+                                    {row.trend_pct >= 0 ? <ArrowUp className="size-3" /> : <ArrowDown className="size-3" />}
+                                    {Math.abs(row.trend_pct).toLocaleString()}
+                                    %
+                                  </span>
+                                )}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                  {rows.length === 0 && (
+                    <p className="py-6 text-center text-sm text-gray-500 dark:text-gray-400">
+                      No game activity in this window.
+                    </p>
+                  )}
+                </CardContent>
+              </Card>
+            )}
+    </ReportsShell>
+  );
+}

--- a/components/reports/ReportsNav.tsx
+++ b/components/reports/ReportsNav.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { BarChart3, Clock, Gamepad2, Repeat, Timer, Users } from 'lucide-react';
+import { BarChart3, Clock, Gamepad2, LayoutGrid, Repeat, Timer, Users } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { cn } from '@/lib/utils';
 
 const TABS = [
   { href: '/reports', label: 'Daily Pulse', icon: BarChart3 },
+  { href: '/reports/games', label: 'Games', icon: LayoutGrid },
   { href: '/reports/multiplayer', label: 'Multiplayer', icon: Gamepad2 },
   { href: '/reports/patterns', label: 'Patterns', icon: Clock },
   { href: '/reports/duration', label: 'Session length', icon: Timer },

--- a/lib/__tests__/report-sort.test.ts
+++ b/lib/__tests__/report-sort.test.ts
@@ -1,0 +1,68 @@
+import type { GameTotals } from '@/types/reports';
+import { describe, expect, it } from 'vitest';
+import { sortGameTotals } from '@/lib/report-sort';
+
+function game(game_type: string, overrides: Partial<GameTotals> = {}): GameTotals {
+  return {
+    game_type,
+    games_started: 0,
+    games_finished: 0,
+    distinct_players: 0,
+    mp_player_sessions: 0,
+    completion_pct: null,
+    sessions_per_player: null,
+    share_pct: null,
+    repeat_players: 0,
+    repeat_rate_pct: null,
+    previous_games_started: 0,
+    trend_pct: null,
+    ...overrides,
+  } as GameTotals;
+}
+
+describe('sortGameTotals', () => {
+  it('ranks descending', () => {
+    const rows = [game('a', { games_started: 5 }), game('b', { games_started: 50 })];
+
+    expect(sortGameTotals(rows, 'games_started').map(r => r.game_type)).toEqual(['b', 'a']);
+  });
+
+  it('puts unmeasured games last, not bottom of the ranking', () => {
+    // The bug this prevents: a game nobody played has a null completion rate.
+    // Treating null as 0 ranks it below a genuinely abandoned game, asserting
+    // it is the worst performer when nothing was measured at all.
+    const rows = [
+      game('unplayed', { completion_pct: null }),
+      game('abandoned', { completion_pct: 3 }),
+      game('healthy', { completion_pct: 80 }),
+    ];
+
+    expect(sortGameTotals(rows, 'completion_pct').map(r => r.game_type))
+      .toEqual(['healthy', 'abandoned', 'unplayed']);
+  });
+
+  it('keeps unmeasured games last even when every measured value is negative', () => {
+    // A null must not drift above real values just because they're below zero.
+    const rows = [
+      game('unmeasured', { trend_pct: null }),
+      game('falling', { trend_pct: -60 }),
+      game('slipping', { trend_pct: -5 }),
+    ];
+
+    expect(sortGameTotals(rows, 'trend_pct').map(r => r.game_type))
+      .toEqual(['slipping', 'falling', 'unmeasured']);
+  });
+
+  it('does not mutate the input', () => {
+    const rows = [game('a', { games_started: 1 }), game('b', { games_started: 9 })];
+    sortGameTotals(rows, 'games_started');
+
+    expect(rows.map(r => r.game_type)).toEqual(['a', 'b']);
+  });
+
+  it('handles an all-null column without reordering arbitrarily', () => {
+    const rows = [game('a'), game('b'), game('c')];
+
+    expect(sortGameTotals(rows, 'repeat_rate_pct').map(r => r.game_type)).toEqual(['a', 'b', 'c']);
+  });
+});

--- a/lib/report-sort.ts
+++ b/lib/report-sort.ts
@@ -1,0 +1,29 @@
+import type { GameTotals } from '@/types/reports';
+
+export type GameSortKey
+  = 'games_started' | 'completion_pct' | 'trend_pct' | 'repeat_rate_pct' | 'sessions_per_player';
+
+/**
+ * Rank games by one metric, descending, with unmeasured games last.
+ *
+ * The null rule is the whole reason this isn't an inline comparator. A null
+ * completion rate means nobody played, not that everyone abandoned it — so a
+ * null must never be ordered as if it were a low value. Sorting it to the
+ * bottom of "worst completion" would state something the data doesn't say.
+ */
+export function sortGameTotals(rows: GameTotals[], key: GameSortKey): GameTotals[] {
+  return [...rows].sort((a, b) => {
+    const left = a[key];
+    const right = b[key];
+    if (left === null && right === null) {
+      return 0;
+    }
+    if (left === null) {
+      return 1;
+    }
+    if (right === null) {
+      return -1;
+    }
+    return right - left;
+  });
+}


### PR DESCRIPTION
There was a per-game report at `/reports/games/<key>` but **no index and no nav entry** — the only route in was clicking a badge on another page. So there was nowhere to answer "which games are doing well", which is most of the point of having eleven of them.

No backend work: `/reporting/summary/` already returns every field per game. Sortable by played, completion, sessions per player, repeat rate, and trend.

## The null rule is the actual logic

Extracted to `lib/report-sort.ts` rather than inlined, because it's the part that can be wrong in a way nobody notices.

A null completion rate means **nobody played**, not that everyone abandoned it. Treating null as 0 ranks an untouched game *below* a genuinely abandoned one under "worst completion" — asserting something the data doesn't say. Nulls sort last instead.

The non-obvious case, and the one that makes the test worth having: **when every measured value is negative**, `?? 0` floats the unmeasured game to the *top*:

```
rows:     unmeasured (null), falling (-60%), slipping (-5%)
?? 0:     unmeasured, slipping, falling   ← "best trend: the game nobody played"
correct:  slipping, falling, unmeasured
```

## A note on the verification

The first run of that mutation **silently did not apply** — `eslint --fix` had added braces to the block my patch matched against, so the file was untouched and the guard looked like it passed. That's a false negative in the verification itself, which is worse than no verification.

The mutation script now asserts the file actually changed before running the tests. Worth flagging since I use this technique on every guard.

| Mutation | Result |
|---|---|
| Treat null as 0 | fails on the negative-trend case |
| Mutate input in place | fails |

234 tests · types clean.