### PR TITLE
feat(reports): render the multiplayer mode breakdown (it was built but never wired in)

### DIFF
--- a/app/reports/multiplayer/page.tsx
+++ b/app/reports/multiplayer/page.tsx
@@ -3,6 +3,7 @@
 import type { RangeState } from '@/lib/report-range';
 import { useMemo, useState } from 'react';
 import { GameBadge } from '@/components/reports/GameBadge';
+import { ModeBreakdown } from '@/components/reports/ModeBreakdown';
 import { RangePicker } from '@/components/reports/RangePicker';
 import { ReportError } from '@/components/reports/ReportError';
 import { ReportsShell } from '@/components/reports/ReportsShell';
@@ -80,6 +81,11 @@ export default function MultiplayerReportPage() {
                     </Card>
                   ))}
                 </div>
+
+                {/* Above the per-game table: modes are shared across games, so
+                    "is Elimination working anywhere" is a question the per-game
+                    split can't answer, and it's the one you ask first. */}
+                <ModeBreakdown rows={data.by_mode} meta={meta} onSelectGame={key => setGame(game === key ? null : key)} />
 
                 <Card>
                   <CardHeader>

--- a/components/reports/__tests__/ModeBreakdown.test.tsx
+++ b/components/reports/__tests__/ModeBreakdown.test.tsx
@@ -1,0 +1,58 @@
+import type { MultiplayerModeRow } from '@/types/reports';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { ModeBreakdown } from '@/components/reports/ModeBreakdown';
+
+const META = {
+  grid: { key: 'grid', label: 'Grid', color: '#10b981' },
+  quiz: { key: 'quiz', label: 'Quiz', color: '#2563eb' },
+};
+
+const ROWS: MultiplayerModeRow[] = [
+  { game_type: 'grid', mode: 'ELIMINATION', rooms_created: 40, rooms_started: 30, rooms_finished: 25 },
+  { game_type: 'quiz', mode: 'ELIMINATION', rooms_created: 10, rooms_started: 4, rooms_finished: 2 },
+  { game_type: 'grid', mode: 'TIME_ATTACK', rooms_created: 20, rooms_started: 18, rooms_finished: 15 },
+  // Quiz has no mode column server-side, so its rooms arrive as null.
+  { game_type: 'quiz', mode: null, rooms_created: 5, rooms_started: 5, rooms_finished: 5 },
+];
+
+describe('modeBreakdown', () => {
+  it('totals a mode across the games that share it', () => {
+    // The reason this view exists: "is Elimination working anywhere" can't be
+    // read off a per-game table, because each game only shows its own slice.
+    render(<ModeBreakdown rows={ROWS} meta={META} />);
+
+    expect(screen.getByText('50 rooms · 34 started')).toBeInTheDocument();
+  });
+
+  it('keeps modeless rooms visible instead of dropping them', () => {
+    // A null mode is real activity. Filtering it out would quietly shrink the
+    // totals and make them disagree with the multiplayer tiles above.
+    render(<ModeBreakdown rows={ROWS} meta={META} />);
+
+    expect(screen.getByText('No mode')).toBeInTheDocument();
+  });
+
+  it('orders modes by volume so the biggest is read first', () => {
+    render(<ModeBreakdown rows={ROWS} meta={META} />);
+    const headings = screen.getAllByRole('heading', { level: 4 }).map(h => h.textContent);
+
+    expect(headings).toEqual(['Elimination', 'Time Attack', 'No mode']);
+  });
+
+  it('lets a game badge drive the page filter', async () => {
+    const onSelectGame = vi.fn();
+    render(<ModeBreakdown rows={ROWS} meta={META} onSelectGame={onSelectGame} />);
+
+    await userEvent.click(screen.getAllByText('Grid')[0]);
+
+    expect(onSelectGame).toHaveBeenCalledWith('grid');
+  });
+
+  it('says there are no rooms rather than rendering an empty chart', () => {
+    render(<ModeBreakdown rows={[]} meta={META} />);
+
+    expect(screen.getByText(/no multiplayer rooms in this window/i)).toBeInTheDocument();
+  });
+});

--- a/lib/__tests__/no-orphaned-components.test.ts
+++ b/lib/__tests__/no-orphaned-components.test.ts
@@ -1,0 +1,63 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Guards against building a component and never rendering it.
+ *
+ * ModeBreakdown was written, reviewed and merged complete — and then wasn't
+ * imported anywhere for several PRs. `by_mode` was fetched on every multiplayer
+ * request and thrown away. Nothing failed: tests passed, types passed, the page
+ * rendered. The feature simply wasn't there.
+ *
+ * Dead UI code fails silently in a way dead logic doesn't, because there's no
+ * caller to notice. This is the cheapest thing that would have caught it.
+ */
+
+const ROOT = process.cwd();
+const COMPONENT_DIR = join(ROOT, 'components', 'reports');
+
+/** Directories that can legitimately reference a component. */
+const SEARCH_DIRS = ['app', 'components', 'hooks', 'lib'];
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === '__tests__') {
+        continue;
+      }
+      out.push(...walk(full));
+    } else if (/\.tsx?$/.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe('report components', () => {
+  it('are all rendered somewhere', () => {
+    const components = readdirSync(COMPONENT_DIR)
+      .filter(name => name.endsWith('.tsx'))
+      .map(name => name.replace(/\.tsx$/, ''));
+
+    // If this is ever empty the test would pass vacuously and guard nothing.
+    expect(components.length).toBeGreaterThan(5);
+
+    // Components legitimately render each other (ReportsShell renders
+    // ReportsNav), so only the component's OWN file is excluded — excluding the
+    // whole directory would report a used component as orphaned.
+    const files = SEARCH_DIRS.flatMap(dir => walk(join(ROOT, dir)))
+      .map(file => ({ file, source: readFileSync(file, 'utf8') }));
+
+    const orphaned = components.filter((name) => {
+      const own = join(COMPONENT_DIR, `${name}.tsx`);
+      return !files.some(
+        ({ file, source }) => file !== own && new RegExp(`\\b${name}\\b`).test(source),
+      );
+    });
+
+    expect(orphaned, `Built but never rendered: ${orphaned.join(', ')}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
`ModeBreakdown` was written complete — chart, per-game split, clickable badges — and **never imported anywhere**. `by_mode` was fetched on every multiplayer request and discarded.

Nothing failed. Tests passed, types passed, the page rendered. The feature you asked for ("for multiplayer we have different modes which are shared between games") just wasn't on screen.

## Placement

Above the per-game table, because **"is Elimination working anywhere"** is the first question and the per-game split structurally can't answer it — each game only shows its own slice of a shared mode.

## The guard matters more than the fix

Dead UI code fails silently in a way dead logic doesn't: there's no caller to go missing, no import to break, no type to mismatch. So a test now asserts every component in `components/reports/` is referenced somewhere.

Two details that make it correct rather than merely present:

- It excludes only the component's **own file**, not the whole directory. Excluding the directory reported `ReportsNav` as orphaned when `ReportsShell` renders it — a false positive that would have gotten the guard deleted.
- It asserts it actually found components, so a bad path can't make it pass vacuously.

Verified by reverting the wiring: the guard fails with `Built but never rendered: ModeBreakdown`.

## Tests it never had

The one worth reading: **rooms with a null mode stay visible**. Quiz has no mode column, so its rooms arrive as `null`. Filtering them out is the tempting cleanup, and it would quietly shrink the mode totals until they disagreed with the multiplayer tiles directly above them.

| Mutation | Result |
|---|---|
| Un-wire the component | orphan guard fails |
| Drop null-mode rows | 2 fail |
| Group per-game instead of per-mode | 3 fail |
| Sort alphabetically not by volume | fails |

## The gate earned its keep

While committing this, the typecheck gate from #40 blocked a fixture missing `rooms_finished` — **the same shape of defect that reached production in #38**, caught this time before the commit landed.

245 tests · types clean.