### PR TITLE
fix: stop /reports/players/[id] requesting the API forever

### DIFF
--- a/app/reports/players/[id]/page.tsx
+++ b/app/reports/players/[id]/page.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import type { RangeState } from '@/lib/report-range';
+import type { ReportParams } from '@/types/reports';
 import { ArrowLeft } from 'lucide-react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { Area, AreaChart, CartesianGrid, Cell, Pie, PieChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import { GameBadge } from '@/components/reports/GameBadge';
 import { RangePicker } from '@/components/reports/RangePicker';
@@ -40,12 +41,25 @@ export default function PlayerDetailPage() {
   const params = useMemo(() => rangeToParams(range), [range]);
 
   const { meta } = useGameMeta(enabled);
+
+  // Must be memoised. useReport keys its effect on the fetcher's identity, and
+  // every other page passes a static ReportsAPI method, which is stable for
+  // free. This is the only endpoint taking a bound argument, so an inline arrow
+  // here is a new function on every render: effect refires -> setState ->
+  // re-render -> new arrow, and the page requests the API forever.
+  const fetchPlayerDetail = useCallback(
+    (reportParams?: ReportParams) => ReportsAPI.getPlayerDetail(userId, reportParams),
+    [userId],
+  );
+
   const { data, isLoading, error, notDeployed, refetch } = useReport(
-    // Bound to this route's id, so the hook's generic fetcher signature still fits.
-    reportParams => ReportsAPI.getPlayerDetail(userId, reportParams),
+    fetchPlayerDetail,
     params,
     enabled && Number.isFinite(userId),
     'The player detail endpoint',
+    // userId lives in the path, not in params, so it has to be declared here for
+    // navigating between players to refetch.
+    String(userId),
   );
 
   return (

--- a/hooks/__tests__/use-report.test.tsx
+++ b/hooks/__tests__/use-report.test.tsx
@@ -1,0 +1,102 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { useState } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { useReport } from '@/hooks/use-report';
+
+/**
+ * Regression guard for an infinite request loop.
+ *
+ * useReport keys its effect on the fetcher's identity. Every reporting page
+ * passes a static ReportsAPI method, which is stable for free — except the
+ * player detail page, the only endpoint taking a bound argument. An inline
+ * arrow there is a new function each render, so the effect refires, sets state,
+ * re-renders, and requests the API forever. It hit production.
+ */
+
+function Harness({ fetcher }: { fetcher: (params?: unknown) => Promise<{ ok: boolean }> }) {
+  const { data } = useReport(fetcher as never, { window: 30 } as never, true, 'test endpoint');
+  return <div>{data ? 'loaded' : 'loading'}</div>;
+}
+
+describe('useReport', () => {
+  it('fetches once for a stable fetcher', async () => {
+    const fetcher = vi.fn(async () => ({ ok: true }));
+    render(<Harness fetcher={fetcher} />);
+
+    await screen.findByText('loaded');
+    await new Promise(resolve => setTimeout(resolve, 60));
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not loop when the caller rebuilds params each render', async () => {
+    // Params are keyed by value, not identity — a fresh object with the same
+    // contents must not count as a change.
+    const fetcher = vi.fn(async () => ({ ok: true }));
+
+    function RebuildsParams() {
+      const { data } = useReport(fetcher as never, { window: 30, include_bots: false } as never, true, 'test');
+      return <div>{data ? 'loaded' : 'loading'}</div>;
+    }
+
+    render(<RebuildsParams />);
+    await screen.findByText('loaded');
+    await new Promise(resolve => setTimeout(resolve, 60));
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not loop when the fetcher is a fresh function every render', async () => {
+    // The production bug, reproduced. Before the fix this reached ~2,000 calls
+    // in 400ms; the fetcher is now invoked through a ref and is not an effect
+    // dependency, so an unmemoised caller cannot spin.
+    const inner = vi.fn(async (_params?: unknown) => ({ ok: true }));
+
+    function InlineArrow() {
+      const { data } = useReport(
+        async params => inner(params) as never,
+        { window: 30 } as never,
+        true,
+        'test',
+      );
+      return <div>{data ? 'loaded' : 'loading'}</div>;
+    }
+
+    render(<InlineArrow />);
+    await screen.findByText('loaded');
+    await new Promise(resolve => setTimeout(resolve, 400));
+
+    expect(inner).toHaveBeenCalledTimes(1);
+  });
+
+  it('refetches when a bound argument changes, via resourceKey', async () => {
+    // The correct shape for the player-detail case: bound id, memoised on it.
+    const calls: number[] = [];
+    let setId: (id: number) => void = () => {};
+
+    function BoundArg() {
+      const [userId, setUserId] = useState(18);
+      setId = setUserId;
+      // Deliberately NOT memoised, to prove resourceKey is what drives the
+      // refetch — identity no longer can, by design.
+      const fetcher = async () => {
+        calls.push(userId);
+        return { ok: true };
+      };
+      const { data } = useReport(fetcher as never, { window: 30 } as never, true, 'test', String(userId));
+      return <div>{data ? `loaded-${userId}` : 'loading'}</div>;
+    }
+
+    render(<BoundArg />);
+    await screen.findByText('loaded-18');
+    await new Promise(resolve => setTimeout(resolve, 60));
+    expect(calls).toEqual([18]);
+
+    await act(async () => setId(19));
+    await waitFor(() => expect(calls).toEqual([18, 19]));
+
+    // And having refetched once, it settles rather than looping on the new id.
+    await new Promise(resolve => setTimeout(resolve, 60));
+    expect(calls).toEqual([18, 19]);
+  });
+});

--- a/hooks/use-report.ts
+++ b/hooks/use-report.ts
@@ -7,7 +7,7 @@
  */
 
 import type { ReportParams } from '@/types/reports';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import config from '@/lib/config';
 
 export type UseReport<T> = {
@@ -24,6 +24,12 @@ export function useReport<T>(
   params: ReportParams,
   enabled: boolean,
   endpointLabel: string,
+  /**
+   * Identity of the thing being fetched, when it isn't captured by `params` —
+   * e.g. the user id on the player drill-down, which lives in the path. Changing
+   * it refetches. Omitting it can only ever cause a missed refetch, never a loop.
+   */
+  resourceKey: string = '',
 ): UseReport<T> {
   const [data, setData] = useState<T | null>(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -33,14 +39,24 @@ export function useReport<T>(
   // Params are rebuilt on each render by callers; key on the values so the
   // effect doesn't refetch forever on an identical object.
   const key = JSON.stringify(params);
-  const stableParams = useMemo(() => params, [key]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // The fetcher is invoked through a ref and deliberately NOT an effect
+  // dependency. Callers that bind an argument (`p => getPlayerDetail(id, p)`)
+  // produce a new function every render, which made the effect refire, set
+  // state, re-render and request forever — ~2,000 calls in 400ms, in
+  // production. Refetching is driven by `key` and `resourceKey` instead, both
+  // values rather than identities, so an unmemoised fetcher can't spin.
+  const fetcherRef = useRef(fetcher);
+  fetcherRef.current = fetcher;
+  const paramsRef = useRef(params);
+  paramsRef.current = params;
 
   const load = useCallback(async () => {
     setIsLoading(true);
     setError(null);
     setNotDeployed(false);
     try {
-      setData(await fetcher(stableParams));
+      setData(await fetcherRef.current(paramsRef.current));
     } catch (err: unknown) {
       const raw = err instanceof Error ? err.message : `Failed to load ${endpointLabel}`;
       const is404 = /404|Not Found/i.test(raw);
@@ -54,7 +70,7 @@ export function useReport<T>(
     } finally {
       setIsLoading(false);
     }
-  }, [fetcher, stableParams, endpointLabel]);
+  }, [key, resourceKey, endpointLabel]);
 
   useEffect(() => {
     if (enabled) {


### PR DESCRIPTION
`/reports/players/18` fired **~2,000 requests in 400ms** at `api.extratime.world` and never stopped. Thanks for catching it — the page renders fine, so only the network tab shows it.

## Cause

`useReport` keyed its effect on the **fetcher's identity**. Every reporting page passes a static `ReportsAPI` method, which is stable for free. Player detail is the only endpoint taking a bound argument (`userId` lives in the path), so it passed an inline arrow:

```ts
reportParams => ReportsAPI.getPlayerDetail(userId, reportParams)
```

New function each render → effect refires → `setState` → re-render → new arrow → forever.

Measured before the fix: **1,968 calls in 400ms**.

## Fixed twice, on purpose

The call-site fix alone leaves the identical trap for the next endpoint that needs a bound argument — so the loop is now structurally impossible:

- The fetcher is invoked through a **ref** and is deliberately **not** an effect dependency.
- Refetching is driven by the params key plus a new optional `resourceKey` — both **values**, never identities.
- `resourceKey` carries identity that isn't in params (here `userId`). Forgetting it can only cause a *missed refetch*, never a loop: the failure mode becomes stale data you can see, instead of an outage you can't.

## My first three tests were worthless

They all passed a *stable* fetcher, so they'd have passed with or without the fix. That's the trap this whole PR is about, and I walked into it in the tests too.

The inline-arrow case is now tested explicitly, and mutation-verified — putting the fetcher back in the dependency array fails 2 tests:

```
expected "vi.fn()" to be called 1 times, but got 1941 times
```

249 tests · types clean.