### PR TITLE
feat(reports): theme-aware game colours + fix "Club_connection" in the MP table

### DIFF
--- a/app/reports/games/[key]/page.tsx
+++ b/app/reports/games/[key]/page.tsx
@@ -13,7 +13,7 @@ import { ReportError } from '@/components/reports/ReportError';
 import { ReportsShell } from '@/components/reports/ReportsShell';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
-import { useGameMeta } from '@/hooks/use-game-meta';
+import { useGameMeta, useGameColor } from '@/hooks/use-game-meta';
 import { useReport } from '@/hooks/use-report';
 import { useAuth } from '@/lib/auth';
 import { rangeToParams } from '@/lib/report-range';
@@ -33,6 +33,7 @@ function Stat({ label, value, hint }: { label: string; value: string; hint?: str
 
 /** Everything about one game in one place, instead of filtering five pages by hand. */
 export default function GameDetailPage() {
+  const resolveColor = useGameColor();
   const { isAuthenticated, user } = useAuth();
   const enabled = isAuthenticated && !!(user?.is_staff || user?.is_superuser);
   const routeParams = useParams();
@@ -118,7 +119,7 @@ export default function GameDetailPage() {
         <ActivityChart
           series={activity.data.series}
           metric="games_started"
-          color={meta[gameKey]?.color}
+          color={resolveColor(meta, gameKey)}
           title={`${label} — last ${activity.data.days} days`}
           description={`${activity.data.totals.games_started.toLocaleString()} played, ${activity.data.totals.games_finished.toLocaleString()} finished.`}
         />

--- a/app/reports/page.tsx
+++ b/app/reports/page.tsx
@@ -13,7 +13,7 @@ import { RangePicker } from '@/components/reports/RangePicker';
 import { ReportError } from '@/components/reports/ReportError';
 import { ReportsShell } from '@/components/reports/ReportsShell';
 import { Skeleton } from '@/components/ui/skeleton';
-import { useGameMeta } from '@/hooks/use-game-meta';
+import { useGameMeta, useGameColor } from '@/hooks/use-game-meta';
 import { useReport } from '@/hooks/use-report';
 import { useReportFilters } from '@/hooks/use-report-filters';
 import { useAuth } from '@/lib/auth';
@@ -21,6 +21,7 @@ import { rangeToParams } from '@/lib/report-range';
 import { ReportsAPI } from '@/lib/reports-api';
 
 export default function ReportsPage() {
+  const resolveColor = useGameColor();
   const { isAuthenticated, user } = useAuth();
   const enabled = isAuthenticated && !!(user?.is_staff || user?.is_superuser);
 
@@ -107,7 +108,7 @@ export default function ReportsPage() {
               <ActivityChart
                 series={activity.data.series}
                 metric={metric}
-                color={game ? meta[game]?.color : undefined}
+                color={game ? resolveColor(meta, game) : undefined}
                 title={`${selectedLabel ?? 'All games'} — last ${activity.data.window} days`}
                 description={`${activity.data.totals.games_started.toLocaleString()} played, ${activity.data.totals.games_finished.toLocaleString()} finished, ${activity.data.totals.distinct_players.toLocaleString()} distinct players.`}
               />

--- a/app/reports/players/[id]/page.tsx
+++ b/app/reports/players/[id]/page.tsx
@@ -13,7 +13,7 @@ import { ReportError } from '@/components/reports/ReportError';
 import { ReportsShell } from '@/components/reports/ReportsShell';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
-import { FALLBACK_COLOR, useGameMeta } from '@/hooks/use-game-meta';
+import { useGameColor, useGameMeta } from '@/hooks/use-game-meta';
 import { useReport } from '@/hooks/use-report';
 import { useAuth } from '@/lib/auth';
 import { rangeToParams } from '@/lib/report-range';
@@ -32,6 +32,7 @@ function Tile({ label, value, hint }: { label: string; value: string; hint?: str
 }
 
 export default function PlayerDetailPage() {
+  const resolveColor = useGameColor();
   const { isAuthenticated, user } = useAuth();
   const enabled = isAuthenticated && !!(user?.is_staff || user?.is_superuser);
   const routeParams = useParams();
@@ -144,7 +145,7 @@ export default function PlayerDetailPage() {
                               {data.by_game.map(row => (
                                 <Cell
                                   key={row.game_type}
-                                  fill={meta[row.game_type]?.color ?? FALLBACK_COLOR}
+                                  fill={resolveColor(meta, row.game_type)}
                                 />
                               ))}
                             </Pie>

--- a/components/reports/DurationTable.tsx
+++ b/components/reports/DurationTable.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { GameMetaMap } from '@/hooks/use-game-meta';
+import { useGameColor } from '@/hooks/use-game-meta';
 import type { DurationResponse } from '@/types/reports';
 import { Info } from 'lucide-react';
 import { ExportButton } from '@/components/reports/ExportButton';
@@ -19,6 +20,7 @@ import { cn } from '@/lib/utils';
  * shapes are split into separate tables.
  */
 export function DurationTable({ data, meta }: { data: DurationResponse; meta: GameMetaMap }) {
+  const resolveColor = useGameColor();
   const comparable = data.rows.filter(row => row.supported && row.single_sitting);
   const longLived = data.rows.filter(row => row.supported && row.single_sitting === false);
   const unsupported = data.rows.filter(row => !row.supported);
@@ -41,7 +43,7 @@ export function DurationTable({ data, meta }: { data: DurationResponse; meta: Ga
                 className="h-full rounded-full"
                 style={{
                   width: `${maxMedian > 0 ? Math.max(2, ((row.median_seconds ?? 0) / maxMedian) * 100) : 0}%`,
-                  backgroundColor: meta[row.game_type]?.color ?? '#94a3b8',
+                  backgroundColor: resolveColor(meta, row.game_type),
                 }}
               />
             </div>

--- a/components/reports/GameBadge.tsx
+++ b/components/reports/GameBadge.tsx
@@ -2,7 +2,7 @@
 
 import type { GameMetaMap } from '@/hooks/use-game-meta';
 import { X } from 'lucide-react';
-import { FALLBACK_COLOR } from '@/hooks/use-game-meta';
+import { useGameColor } from '@/hooks/use-game-meta';
 import { prettySlug } from '@/lib/user-hub-format';
 import { cn } from '@/lib/utils';
 
@@ -22,7 +22,8 @@ export function GameBadge({ gameKey, meta, active, onClick, count }: {
   onClick?: (gameKey: string) => void;
   count?: number;
 }) {
-  const color = meta[gameKey]?.color ?? FALLBACK_COLOR;
+  const resolveColor = useGameColor();
+  const color = resolveColor(meta, gameKey);
   const label = meta[gameKey]?.label ?? prettySlug(gameKey);
   const interactive = !!onClick;
 

--- a/components/reports/GameLeaderboard.tsx
+++ b/components/reports/GameLeaderboard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { GameMetaMap } from '@/hooks/use-game-meta';
+import { useGameColor } from '@/hooks/use-game-meta';
 import type { GameTotals, MetricKey } from '@/types/reports';
 import { ChevronDown, ChevronRight, Minus, TrendingDown, TrendingUp } from 'lucide-react';
 import Link from 'next/link';
@@ -60,6 +61,7 @@ export function GameLeaderboard({ rows, meta, metric, selected, onSelect }: {
   selected: string | null;
   onSelect: (gameKey: string | null) => void;
 }) {
+  const resolveColor = useGameColor();
   const [expanded, setExpanded] = useState<string | null>(null);
   const active = rows.filter(row => row.games_started > 0);
   const max = Math.max(...active.map(row => row[metric]), 0);
@@ -92,7 +94,7 @@ export function GameLeaderboard({ rows, meta, metric, selected, onSelect }: {
         )}
 
         {active.map((row) => {
-          const color = meta[row.game_type]?.color ?? '#94a3b8';
+          const color = resolveColor(meta, row.game_type);
           const isOpen = expanded === row.game_type;
           const isSelected = selected === row.game_type;
 

--- a/components/reports/ModeBreakdown.tsx
+++ b/components/reports/ModeBreakdown.tsx
@@ -5,7 +5,7 @@ import type { MultiplayerModeRow } from '@/types/reports';
 import { Bar, BarChart, CartesianGrid, Cell, LabelList, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import { GameBadge } from '@/components/reports/GameBadge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { FALLBACK_COLOR } from '@/hooks/use-game-meta';
+import { useGameColor } from '@/hooks/use-game-meta';
 
 /** Quiz has no mode column, so its rooms arrive as null rather than being dropped. */
 function modeLabel(mode: string | null): string {
@@ -25,6 +25,7 @@ export function ModeBreakdown({ rows, meta, onSelectGame }: {
   meta: GameMetaMap;
   onSelectGame?: (gameKey: string) => void;
 }) {
+  const resolveColor = useGameColor();
   const byMode = new Map<string, { mode: string; rooms_created: number; rooms_started: number; games: MultiplayerModeRow[] }>();
   for (const row of rows) {
     const label = modeLabel(row.mode);
@@ -64,7 +65,7 @@ export function ModeBreakdown({ rows, meta, onSelectGame }: {
                       <Bar dataKey="rooms_created" name="Rooms" radius={[4, 4, 0, 0]}>
                         <LabelList dataKey="rooms_created" position="top" style={{ fontSize: 11 }} />
                         {modes.map(mode => (
-                          <Cell key={mode.mode} fill={meta[mode.games[0]?.game_type ?? '']?.color ?? FALLBACK_COLOR} />
+                          <Cell key={mode.mode} fill={resolveColor(meta, mode.games[0]?.game_type ?? '')} />
                         ))}
                       </Bar>
                     </BarChart>

--- a/hooks/__tests__/use-game-meta.test.tsx
+++ b/hooks/__tests__/use-game-meta.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { GameBadge } from '@/components/reports/GameBadge';
+import { FALLBACK_COLOR, gameColor } from '@/hooks/use-game-meta';
+
+const GRID = { key: 'grid', label: 'Grid', color: '#f97316', color_dark: '#fdba74' };
+
+describe('gameColor', () => {
+  it('uses the dark step on a dark surface', () => {
+    // Not cosmetic: the light step sits at 2.2-2.8:1 on the dark card for five
+    // games, which reads as a smudge rather than a colour.
+    expect(gameColor(GRID, true)).toBe('#fdba74');
+    expect(gameColor(GRID, false)).toBe('#f97316');
+  });
+
+  it('falls back to the light colour when the BE predates color_dark', () => {
+    // Degrading to grey here would drop game identity entirely during the
+    // window between the BE and FE deploys.
+    const legacy = { key: 'grid', label: 'Grid', color: '#f97316' };
+
+    expect(gameColor(legacy, true)).toBe('#f97316');
+  });
+
+  it('falls back to grey for a game the BE has not described', () => {
+    expect(gameColor(undefined, false)).toBe(FALLBACK_COLOR);
+    expect(gameColor(undefined, true)).toBe(FALLBACK_COLOR);
+  });
+});
+
+describe('game marks', () => {
+  it('always carry their name, because four light colours are under 3:1', () => {
+    // The palette is only legal with "relief" — a visible label. If a badge
+    // ever renders as colour alone, the contrast exemption stops holding and
+    // the mark becomes unreadable for anyone who can't resolve the hue.
+    render(<GameBadge gameKey="grid" meta={{ grid: GRID }} />);
+
+    expect(screen.getByText('Grid')).toBeTruthy();
+  });
+
+  it('names an unknown game readably rather than showing a bare swatch', () => {
+    // BE game keys are snake_case. prettySlug only split on hyphens, so the
+    // multiplayer table was rendering "Club_connection" on screen.
+    render(<GameBadge gameKey="brand_new_game" meta={{}} />);
+
+    expect(screen.getByText('Brand New Game')).toBeTruthy();
+  });
+});

--- a/hooks/use-game-meta.ts
+++ b/hooks/use-game-meta.ts
@@ -7,7 +7,8 @@
  */
 
 import type { GameMeta } from '@/types/reports';
-import { useEffect, useState } from 'react';
+import { useTheme } from 'next-themes';
+import { useCallback, useEffect, useState } from 'react';
 import { ReportsAPI } from '@/lib/reports-api';
 
 export type GameMetaMap = Record<string, GameMeta>;
@@ -15,8 +16,41 @@ export type GameMetaMap = Record<string, GameMeta>;
 /** Neutral grey for a game the BE hasn't told us about yet. */
 export const FALLBACK_COLOR = '#94a3b8';
 
+/**
+ * The colour to draw a game with on the current surface.
+ *
+ * A dark theme needs its own steps, not a flipped light colour: five games sat
+ * between 2.2 and 2.8:1 on the dark card when one palette served both, which
+ * reads as a smudge rather than a colour. `color_dark` is optional, so a BE
+ * that predates it degrades to the light colour rather than to grey.
+ */
+export function gameColor(meta: GameMeta | undefined, isDark: boolean): string {
+  if (!meta) {
+    return FALLBACK_COLOR;
+  }
+  return isDark ? (meta.color_dark ?? meta.color) : meta.color;
+}
+
+/**
+ * Resolver for components that receive `meta` as a prop rather than calling
+ * `useGameMeta` themselves. Reads the theme here so no component has to accept
+ * an `isDark` prop it would only pass straight through — and so a new consumer
+ * can't quietly draw the light colour on a dark card.
+ */
+export function useGameColor() {
+  const { resolvedTheme } = useTheme();
+  const isDark = resolvedTheme === 'dark';
+
+  return useCallback(
+    (meta: GameMetaMap, gameKey: string) => gameColor(meta[gameKey], isDark),
+    [isDark],
+  );
+}
+
 export function useGameMeta(enabled: boolean) {
   const [meta, setMeta] = useState<GameMetaMap>({});
+  const { resolvedTheme } = useTheme();
+  const isDark = resolvedTheme === 'dark';
 
   useEffect(() => {
     if (!enabled) {
@@ -39,5 +73,12 @@ export function useGameMeta(enabled: boolean) {
     };
   }, [enabled]);
 
-  return { meta };
+  // Bound to the resolved theme so callers can't forget which surface they're
+  // drawing on — the common way a dark-mode palette silently goes unused.
+  const colorFor = useCallback(
+    (gameKey: string) => gameColor(meta[gameKey], isDark),
+    [meta, isDark],
+  );
+
+  return { meta, isDark, colorFor };
 }

--- a/lib/user-hub-format.ts
+++ b/lib/user-hub-format.ts
@@ -13,8 +13,11 @@ export function initialsFor(user: Pick<HubUser, 'first_name' | 'last_name' | 'us
 
 /** Turn a kebab slug into a readable label until a slug→display-name map exists. */
 export function prettySlug(slug: string): string {
+  // Splits on both separators: FE favourite-game slugs are kebab-case, but BE
+  // registry keys are snake_case, and the multiplayer table renders those —
+  // hyphen-only turned "club_connection" into "Club_connection" on screen.
   return slug
-    .split('-')
+    .split(/[-_]/)
     .map(w => (w ? w[0].toUpperCase() + w.slice(1) : w))
     .join(' ');
 }

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -241,8 +241,13 @@ export type PlayerDetailResponse = {
 export type GameMeta = {
   key: string;
   label: string;
-  /** Hex, e.g. '#2563eb'. Same colour the Django admin dashboard draws the game with. */
+  /** Hex for a light surface. Same colour the Django admin dashboard draws the game with. */
   color: string;
+  /**
+   * Hex for a dark surface — the same hue re-stepped, not a computed flip.
+   * Optional so the UI keeps working against a BE that predates it.
+   */
+  color_dark?: string;
 };
 
 export type GamesResponse = { games: GameMeta[] };


### PR DESCRIPTION
Consumes `color_dark` from [App #1442](https://github.com/FootballExtraTime/App/pull/1442) — merge that first.

Every surface that paints a game — badges, mode chart, duration bars, leaderboard, per-game pie, page accents — now resolves against the current theme instead of always using the light step. Five of the eleven games were sitting at **2.2–2.8:1 on the dark card**, which reads as a smudge rather than a colour.

## Why a hook, not an `isDark` prop

Components receive `meta` as a prop, so the obvious move is to pass `isDark` alongside it. That's a prop every component forwards without using, and the failure mode is silent: one consumer forgets, draws the light colour on a dark card, and nothing errors.

`useGameColor()` reads the theme where the colour is resolved, so a **new consumer is correct by default**.

## Degrading between deploys

`color_dark` is optional. In the window between the BE and FE deploys a game falls back to its light colour rather than to grey — a duller mark beats losing identity entirely.

## A guard for the constraint the palette created

Four light colours are under 3:1 and are legal **only "with relief"** — a visible label. That holds today by luck of how badges are built. A test now asserts a game mark always renders its name, so a reasonable-looking refactor to a bare swatch fails instead of quietly making marks unreadable.

## A real bug found while writing that test

`prettySlug` split on hyphens only. BE game keys are **snake_case**, and the multiplayer table renders them directly — so it has been showing:

> Club_connection · Avatar_of_football · Missing_team

It now splits on both separators. The kebab-case user-hub callers are unchanged.

254 tests · types clean.