### PR TITLE
feat(reports): explain what every number means, where the number is

### DIFF
--- a/app/reports/games/page.tsx
+++ b/app/reports/games/page.tsx
@@ -7,6 +7,7 @@ import { ArrowDown, ArrowUp } from 'lucide-react';
 import Link from 'next/link';
 import { useMemo, useState } from 'react';
 import { GameBadge } from '@/components/reports/GameBadge';
+import { MetricInfo } from '@/components/reports/MetricInfo';
 import { RangePicker } from '@/components/reports/RangePicker';
 import { ReportError } from '@/components/reports/ReportError';
 import { ReportsShell } from '@/components/reports/ReportsShell';
@@ -18,12 +19,13 @@ import { useAuth } from '@/lib/auth';
 import { rangeToParams } from '@/lib/report-range';
 import { ReportsAPI } from '@/lib/reports-api';
 
-const COLUMNS: { key: GameSortKey; label: string; hint: string }[] = [
-  { key: 'games_started', label: 'Played', hint: 'Sessions started in the window' },
-  { key: 'completion_pct', label: 'Finished', hint: 'Share of started sessions that were completed' },
-  { key: 'sessions_per_player', label: 'Per player', hint: 'Sessions per distinct player — depth of engagement' },
-  { key: 'repeat_rate_pct', label: 'Came back', hint: 'Share of players who returned on another day' },
-  { key: 'trend_pct', label: 'Trend', hint: 'vs the immediately preceding window of equal length' },
+/** `metric` keys into lib/metric-definitions so the column explains itself. */
+const COLUMNS: { key: GameSortKey; label: string; hint: string; metric: string }[] = [
+  { key: 'games_started', label: 'Played', hint: 'Sessions started in the window', metric: 'games_started' },
+  { key: 'completion_pct', label: 'Finished', hint: 'Share of started sessions that were completed', metric: 'completion_pct' },
+  { key: 'sessions_per_player', label: 'Per player', hint: 'Sessions per distinct player — depth of engagement', metric: 'sessions_per_player' },
+  { key: 'repeat_rate_pct', label: 'Came back', hint: 'Share of players who returned on another day', metric: 'repeat_rate_pct' },
+  { key: 'trend_pct', label: 'Trend', hint: 'vs the immediately preceding window of equal length', metric: 'trend_pct' },
 ];
 
 /**
@@ -123,6 +125,7 @@ export default function GamesIndexPage() {
                             >
                               {column.label}
                             </button>
+                            <MetricInfo metric={column.metric} />
                           </th>
                         ))}
                       </tr>

--- a/app/reports/glossary/page.tsx
+++ b/app/reports/glossary/page.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import Link from 'next/link';
+import { ReportsShell } from '@/components/reports/ReportsShell';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { METRIC_DEFINITIONS, METRICS_BY_KEY } from '@/lib/metric-definitions';
+
+/**
+ * The same definitions the inline info popovers show, in one place.
+ *
+ * Deliberately not the primary surface — a number is best explained where it
+ * appears. This exists for reading end to end before trusting a report, and as
+ * something to point at in a conversation.
+ */
+export default function GlossaryPage() {
+  return (
+    <ReportsShell
+      title="What the numbers mean"
+      description="Every metric: what it counts, what it leaves out, and how it can be misread."
+    >
+      <p className="text-sm text-gray-600 dark:text-gray-300">
+        Bot and simulation accounts are excluded everywhere by default. Anonymous
+        players are real people and are always counted. All dates and hours are
+        Europe/Sofia.
+      </p>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        {METRIC_DEFINITIONS.map(definition => (
+          <Card key={definition.key} id={definition.key} className="scroll-mt-4">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-base">{definition.label}</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2 text-sm">
+              <p className="text-gray-800 dark:text-gray-100">{definition.counts}</p>
+
+              {definition.excludes && (
+                <p className="text-gray-600 dark:text-gray-300">
+                  <span className="font-medium">Excludes: </span>
+                  {definition.excludes}
+                </p>
+              )}
+
+              {definition.caveat && (
+                <p className="rounded border border-amber-200 bg-amber-50 p-2 text-gray-800 dark:border-amber-900 dark:bg-amber-900/20 dark:text-gray-100">
+                  <span className="font-medium">Easy to misread: </span>
+                  {definition.caveat}
+                </p>
+              )}
+
+              {definition.related && definition.related.length > 0 && (
+                <p className="text-xs text-gray-500 dark:text-gray-400">
+                  Read with
+                  {' '}
+                  {definition.related.map((key, index) => (
+                    <span key={key}>
+                      {index > 0 && ', '}
+                      <Link href={`#${key}`} className="text-emerald-700 hover:underline dark:text-emerald-400">
+                        {METRICS_BY_KEY[key]?.label ?? key}
+                      </Link>
+                    </span>
+                  ))}
+                </p>
+              )}
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </ReportsShell>
+  );
+}

--- a/app/reports/patterns/page.tsx
+++ b/app/reports/patterns/page.tsx
@@ -4,6 +4,7 @@ import type { RangeState } from '@/lib/report-range';
 import { useMemo, useState } from 'react';
 import { Area, AreaChart, Bar, BarChart, CartesianGrid, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import { ActivityHeatmap } from '@/components/reports/ActivityHeatmap';
+import { MetricInfo } from '@/components/reports/MetricInfo';
 import { RangePicker } from '@/components/reports/RangePicker';
 import { ReportError } from '@/components/reports/ReportError';
 import { ReportsShell } from '@/components/reports/ReportsShell';
@@ -14,11 +15,14 @@ import { useAuth } from '@/lib/auth';
 import { rangeToParams } from '@/lib/report-range';
 import { ReportsAPI } from '@/lib/reports-api';
 
-function Tile({ label, value, hint }: { label: string; value: string; hint: string }) {
+function Tile({ label, value, hint, metric }: { label: string; value: string; hint: string; metric?: string }) {
   return (
     <Card>
       <CardContent className="space-y-1 p-4">
-        <p className="text-sm font-medium text-gray-600 dark:text-gray-300">{label}</p>
+        <p className="text-sm font-medium text-gray-600 dark:text-gray-300">
+          {label}
+          {metric && <MetricInfo metric={metric} />}
+        </p>
         <p className="text-2xl font-bold text-gray-900 dark:text-white">{value}</p>
         <p className="text-xs text-gray-500 dark:text-gray-400">{hint}</p>
       </CardContent>
@@ -68,6 +72,7 @@ export default function PatternsPage() {
                 <div className="grid grid-cols-1 gap-4 sm:grid-cols-4">
                   <Tile
                     label="Busiest slot"
+                    metric="peak_cell"
                     value={data.peak_cell
                       ? `${data.peak_cell.name.slice(0, 3)} ${String(data.peak_cell.hour).padStart(2, '0')}:00`
                       : '—'}
@@ -79,6 +84,7 @@ export default function PatternsPage() {
                   />
                   <Tile
                     label="Peak hour"
+                    metric="peak_hour"
                     value={data.peak_hour === null ? '—' : `${String(data.peak_hour).padStart(2, '0')}:00`}
                     hint={`${peakHourCount.toLocaleString()} games · ${data.timezone}`}
                   />

--- a/components/reports/MetricInfo.tsx
+++ b/components/reports/MetricInfo.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { Info } from 'lucide-react';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { METRICS_BY_KEY } from '@/lib/metric-definitions';
+
+/**
+ * The definition of a metric, next to the metric.
+ *
+ * A glossary page alone doesn't work: nobody leaves the number they're
+ * questioning to go and look it up. The caveat is the part worth surfacing —
+ * every one of them is a way the number has actually been misread.
+ */
+export function MetricInfo({ metric }: { metric: string }) {
+  const definition = METRICS_BY_KEY[metric];
+  if (!definition) {
+    return null;
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger
+        className="ml-1 inline-flex align-middle text-gray-400 transition-colors hover:text-gray-700 dark:hover:text-gray-200"
+        aria-label={`What "${definition.label}" means`}
+      >
+        <Info className="size-3.5" />
+      </PopoverTrigger>
+      <PopoverContent className="w-80 text-sm" align="start">
+        <p className="font-semibold text-gray-900 dark:text-white">{definition.label}</p>
+        <p className="mt-1 text-gray-700 dark:text-gray-200">{definition.counts}</p>
+        {definition.excludes && (
+          <p className="mt-2 text-gray-600 dark:text-gray-300">
+            <span className="font-medium">Excludes: </span>
+            {definition.excludes}
+          </p>
+        )}
+        {definition.caveat && (
+          <p className="mt-2 rounded border border-amber-200 bg-amber-50 p-2 text-gray-800 dark:border-amber-900 dark:bg-amber-900/20 dark:text-gray-100">
+            {definition.caveat}
+          </p>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/components/reports/ReportsNav.tsx
+++ b/components/reports/ReportsNav.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { BarChart3, Clock, Gamepad2, LayoutGrid, Repeat, Timer, Users } from 'lucide-react';
+import { BarChart3, BookOpen, Clock, Gamepad2, LayoutGrid, Repeat, Timer, Users } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { cn } from '@/lib/utils';
@@ -13,6 +13,7 @@ const TABS = [
   { href: '/reports/duration', label: 'Session length', icon: Timer },
   { href: '/reports/players', label: 'Players', icon: Users },
   { href: '/reports/retention', label: 'Retention', icon: Repeat },
+  { href: '/reports/glossary', label: 'What the numbers mean', icon: BookOpen },
 ];
 
 export function ReportsNav() {

--- a/lib/__tests__/metric-definitions.test.ts
+++ b/lib/__tests__/metric-definitions.test.ts
@@ -1,0 +1,65 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { METRIC_DEFINITIONS, METRICS_BY_KEY } from '@/lib/metric-definitions';
+
+const ROOT = process.cwd();
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === '__tests__') continue;
+      out.push(...walk(full));
+    } else if (/\.tsx?$/.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe('metric definitions', () => {
+  it('exist for every metric the UI points at', () => {
+    // A <MetricInfo metric="..."/> with no definition renders nothing at all —
+    // it fails silently, so the affordance just quietly disappears.
+    const sources = ['app', 'components'].flatMap(dir => walk(join(ROOT, dir)))
+      .map(file => readFileSync(file, 'utf8'));
+
+    const referenced = new Set<string>();
+    for (const source of sources) {
+      for (const match of source.matchAll(/metric[=:]\s*['"]([a-z_]+)['"]/g)) {
+        referenced.add(match[1]);
+      }
+    }
+
+    expect(referenced.size).toBeGreaterThan(0);
+
+    const missing = [...referenced].filter(key => !METRICS_BY_KEY[key]);
+    expect(missing, `Referenced with no definition: ${missing.join(', ')}`).toEqual([]);
+  });
+
+  it('have unique keys', () => {
+    const keys = METRIC_DEFINITIONS.map(d => d.key);
+
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it('only cross-reference metrics that exist', () => {
+    // A dead `related` key renders a link to an anchor that isn't on the page.
+    const dangling = METRIC_DEFINITIONS.flatMap(
+      d => (d.related ?? []).filter(key => !METRICS_BY_KEY[key]).map(key => `${d.key} -> ${key}`),
+    );
+
+    expect(dangling, `Dangling cross-references: ${dangling.join(', ')}`).toEqual([]);
+  });
+
+  it('say what they count and what they exclude', () => {
+    for (const definition of METRIC_DEFINITIONS) {
+      expect(definition.counts.length, `${definition.key} has no "counts"`).toBeGreaterThan(20);
+      // `excludes` may be empty, but must be a deliberate empty string rather
+      // than undefined — "nothing is excluded" is itself a claim worth making.
+      expect(typeof definition.excludes, `${definition.key} has no "excludes"`).toBe('string');
+    }
+  });
+});

--- a/lib/metric-definitions.ts
+++ b/lib/metric-definitions.ts
@@ -1,0 +1,203 @@
+/**
+ * What every reported number actually means.
+ *
+ * One registry, two surfaces: the info affordance next to a metric and the
+ * glossary page both read from here, so a definition can't be right in one
+ * place and stale in the other.
+ *
+ * `caveat` is the field that earns this file. Most of these numbers are easy to
+ * read wrongly in a way that looks perfectly reasonable — a distinct-player
+ * count that seems additive, a 0% completion that actually means "nobody
+ * played", a retention cohort inflated by its own window. Every caveat here
+ * corresponds to a mistake that was actually made while building these reports.
+ */
+
+export type MetricDefinition = {
+  key: string;
+  label: string;
+  /** One line: what the number counts. */
+  counts: string;
+  /** What is deliberately left out. Empty string when nothing is. */
+  excludes: string;
+  /** How to misread it. Omitted only when there is genuinely no trap. */
+  caveat?: string;
+  /** Keys of metrics worth reading alongside this one. */
+  related?: string[];
+};
+
+export const METRIC_DEFINITIONS: MetricDefinition[] = [
+  {
+    key: 'games_started',
+    label: 'Games played',
+    counts: 'Sessions started in the window, across every game mode.',
+    excludes: 'Bot and simulation accounts, unless "include bots" is on.',
+    caveat:
+      'A started session is not a played one — someone who opens a game and leaves counts here. Read it next to Finished rather than alone.',
+    related: ['games_finished', 'completion_pct'],
+  },
+  {
+    key: 'games_finished',
+    label: 'Games finished',
+    counts: 'Sessions in the window that reached a finished state.',
+    excludes: 'Bot and simulation accounts, unless "include bots" is on.',
+    caveat:
+      'Attributed to the day the session STARTED, so a game begun before midnight and finished after it counts on the earlier day. Totals stay consistent; a single day can look slightly off.',
+    related: ['games_started', 'completion_pct'],
+  },
+  {
+    key: 'distinct_players',
+    label: 'Players',
+    counts: 'Distinct accounts that started at least one session in the window.',
+    excludes: 'Bot and simulation accounts, unless "include bots" is on.',
+    caveat:
+      'NOT additive. Someone who plays Grid and Quiz on three days is one player, not six — so per-game numbers do not sum to the platform figure, and per-day numbers do not sum to the window. Summing them inflated this figure 5.6× before it was caught.',
+    related: ['sessions_per_player', 'new_players'],
+  },
+  {
+    key: 'mp_player_sessions',
+    label: 'Multiplayer participations',
+    counts: 'One per player per multiplayer session — four players in a room is four.',
+    excludes: 'Bot and simulation accounts, unless "include bots" is on.',
+    caveat:
+      'A different grain from every "rooms" figure on the Multiplayer page, which counts rooms. Four players in one room is 4 participations and 1 room; the two will never agree, and neither is wrong.',
+    related: ['rooms_created'],
+  },
+  {
+    key: 'completion_pct',
+    label: 'Completion rate',
+    counts: 'Finished divided by started, for sessions in the window.',
+    excludes: 'Games nobody played — those report no rate at all.',
+    caveat:
+      'Null is not zero. A game nobody touched has no completion rate; showing 0% would read as "everyone abandoned it", which is the opposite of what happened. Unmeasured games sort last rather than bottom.',
+    related: ['games_started', 'games_finished'],
+  },
+  {
+    key: 'sessions_per_player',
+    label: 'Sessions per player',
+    counts: 'Sessions started divided by distinct players, in the window.',
+    excludes: 'Bot and simulation accounts, unless "include bots" is on.',
+    caveat:
+      'Depth, not reach. It rises when a small group plays a lot AND when a large audience drifts away, so it only means something read beside player count.',
+    related: ['distinct_players', 'repeat_rate_pct'],
+  },
+  {
+    key: 'share_pct',
+    label: 'Share of play',
+    counts: 'This game\'s sessions as a percentage of all sessions in the window.',
+    excludes: 'Bot and simulation accounts, unless "include bots" is on.',
+    caveat:
+      'Relative, so a game\'s share can rise while its own play falls — it only needs to fall more slowly than everything else. Check the trend before reading a rising share as growth.',
+    related: ['games_started', 'trend_pct'],
+  },
+  {
+    key: 'repeat_rate_pct',
+    label: 'Came back',
+    counts: 'Share of a game\'s players who played it on more than one distinct day.',
+    excludes: 'Bot and simulation accounts, unless "include bots" is on.',
+    caveat:
+      'Counted over days, not sessions, so five games in one sitting is not "coming back". Short windows suppress it mechanically: nobody can return across two days in a one-day window.',
+    related: ['retention_d1', 'sessions_per_player'],
+  },
+  {
+    key: 'trend_pct',
+    label: 'Trend',
+    counts: 'Change against the immediately preceding window of equal length.',
+    excludes: 'Windows where the previous period had no activity to compare against.',
+    caveat:
+      'Weekday-sensitive. A 7-day window compares like with like; a 3-day window can straddle a weekend and swing hard for reasons that have nothing to do with the game.',
+    related: ['games_started'],
+  },
+  {
+    key: 'rooms_created',
+    label: 'Rooms created',
+    counts: 'Multiplayer rooms opened in the window, regardless of whether they started.',
+    excludes: 'Solo sessions entirely.',
+    caveat:
+      'Counts rooms, not people. Compare with multiplayer participations for the per-player view.',
+    related: ['never_started_pct', 'mp_player_sessions'],
+  },
+  {
+    key: 'never_started_pct',
+    label: 'Never started',
+    counts: 'Share of rooms opened in the window that never began play.',
+    excludes: 'Rooms opened before the window.',
+    caveat:
+      'Usually a matchmaking signal rather than a game-quality one — it mostly means not enough players arrived, so it tracks concurrency more than the game itself.',
+    related: ['rooms_created'],
+  },
+  {
+    key: 'retention_d1',
+    label: 'Retention (D1 / D7 / D30)',
+    counts: 'Of players whose first session fell on a given day, the share who played again 1, 7 or 30 days later.',
+    excludes: 'Cohorts too recent for the milestone to have happened yet.',
+    caveat:
+      'The earliest cohort in a window is inflated: some of its "new" players were not new, they were simply first seen inside the window. It is flagged and left out of the averages — treat it as unreliable, not as the best day you ever had.',
+    related: ['new_players', 'repeat_rate_pct'],
+  },
+  {
+    key: 'new_players',
+    label: 'New vs returning',
+    counts: 'New = the account was REGISTERED that day. Returning = registered earlier.',
+    excludes: 'Bot and simulation accounts, unless "include bots" is on.',
+    caveat:
+      'This is registration, not first play. Someone who signed up months ago and plays for the first time today is "returning". A healthy day has both: all-returning means growth stalled, all-new means nobody stays.',
+    related: ['distinct_players', 'retention_d1'],
+  },
+  {
+    key: 'median_duration',
+    label: 'Session length',
+    counts: 'Median minutes between a session starting and finishing.',
+    excludes: 'Unfinished sessions, which have no end to measure.',
+    caveat:
+      'Not comparable across games. Conquest is a campaign played over days — its real median is around 1,440 minutes — while Grid is one sitting. Capping the outliers deleted 72% of Conquest\'s data before that was understood; sessions are now flagged instead, and only single-sitting games are comparable with each other.',
+    related: ['games_finished'],
+  },
+  {
+    key: 'peak_cell',
+    label: 'Busiest slot',
+    counts: 'The single weekday-and-hour with the most sessions started, in Europe/Sofia.',
+    excludes: 'Windows with no activity, which report no peak rather than defaulting to Monday 00:00.',
+    caveat:
+      'Not the peak day crossed with the peak hour. Those two need not intersect at a busy cell — on real data they point at Thursday 15:00 while the actual busiest slot is Tuesday 16:00.',
+    related: ['peak_hour'],
+  },
+  {
+    key: 'peak_hour',
+    label: 'Peak hour / busiest day',
+    counts: 'The hour, and the weekday, with the most sessions started — each totalled separately.',
+    excludes: 'Windows with no activity.',
+    caveat:
+      'These are two independent totals. Multiplying them together to guess "when" is the mistake the heatmap exists to prevent.',
+    related: ['peak_cell'],
+  },
+  {
+    key: 'coverage',
+    label: 'Coverage',
+    counts: 'Which days in the window have actually been computed by the rollup.',
+    excludes: 'Nothing — it describes the data rather than the play.',
+    caveat:
+      'An uncomputed day is not a quiet day. Without this, a missing rollup reads as genuine zero activity, which is why "typical Wednesday: 0" once appeared next to "+100% vs usual". Charts mark uncovered days rather than drawing them at zero.',
+    related: ['anomaly_threshold'],
+  },
+  {
+    key: 'anomaly_threshold',
+    label: 'Needs attention',
+    counts: 'Movements above 25% against the previous window, on at least 30 sessions.',
+    excludes: 'Everything quieter — deliberately.',
+    caveat:
+      'The thresholds are the point. Without a volume floor a game going 2→5 shouts "+150%" over a real 20% drop on thousands of sessions; without a percentage floor, ordinary variation trains you to ignore the panel. An empty list means nothing moved, and says so differently from "we could not tell".',
+    related: ['coverage', 'trend_pct'],
+  },
+  {
+    key: 'bots',
+    label: 'Bot accounts',
+    counts: 'Nothing by itself — a filter applied to every metric on every page.',
+    excludes: 'Accounts flagged as dummy/simulation in the backend.',
+    caveat:
+      'Off by default everywhere, because simulation runs would otherwise dominate quiet days. Anonymous players are real people and are always included — they are not bots.',
+  },
+];
+
+export const METRICS_BY_KEY: Record<string, MetricDefinition> = Object.fromEntries(
+  METRIC_DEFINITIONS.map(definition => [definition.key, definition]),
+);


### PR DESCRIPTION
You asked for the best legend of what's what. This is it — but built so it can't rot.

## One registry, two surfaces

`lib/metric-definitions.ts` holds every metric: **what it counts**, **what it excludes**, and **how it can be misread**. The inline info popover and the glossary page both read from it, so a definition can't be correct in one place and stale in the other.

## Placement over completeness

A glossary page alone doesn't work — nobody leaves the number they're questioning to go look it up. So definitions sit **next to the metric** (sortable column headers, the Patterns tiles), and the page exists for reading end to end before trusting a report.

## The caveats are the actual value

Every one is a mistake that was really made while building these reports:

- **Players** isn't additive — summing across games and days inflated it **5.6×**
- **Completion rate** null means *nobody played*, not *everyone bailed*
- **Multiplayer participations vs rooms** are different grains and will never agree — neither is wrong
- The **earliest retention cohort** is inflated by its own window
- **Session length** isn't comparable across games; capping outliers deleted **72%** of Conquest's data
- An **uncomputed day is not a quiet day** — that's how "typical Wednesday: 0" appeared next to "+100% vs usual"
- **Peak day × peak hour ≠ busiest slot** — on real data they disagree
- **Anonymous players are real people** and are always counted; they are not bots

## Guards

`MetricInfo` renders `null` for an unknown key — it fails silently, so a typo would just make the affordance quietly disappear. Mutation-verified:

| Mutation | Result |
|---|---|
| Rename a definition key still referenced in the UI | fails, names the metric |
| Point `related` at a nonexistent metric | fails, names the pair |

258 tests · types clean · build includes `/reports/glossary`.

## Where I'd go next

The definitions currently live on the frontend. The truest home for several of them is beside the query that computes them — that's the version that can't drift from the maths. Worth doing once the shape settles rather than now.