### PR TITLE
feat(reports): show where multiplayer rooms are lost

### DIFF
--- a/app/reports/multiplayer/page.tsx
+++ b/app/reports/multiplayer/page.tsx
@@ -4,6 +4,7 @@ import type { RangeState } from '@/lib/report-range';
 import { useMemo, useState } from 'react';
 import { GameBadge } from '@/components/reports/GameBadge';
 import { ModeBreakdown } from '@/components/reports/ModeBreakdown';
+import { MultiplayerFunnel } from '@/components/reports/MultiplayerFunnel';
 import { RangePicker } from '@/components/reports/RangePicker';
 import { ReportError } from '@/components/reports/ReportError';
 import { ReportsShell } from '@/components/reports/ReportsShell';
@@ -85,6 +86,11 @@ export default function MultiplayerReportPage() {
                 {/* Above the per-game table: modes are shared across games, so
                     "is Elimination working anywhere" is a question the per-game
                     split can't answer, and it's the one you ask first. */}
+                {/* Ahead of the mode split and the table: "which stage loses
+                    people" is the first question, and both of those make you do
+                    the subtraction yourself. */}
+                <MultiplayerFunnel rows={data.by_game} meta={meta} />
+
                 <ModeBreakdown rows={data.by_mode} meta={meta} onSelectGame={key => setGame(game === key ? null : key)} />
 
                 <Card>

--- a/components/reports/MultiplayerFunnel.tsx
+++ b/components/reports/MultiplayerFunnel.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import type { GameMetaMap } from '@/hooks/use-game-meta';
+import type { MultiplayerGameRow } from '@/types/reports';
+import { useTheme } from 'next-themes';
+import { GameBadge } from '@/components/reports/GameBadge';
+import { MetricInfo } from '@/components/reports/MetricInfo';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+/**
+ * Where multiplayer rooms are lost, per game.
+ *
+ * The table below this holds the same numbers, but a table makes you do the
+ * subtraction. The question here — "which stage loses people" — is a shape
+ * question, so it gets a shape.
+ *
+ * Stages are ORDINAL, not categorical: created → started → finished only means
+ * anything in that order. So they take one hue in monotone lightness steps
+ * rather than three separate identities, which would spend the identity channel
+ * re-encoding an order the layout already shows. Both ramps are validated
+ * against their own surface; the dark one re-anchors rather than flipping the
+ * light one.
+ */
+const STAGE_RAMP_LIGHT = ['#10b981', '#047857', '#064e3b'];
+const STAGE_RAMP_DARK = ['#6ee7b7', '#34d399', '#10b981'];
+
+/** Null, never 0, when there is nothing to divide by — no rooms means no rate. */
+function share(value: number, total: number): number | null {
+  return total > 0 ? Math.round((value / total) * 1000) / 10 : null;
+}
+
+export function MultiplayerFunnel({ rows, meta }: { rows: MultiplayerGameRow[]; meta: GameMetaMap }) {
+  const { resolvedTheme } = useTheme();
+  const ramp = resolvedTheme === 'dark' ? STAGE_RAMP_DARK : STAGE_RAMP_LIGHT;
+
+  const played = [...rows]
+    .filter(row => row.rooms_created > 0)
+    .sort((a, b) => b.rooms_created - a.rooms_created);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center">
+          Where rooms are lost
+          <MetricInfo metric="never_started_pct" />
+        </CardTitle>
+        <CardDescription>
+          Each row is one game, scaled to its own rooms created — so the gaps are
+          the drop-off: people who never found a game, then games that started
+          and were abandoned. Games are not scaled against each other; use the
+          counts on the right to compare sizes.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        {played.length === 0 && (
+          <p className="py-6 text-center text-sm text-gray-500 dark:text-gray-400">
+            No multiplayer rooms in this window.
+          </p>
+        )}
+
+        {played.map((row) => {
+          const stages = [
+            { label: 'Created', value: row.rooms_created },
+            { label: 'Started', value: row.rooms_started },
+            { label: 'Finished', value: row.rooms_finished },
+          ];
+          const startedPct = share(row.rooms_started, row.rooms_created);
+          const finishedPct = share(row.rooms_finished, row.rooms_started);
+
+          return (
+            <div key={row.game_type} className="space-y-1.5">
+              <div className="flex flex-wrap items-center gap-2">
+                <GameBadge gameKey={row.game_type} meta={meta} />
+                <span className="text-xs text-gray-500 dark:text-gray-400">
+                  {startedPct === null ? '—' : `${startedPct}% started`}
+                  {' · '}
+                  {finishedPct === null
+                    ? 'none started, so nothing to finish'
+                    : `${finishedPct}% of those finished`}
+                </span>
+              </div>
+
+              {stages.map((stage, index) => {
+                const width = row.rooms_created > 0 ? (stage.value / row.rooms_created) * 100 : 0;
+                return (
+                  <div key={stage.label} className="flex items-center gap-2">
+                    <span className="w-16 shrink-0 text-right text-xs text-gray-500 dark:text-gray-400">
+                      {stage.label}
+                    </span>
+                    <div className="h-4 flex-1 rounded-sm bg-gray-100 dark:bg-slate-700">
+                      <div
+                        className="h-4 rounded-sm"
+                        style={{ width: `${width}%`, backgroundColor: ramp[index] }}
+                        // The count sits beside the bar, so the bar is only ever
+                        // the shape — nothing here depends on reading a colour
+                        // or estimating a width.
+                        role="img"
+                        aria-label={`${stage.label}: ${stage.value} rooms`}
+                      />
+                    </div>
+                    <span className="w-14 shrink-0 text-xs tabular-nums text-gray-700 dark:text-gray-200">
+                      {stage.value.toLocaleString()}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/reports/__tests__/MultiplayerFunnel.test.tsx
+++ b/components/reports/__tests__/MultiplayerFunnel.test.tsx
@@ -1,0 +1,76 @@
+import type { MultiplayerGameRow } from '@/types/reports';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { MultiplayerFunnel } from '@/components/reports/MultiplayerFunnel';
+
+const META = { grid: { key: 'grid', label: 'Grid', color: '#f97316', color_dark: '#fdba74' } };
+
+function row(overrides: Partial<MultiplayerGameRow> = {}): MultiplayerGameRow {
+  return {
+    game_type: 'grid',
+    rooms_created: 100,
+    rooms_started: 40,
+    rooms_finished: 30,
+    rooms_cancelled: 0,
+    never_started_pct: 60,
+    ...overrides,
+  } as MultiplayerGameRow;
+}
+
+describe('multiplayerFunnel', () => {
+  it('states each drop-off rather than leaving you to subtract', () => {
+    render(<MultiplayerFunnel rows={[row()]} meta={META} />);
+
+    // 40/100 started, then 30/40 of those finished — the second rate is of the
+    // previous stage, not of rooms created, which is the easy thing to get wrong.
+    expect(screen.getByText(/40% started/)).toBeTruthy();
+    expect(screen.getByText(/75% of those finished/)).toBeTruthy();
+  });
+
+  it('says nothing started rather than claiming 0% finished', () => {
+    // 0/0 is not 0%. Rendering "0% of those finished" would read as total
+    // abandonment when in fact no game ever began.
+    render(<MultiplayerFunnel rows={[row({ rooms_started: 0, rooms_finished: 0 })]} meta={META} />);
+
+    expect(screen.getByText(/none started, so nothing to finish/)).toBeTruthy();
+    expect(screen.queryByText(/0% of those finished/)).toBeNull();
+  });
+
+  it('labels every bar with its count, so the shape is never the only signal', () => {
+    render(<MultiplayerFunnel rows={[row()]} meta={META} />);
+
+    expect(screen.getByLabelText('Created: 100 rooms')).toBeTruthy();
+    expect(screen.getByLabelText('Started: 40 rooms')).toBeTruthy();
+    expect(screen.getByLabelText('Finished: 30 rooms')).toBeTruthy();
+  });
+
+  it('drops games with no rooms instead of drawing empty scaffolding', () => {
+    render(
+      <MultiplayerFunnel
+        rows={[row(), row({ game_type: 'quiz', rooms_created: 0, rooms_started: 0, rooms_finished: 0 })]}
+        meta={META}
+      />,
+    );
+
+    expect(screen.queryByLabelText('Created: 0 rooms')).toBeNull();
+  });
+
+  it('orders games by volume so the biggest funnel is read first', () => {
+    render(
+      <MultiplayerFunnel
+        rows={[row({ game_type: 'quiz', rooms_created: 10 }), row({ rooms_created: 500 })]}
+        meta={META}
+      />,
+    );
+
+    const counts = screen.getAllByLabelText(/^Created: /).map(n => n.getAttribute('aria-label'));
+
+    expect(counts).toEqual(['Created: 500 rooms', 'Created: 10 rooms']);
+  });
+
+  it('says so when there are no rooms at all', () => {
+    render(<MultiplayerFunnel rows={[]} meta={META} />);
+
+    expect(screen.getByText(/no multiplayer rooms in this window/i)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
The Multiplayer table already had created / started / finished per game — but a table makes you do the subtraction. **"Which stage loses people"** is a shape question, so it gets a shape, placed above the mode split and the table because it's the first thing you want to know.

## Stages are ordinal, not categorical

created → started → finished only means anything *in that order*. So they take **one hue in monotone lightness steps**, not three separate identities — three colours would spend the identity channel re-encoding an order the layout already shows.

Both ramps were validated against their own surface rather than picked by eye:

```
light  #10b981 → #047857 → #064e3b   ALL CHECKS PASS
dark   #6ee7b7 → #34d399 → #10b981   ALL CHECKS PASS  (vs the slate card)
```

The dark ramp re-anchors rather than flipping the light one — a flipped ramp inverts the reading direction, so the funnel would appear to darken toward the wide end.

## Three things it refuses to get wrong

**The finished rate is of the previous stage.** "75% of those finished" answers a different question from "30% of all rooms finished". Conflating them is the easy mistake, and it flatters or damns a game depending on which you pick.

**0/0 is not 0%.** A game where no room ever started says *"none started, so nothing to finish"* rather than reporting total abandonment that never happened.

**Each row is scaled to its own rooms created**, so drop-off is readable per game — which means games are **not** scaled against each other. The description says that outright instead of leaving it to be discovered from a misleading comparison.

## Accessibility

Every bar carries its count as an accessible label, so nothing depends on reading a colour or estimating a width. Widths are the shape; the numbers sit beside them.

## Mutation-verified

| Mutation | Result |
|---|---|
| Treat 0/0 as 0% | fails |
| Divide finished by created, not started | fails (2 tests) |
| Remove the bar labels | fails (2 tests) |

264 tests · types clean.
