### PR TITLE
feat(reports): make every report view shareable, not just the Pulse

### DIFF
--- a/app/reports/duration/page.tsx
+++ b/app/reports/duration/page.tsx
@@ -9,6 +9,7 @@ import { ReportsShell } from '@/components/reports/ReportsShell';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useGameMeta } from '@/hooks/use-game-meta';
 import { useReport } from '@/hooks/use-report';
+import { useReportFilters } from '@/hooks/use-report-filters';
 import { useAuth } from '@/lib/auth';
 import { rangeToParams } from '@/lib/report-range';
 import { ReportsAPI } from '@/lib/reports-api';
@@ -17,8 +18,17 @@ export default function DurationPage() {
   const { isAuthenticated, user } = useAuth();
   const enabled = isAuthenticated && !!(user?.is_staff || user?.is_superuser);
 
-  const [range, setRange] = useState<RangeState>({ window: 30 });
-  const [includeBots, setIncludeBots] = useState(false);
+  // Filters live in the URL so a view can be bookmarked, shared or reloaded
+  // without losing what was selected.
+  const { filters, update } = useReportFilters({
+    range: { window: 30 },
+    includeBots: false,
+    game: null,
+    metric: 'games_started',
+  });
+  const { range, includeBots, game } = filters;
+  const setRange = (next: RangeState) => update({ range: next });
+  const setIncludeBots = (next: boolean) => update({ includeBots: next });
   const params = useMemo(
     () => ({ ...rangeToParams(range), include_bots: includeBots }),
     [range, includeBots],

--- a/app/reports/games/[key]/page.tsx
+++ b/app/reports/games/[key]/page.tsx
@@ -15,6 +15,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Skeleton } from '@/components/ui/skeleton';
 import { useGameMeta, useGameColor } from '@/hooks/use-game-meta';
 import { useReport } from '@/hooks/use-report';
+import { useReportFilters } from '@/hooks/use-report-filters';
 import { useAuth } from '@/lib/auth';
 import { rangeToParams } from '@/lib/report-range';
 import { ReportsAPI } from '@/lib/reports-api';
@@ -39,8 +40,17 @@ export default function GameDetailPage() {
   const routeParams = useParams();
   const gameKey = String(routeParams?.key ?? '');
 
-  const [range, setRange] = useState<RangeState>({ window: 30 });
-  const [includeBots, setIncludeBots] = useState(false);
+  // Filters live in the URL so a view can be bookmarked, shared or reloaded
+  // without losing what was selected.
+  const { filters, update } = useReportFilters({
+    range: { window: 30 },
+    includeBots: false,
+    game: null,
+    metric: 'games_started',
+  });
+  const { range, includeBots } = filters;
+  const setRange = (next: RangeState) => update({ range: next });
+  const setIncludeBots = (next: boolean) => update({ includeBots: next });
   const params = useMemo(
     () => ({ ...rangeToParams(range), include_bots: includeBots, game_type: gameKey }),
     [range, includeBots, gameKey],

--- a/app/reports/games/page.tsx
+++ b/app/reports/games/page.tsx
@@ -15,6 +15,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Skeleton } from '@/components/ui/skeleton';
 import { useGameMeta } from '@/hooks/use-game-meta';
 import { useReport } from '@/hooks/use-report';
+import { useReportFilters } from '@/hooks/use-report-filters';
 import { useAuth } from '@/lib/auth';
 import { rangeToParams } from '@/lib/report-range';
 import { ReportsAPI } from '@/lib/reports-api';
@@ -40,8 +41,17 @@ export default function GamesIndexPage() {
   const { isAuthenticated, user } = useAuth();
   const enabled = isAuthenticated && !!(user?.is_staff || user?.is_superuser);
 
-  const [range, setRange] = useState<RangeState>({ window: 30 });
-  const [includeBots, setIncludeBots] = useState(false);
+  // Filters live in the URL so a view can be bookmarked, shared or reloaded
+  // without losing what was selected.
+  const { filters, update } = useReportFilters({
+    range: { window: 30 },
+    includeBots: false,
+    game: null,
+    metric: 'games_started',
+  });
+  const { range, includeBots, game } = filters;
+  const setRange = (next: RangeState) => update({ range: next });
+  const setIncludeBots = (next: boolean) => update({ includeBots: next });
   const [sortBy, setSortBy] = useState<GameSortKey>('games_started');
 
   const params = useMemo(

--- a/app/reports/multiplayer/page.tsx
+++ b/app/reports/multiplayer/page.tsx
@@ -12,6 +12,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Skeleton } from '@/components/ui/skeleton';
 import { useGameMeta } from '@/hooks/use-game-meta';
 import { useReport } from '@/hooks/use-report';
+import { useReportFilters } from '@/hooks/use-report-filters';
 import { useAuth } from '@/lib/auth';
 import { rangeToParams } from '@/lib/report-range';
 import { ReportsAPI } from '@/lib/reports-api';
@@ -21,9 +22,18 @@ export default function MultiplayerReportPage() {
   const { isAuthenticated, user } = useAuth();
   const enabled = isAuthenticated && !!(user?.is_staff || user?.is_superuser);
 
-  const [range, setRange] = useState<RangeState>({ window: 30 });
-  const [includeBots, setIncludeBots] = useState(false);
-  const [game, setGame] = useState<string | null>(null);
+  // Filters live in the URL so a view can be bookmarked, shared or reloaded
+  // without losing what was selected.
+  const { filters, update } = useReportFilters({
+    range: { window: 30 },
+    includeBots: false,
+    game: null,
+    metric: 'games_started',
+  });
+  const { range, includeBots, game } = filters;
+  const setRange = (next: RangeState) => update({ range: next });
+  const setIncludeBots = (next: boolean) => update({ includeBots: next });
+  const setGame = (next: string | null) => update({ game: next });
   const params = useMemo(
     () => ({ ...rangeToParams(range), include_bots: includeBots, ...(game ? { game_type: game } : {}) }),
     [range, includeBots, game],

--- a/app/reports/patterns/page.tsx
+++ b/app/reports/patterns/page.tsx
@@ -11,6 +11,7 @@ import { ReportsShell } from '@/components/reports/ReportsShell';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useReport } from '@/hooks/use-report';
+import { useReportFilters } from '@/hooks/use-report-filters';
 import { useAuth } from '@/lib/auth';
 import { rangeToParams } from '@/lib/report-range';
 import { ReportsAPI } from '@/lib/reports-api';
@@ -34,8 +35,17 @@ export default function PatternsPage() {
   const { isAuthenticated, user } = useAuth();
   const enabled = isAuthenticated && !!(user?.is_staff || user?.is_superuser);
 
-  const [range, setRange] = useState<RangeState>({ window: 30 });
-  const [includeBots, setIncludeBots] = useState(false);
+  // Filters live in the URL so a view can be bookmarked, shared or reloaded
+  // without losing what was selected.
+  const { filters, update } = useReportFilters({
+    range: { window: 30 },
+    includeBots: false,
+    game: null,
+    metric: 'games_started',
+  });
+  const { range, includeBots, game } = filters;
+  const setRange = (next: RangeState) => update({ range: next });
+  const setIncludeBots = (next: boolean) => update({ includeBots: next });
   const params = useMemo(
     () => ({ ...rangeToParams(range), include_bots: includeBots }),
     [range, includeBots],

--- a/app/reports/players/[id]/page.tsx
+++ b/app/reports/players/[id]/page.tsx
@@ -15,6 +15,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Skeleton } from '@/components/ui/skeleton';
 import { useGameColor, useGameMeta } from '@/hooks/use-game-meta';
 import { useReport } from '@/hooks/use-report';
+import { useReportFilters } from '@/hooks/use-report-filters';
 import { useAuth } from '@/lib/auth';
 import { rangeToParams } from '@/lib/report-range';
 import { ReportsAPI } from '@/lib/reports-api';
@@ -38,7 +39,18 @@ export default function PlayerDetailPage() {
   const routeParams = useParams();
   const userId = Number(routeParams?.id);
 
-  const [range, setRange] = useState<RangeState>({ window: 30 });
+  // Filters live in the URL so a view can be bookmarked, shared or reloaded
+  // without losing what was selected.
+  const { filters, update } = useReportFilters({
+    range: { window: 30 },
+    includeBots: false,
+    game: null,
+    metric: 'games_started',
+  });
+  // No bot or game filter here: this endpoint is scoped to one user, so neither
+  // applies — echoing them back would imply a filter the query ignores.
+  const { range } = filters;
+  const setRange = (next: RangeState) => update({ range: next });
   const params = useMemo(() => rangeToParams(range), [range]);
 
   const { meta } = useGameMeta(enabled);

--- a/app/reports/players/page.tsx
+++ b/app/reports/players/page.tsx
@@ -11,6 +11,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Skeleton } from '@/components/ui/skeleton';
 import { useGameMeta } from '@/hooks/use-game-meta';
 import { useReport } from '@/hooks/use-report';
+import { useReportFilters } from '@/hooks/use-report-filters';
 import { useAuth } from '@/lib/auth';
 import { rangeToParams } from '@/lib/report-range';
 import { ReportsAPI } from '@/lib/reports-api';
@@ -19,9 +20,18 @@ export default function PlayersReportPage() {
   const { isAuthenticated, user } = useAuth();
   const enabled = isAuthenticated && !!(user?.is_staff || user?.is_superuser);
 
-  const [range, setRange] = useState<RangeState>({ window: 7 });
-  const [includeBots, setIncludeBots] = useState(false);
-  const [game, setGame] = useState<string | null>(null);
+  // Filters live in the URL so a view can be bookmarked, shared or reloaded
+  // without losing what was selected.
+  const { filters, update } = useReportFilters({
+    range: { window: 7 },
+    includeBots: false,
+    game: null,
+    metric: 'games_started',
+  });
+  const { range, includeBots, game } = filters;
+  const setRange = (next: RangeState) => update({ range: next });
+  const setIncludeBots = (next: boolean) => update({ includeBots: next });
+  const setGame = (next: string | null) => update({ game: next });
   // 'played' ranks by sessions started, 'finished' by ones seen through — the gap
   // between them is the interesting part, so both are reachable.
   const [sortBy, setSortBy] = useState<'played' | 'finished'>('played');

--- a/app/reports/retention/page.tsx
+++ b/app/reports/retention/page.tsx
@@ -8,6 +8,7 @@ import { ReportsShell } from '@/components/reports/ReportsShell';
 import { RetentionTable } from '@/components/reports/RetentionTable';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useReport } from '@/hooks/use-report';
+import { useReportFilters } from '@/hooks/use-report-filters';
 import { useAuth } from '@/lib/auth';
 import { rangeToParams } from '@/lib/report-range';
 import { ReportsAPI } from '@/lib/reports-api';
@@ -18,8 +19,17 @@ export default function RetentionPage() {
 
   // 60 days by default: D30 needs a month of runway before any cohort can even
   // reach it, so a 7-day default would show a table of dashes.
-  const [range, setRange] = useState<RangeState>({ window: 60 });
-  const [includeBots, setIncludeBots] = useState(false);
+  // Filters live in the URL so a view can be bookmarked, shared or reloaded
+  // without losing what was selected.
+  const { filters, update } = useReportFilters({
+    range: { window: 60 },
+    includeBots: false,
+    game: null,
+    metric: 'games_started',
+  });
+  const { range, includeBots, game } = filters;
+  const setRange = (next: RangeState) => update({ range: next });
+  const setIncludeBots = (next: boolean) => update({ includeBots: next });
   const params = useMemo(
     () => ({ ...rangeToParams(range), include_bots: includeBots }),
     [range, includeBots],

--- a/lib/__tests__/report-filters.test.ts
+++ b/lib/__tests__/report-filters.test.ts
@@ -41,3 +41,41 @@ describe('report filter URL state', () => {
     expect(parsed.includeBots).toBe(true);
   });
 });
+
+describe('every report page keeps its filters in the URL', () => {
+  it('has no page falling back to local-only state', async () => {
+    // useReportFilters existed for months and was wired into exactly one page,
+    // so eight report views could not be shared, bookmarked, or survive a
+    // refresh. Nothing failed — the pages worked, they just quietly forgot.
+    const { readdirSync, readFileSync } = await import('node:fs');
+    const { join } = await import('node:path');
+
+    const root = join(process.cwd(), 'app', 'reports');
+
+    function pages(dir: string): string[] {
+      return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) return pages(full);
+        return entry.name === 'page.tsx' ? [full] : [];
+      });
+    }
+
+    const found = pages(root);
+    expect(found.length).toBeGreaterThan(5);
+
+    const offenders = found.filter((file) => {
+      const source = readFileSync(file, 'utf8');
+      // A page with no range picker has no filters to share.
+      if (!source.includes('RangePicker')) return false;
+      // Holding the range in local state is the actual anti-pattern, and the
+      // shape a new page naturally reaches for. Checking only for the hook's
+      // name matched even after its import was removed.
+      return /useState<RangeState>/.test(source) || !/useReportFilters\(/.test(source);
+    });
+
+    expect(
+      offenders.map(f => f.replace(process.cwd(), '')),
+      'Report pages holding filters in local state only — they cannot be shared or bookmarked',
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
`useReportFilters` keeps range, bot inclusion and game selection in the URL. It was written months ago and wired into **exactly one page** — so eight report views couldn't be bookmarked, shared, or survive a refresh.

Nothing failed. The pages worked; they just quietly forgot what you'd picked. Same shape as `ModeBreakdown` being built complete and never rendered.

All eight now use it, so **"Multiplayer, last 90 days, Grid only" is a link you can send someone.**

## Two pages deliberately take less

The **player drill-down** is scoped to one user, so neither the bot nor the game filter applies — carrying them would imply a filter the query ignores, which is exactly the trap already fixed in the API after Copilot caught it. The **per-game page** has no game selector for the same reason.

## The guard matters here

This failure is silent by construction: a page holding its range in local state renders perfectly and passes every test. So the guard flags any page with a `RangePicker` that keeps its range in `useState`.

**My first version of that guard was useless.** It checked whether `useReportFilters` appeared anywhere in the file, so removing the import still passed — the call site kept the substring alive. It now looks for the anti-pattern itself, which is also the shape a new page naturally reaches for:

```
Report pages holding filters in local state only — they cannot be
shared or bookmarked: [ '/app/reports/duration/page.tsx' ]
```

265 tests · types clean · build green.
