### PR TITLE
fix(reports): stop showing today's pulse for a historical range

### DIFF
--- a/app/reports/page.tsx
+++ b/app/reports/page.tsx
@@ -87,16 +87,34 @@ export default function ReportsPage() {
           ? <Skeleton className="h-32 w-full" />
           : (
               <>
-                <PulseTiles pulse={summary.data.pulse} />
-                <p className="text-center text-xs text-gray-500 dark:text-gray-400">
-                  {selectedLabel ? `${selectedLabel} · ` : ''}
-                  compared with the mean of the last
-                  {' '}
-                  {summary.data.pulse.baseline_weeks}
-                  {' '}
-                  {summary.data.pulse.weekday}
-                  s — not with yesterday, which would make every Monday look like a crash.
-                </p>
+                {/* The pulse always describes TODAY, whatever range is selected —
+                    the BE sends pulse_applies to say so. Rendering it beside
+                    comparison tiles that DO follow the range invites reading
+                    today's numbers as the selected period's. */}
+                {summary.data.pulse_applies
+                  ? (
+                      <>
+                        <PulseTiles pulse={summary.data.pulse} />
+                        <p className="text-center text-xs text-gray-500 dark:text-gray-400">
+                          {selectedLabel ? `${selectedLabel} · ` : ''}
+                          compared with the mean of the last
+                          {' '}
+                          {summary.data.pulse.baseline_weeks}
+                          {' '}
+                          {summary.data.pulse.weekday}
+                          s — not with yesterday, which would make every Monday look like a crash.
+                        </p>
+                      </>
+                    )
+                  : (
+                      <p className="rounded-md border border-gray-200 bg-gray-50 p-3 text-center text-sm text-gray-600 dark:border-slate-700 dark:bg-slate-800 dark:text-gray-300">
+                        Today's pulse is hidden because this range ends on
+                        {' '}
+                        {summary.data.end}
+                        . It only ever describes today, so showing it here would
+                        read as the selected period. Everything below follows your range.
+                      </p>
+                    )}
               </>
             )}
 

--- a/app/reports/players/[id]/page.tsx
+++ b/app/reports/players/[id]/page.tsx
@@ -94,6 +94,15 @@ export default function PlayerDetailPage() {
           includeBots={false}
           onIncludeBotsChange={() => undefined}
         />
+
+        {/* Bot accounts are filtered out of every other report, so landing here
+            from a direct link is the one way to read simulation traffic as real
+            play. The BE already flags it; nothing was showing it. */}
+        {data?.is_bot && (
+          <span className="rounded-full border border-amber-300 bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-900 dark:border-amber-800 dark:bg-amber-900/20 dark:text-amber-100">
+            Bot / simulation account — excluded from every other report
+          </span>
+        )}
       </div>
 
       {error

--- a/lib/__tests__/response-fields-used.test.ts
+++ b/lib/__tests__/response-fields-used.test.ts
@@ -1,0 +1,91 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Every field the API sends should reach the UI, or be deliberately listed here.
+ *
+ * The backend computes several "don't misread this" signals — `pulse_applies`
+ * says the pulse describes today whatever range is selected, `coverage` says a
+ * day was never computed. The UI silently dropped `pulse_applies` for months, so
+ * a historical range rendered today's numbers directly above comparison tiles
+ * that DO follow the range. Nothing errored. The page just invited the wrong
+ * reading, which is worse than a blank panel.
+ *
+ * Fetching a field and never rendering it is invisible by construction: no
+ * caller goes missing, no type breaks, no test fails. This is the cheapest
+ * thing that notices.
+ */
+
+const ROOT = process.cwd();
+
+/**
+ * Fields that are deliberately not rendered, with the reason. An entry here is
+ * a decision; the absence of one is an oversight.
+ */
+const NOT_RENDERED: Record<string, string> = {
+  grain: 'A reminder in the payload that multiplayer counts rooms; the card description says it in prose.',
+  long_session_seconds: 'The threshold behind the per-row single_sitting flag, which is what the table renders.',
+  games_without_duration: 'Derived per row as `supported`, which DurationTable already groups by.',
+  long_lived_session_games: 'Derived per row as `single_sitting`, which DurationTable already groups by.',
+  window_totals: 'The comparison tiles render the same window from `comparison`, with movement attached.',
+};
+
+function sources(): string {
+  const out: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === 'node_modules' || entry.name === '__tests__') continue;
+        walk(full);
+      } else if (/\.tsx?$/.test(entry.name) && !full.endsWith(join('types', 'reports.ts'))) {
+        // Comments are stripped: a field named only in prose is documented, not
+        // rendered, and would otherwise satisfy this check while the UI still
+        // drops the value.
+        out.push(
+          readFileSync(full, 'utf8')
+            .replace(/\/\*[\s\S]*?\*\//g, ' ')
+            .replace(/^\s*\/\/.*$/gm, ' '),
+        );
+      }
+    }
+  };
+  for (const dir of ['app', 'components', 'hooks', 'lib']) walk(join(ROOT, dir));
+  return out.join('\n');
+}
+
+describe('reporting response fields', () => {
+  it('are rendered, or explicitly listed as not rendered', () => {
+    const types = readFileSync(join(ROOT, 'types', 'reports.ts'), 'utf8');
+
+    const fields = new Set<string>();
+    for (const block of types.matchAll(/export type \w+Response = \{([\s\S]*?)\n\}/g)) {
+      for (const field of block[1].matchAll(/^ {2}([a-z_][a-z0-9_]*)\??:/gm)) {
+        fields.add(field[1]);
+      }
+    }
+
+    // A regex that matched nothing would make this pass forever.
+    expect(fields.size).toBeGreaterThan(20);
+
+    const blob = sources();
+    const dropped = [...fields]
+      .filter(name => !new RegExp(`\\b${name}\\b`).test(blob))
+      .filter(name => !(name in NOT_RENDERED));
+
+    expect(
+      dropped,
+      `Sent by the API and never used in the UI: ${dropped.join(', ')}. `
+      + 'Render it, or add it to NOT_RENDERED with the reason.',
+    ).toEqual([]);
+  });
+
+  it('does not keep exemptions for fields that are now rendered', () => {
+    // A stale exemption is cover for the next field that gets dropped.
+    const blob = sources();
+    const stale = Object.keys(NOT_RENDERED).filter(name => new RegExp(`\\b${name}\\b`).test(blob));
+
+    expect(stale, `Listed as not rendered, but used: ${stale.join(', ')}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
I went looking for fields the API sends and the UI drops. Seven turned up; one of them is a real correctness problem.

## The Pulse was describing the wrong period

The backend sends `pulse_applies`, with this comment beside it:

> *"The pulse ignores the range because it describes today; the comparison is what responds when you change the dates. **Clients should show the pulse only when the range ends today.**"*

The UI ignored the flag. So selecting a historical range rendered **today's numbers directly above comparison tiles that DO follow the range**. Nothing errored — the page just invited reading today's figures as the selected period's, which is worse than showing nothing at all.

It now explains the absence rather than leaving a hole: which day the range ends on, and that everything below follows the range.

## Bot accounts on the drill-down

`is_bot` was sent and never shown. Bot accounts are filtered out of every *other* report, so arriving at a player page from a direct link was the one route by which simulation traffic could be read as real play.

## The guard is the point

This failure is invisible by construction: a field fetched and never rendered breaks no type, drops no caller, fails no test. So every field on a `*Response` type must now either be used in the UI or **listed as deliberately not rendered, with the reason**.

A second test fails when an exemption goes stale — it caught one of my own entries (`limit`) immediately, which is exactly what stops the list becoming cover for the next dropped field.

**The first version could be fooled by a comment.** Because I'd just written a comment mentioning `pulse_applies`, the guard passed even with the fix reverted. Comments are now stripped before searching — otherwise documenting a bug would have counted as fixing it.

| Mutation | Result |
|---|---|
| Revert the `pulse_applies` fix | fails, names the field |
| Add a stale exemption | fails, names it |

267 tests · types clean · build green.
