### PR TITLE
feat(reports): let retention and patterns be read per game

### DIFF
--- a/app/reports/patterns/page.tsx
+++ b/app/reports/patterns/page.tsx
@@ -5,11 +5,13 @@ import { useMemo, useState } from 'react';
 import { Area, AreaChart, Bar, BarChart, CartesianGrid, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import { ActivityHeatmap } from '@/components/reports/ActivityHeatmap';
 import { MetricInfo } from '@/components/reports/MetricInfo';
+import { GameFilter } from '@/components/reports/GameFilter';
 import { RangePicker } from '@/components/reports/RangePicker';
 import { ReportError } from '@/components/reports/ReportError';
 import { ReportsShell } from '@/components/reports/ReportsShell';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
+import { useGameMeta } from '@/hooks/use-game-meta';
 import { useReport } from '@/hooks/use-report';
 import { useReportFilters } from '@/hooks/use-report-filters';
 import { useAuth } from '@/lib/auth';
@@ -46,11 +48,13 @@ export default function PatternsPage() {
   const { range, includeBots, game } = filters;
   const setRange = (next: RangeState) => update({ range: next });
   const setIncludeBots = (next: boolean) => update({ includeBots: next });
+  const setGame = (next: string | null) => update({ game: next });
   const params = useMemo(
-    () => ({ ...rangeToParams(range), include_bots: includeBots }),
-    [range, includeBots],
+    () => ({ ...rangeToParams(range), include_bots: includeBots, ...(game ? { game_type: game } : {}) }),
+    [range, includeBots, game],
   );
 
+  const { meta } = useGameMeta(enabled);
   const { data, isLoading, error, notDeployed, refetch } = useReport(
     ReportsAPI.getPatterns,
     params,
@@ -72,6 +76,8 @@ export default function PatternsPage() {
         includeBots={includeBots}
         onIncludeBotsChange={setIncludeBots}
       />
+
+      <GameFilter meta={meta} value={game} onChange={setGame} />
 
       {error
         ? <ReportError error={error} notDeployed={notDeployed} onRetry={refetch} />

--- a/app/reports/retention/page.tsx
+++ b/app/reports/retention/page.tsx
@@ -2,11 +2,13 @@
 
 import type { RangeState } from '@/lib/report-range';
 import { useMemo, useState } from 'react';
+import { GameFilter } from '@/components/reports/GameFilter';
 import { RangePicker } from '@/components/reports/RangePicker';
 import { ReportError } from '@/components/reports/ReportError';
 import { ReportsShell } from '@/components/reports/ReportsShell';
 import { RetentionTable } from '@/components/reports/RetentionTable';
 import { Skeleton } from '@/components/ui/skeleton';
+import { useGameMeta } from '@/hooks/use-game-meta';
 import { useReport } from '@/hooks/use-report';
 import { useReportFilters } from '@/hooks/use-report-filters';
 import { useAuth } from '@/lib/auth';
@@ -30,11 +32,13 @@ export default function RetentionPage() {
   const { range, includeBots, game } = filters;
   const setRange = (next: RangeState) => update({ range: next });
   const setIncludeBots = (next: boolean) => update({ includeBots: next });
+  const setGame = (next: string | null) => update({ game: next });
   const params = useMemo(
-    () => ({ ...rangeToParams(range), include_bots: includeBots }),
-    [range, includeBots],
+    () => ({ ...rangeToParams(range), include_bots: includeBots, ...(game ? { game_type: game } : {}) }),
+    [range, includeBots, game],
   );
 
+  const { meta } = useGameMeta(enabled);
   const { data, isLoading, error, notDeployed, refetch } = useReport(
     ReportsAPI.getRetention,
     params,
@@ -53,6 +57,8 @@ export default function RetentionPage() {
         includeBots={includeBots}
         onIncludeBotsChange={setIncludeBots}
       />
+
+      <GameFilter meta={meta} value={game} onChange={setGame} />
 
       {error
         ? <ReportError error={error} notDeployed={notDeployed} onRetry={refetch} />

--- a/components/reports/GameFilter.tsx
+++ b/components/reports/GameFilter.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import type { GameMetaMap } from '@/hooks/use-game-meta';
+import { GameBadge } from '@/components/reports/GameBadge';
+
+/**
+ * Pick one game, or all of them.
+ *
+ * The retention and patterns endpoints have accepted `game_type` since they were
+ * written; nothing in the UI ever sent it, so "which game keeps people coming
+ * back" and "when is Grid played" were a query parameter away and unreachable.
+ *
+ * Games come from the BE registry rather than from the response, so every game
+ * is selectable even when it has no rows in the current window — a game with
+ * zero retention is exactly the one worth looking at, and building the list
+ * from the data would hide it.
+ */
+export function GameFilter({ meta, value, onChange }: {
+  meta: GameMetaMap;
+  value: string | null;
+  onChange: (game: string | null) => void;
+}) {
+  const games = Object.values(meta).sort((a, b) => a.label.localeCompare(b.label));
+
+  if (games.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <span className="text-sm text-gray-600 dark:text-gray-300">Game</span>
+      <button
+        type="button"
+        onClick={() => onChange(null)}
+        aria-pressed={value === null}
+        className={value === null
+          ? 'rounded-full border border-emerald-600 bg-emerald-600 px-2.5 py-0.5 text-xs font-medium text-white'
+          : 'rounded-full border border-gray-300 px-2.5 py-0.5 text-xs font-medium text-gray-700 hover:bg-gray-50 dark:border-slate-600 dark:text-gray-200 dark:hover:bg-slate-700'}
+      >
+        All games
+      </button>
+      {games.map(game => (
+        <GameBadge
+          key={game.key}
+          gameKey={game.key}
+          meta={meta}
+          active={value === game.key}
+          onClick={key => onChange(value === key ? null : key)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/components/reports/__tests__/GameFilter.test.tsx
+++ b/components/reports/__tests__/GameFilter.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { GameFilter } from '@/components/reports/GameFilter';
+
+const META = {
+  grid: { key: 'grid', label: 'Grid', color: '#f97316', color_dark: '#fdba74' },
+  quiz: { key: 'quiz', label: 'Quiz', color: '#3b82f6', color_dark: '#3b82f6' },
+  conquest: { key: 'conquest', label: 'Conquest', color: '#38bdf8', color_dark: '#7dd3fc' },
+};
+
+describe('gameFilter', () => {
+  it('offers every registered game, not only ones with data', () => {
+    // Built from the BE registry rather than the response on purpose: a game
+    // with zero retention is exactly the one worth selecting, and a
+    // data-derived list would hide it precisely when it matters.
+    render(<GameFilter meta={META} value={null} onChange={() => {}} />);
+
+    expect(screen.getByText('Grid')).toBeTruthy();
+    expect(screen.getByText('Quiz')).toBeTruthy();
+    expect(screen.getByText('Conquest')).toBeTruthy();
+  });
+
+  it('marks "All games" as the selected state when nothing is filtered', () => {
+    render(<GameFilter meta={META} value={null} onChange={() => {}} />);
+
+    expect(screen.getByRole('button', { name: 'All games' }).getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('clears the filter when the active game is clicked again', async () => {
+    // Without this the only way back to "all games" is finding the separate
+    // button, and a filter you cannot undo where you set it is a trap.
+    const onChange = vi.fn();
+    render(<GameFilter meta={META} value="grid" onChange={onChange} />);
+
+    await userEvent.click(screen.getByText('Grid'));
+
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it('selects a game that is not currently active', async () => {
+    const onChange = vi.fn();
+    render(<GameFilter meta={META} value="grid" onChange={onChange} />);
+
+    await userEvent.click(screen.getByText('Quiz'));
+
+    expect(onChange).toHaveBeenCalledWith('quiz');
+  });
+
+  it('renders nothing before the registry has loaded', () => {
+    // Better an absent control than an empty one that looks broken.
+    const { container } = render(<GameFilter meta={{}} value={null} onChange={() => {}} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('lists games alphabetically so the control does not reorder itself', () => {
+    render(<GameFilter meta={META} value={null} onChange={() => {}} />);
+    const labels = screen.getAllByRole('button').map(b => b.textContent).filter(t => t !== 'All games');
+
+    expect(labels).toEqual(['Conquest', 'Grid', 'Quiz']);
+  });
+});


### PR DESCRIPTION
The retention and patterns endpoints have accepted `game_type` since they were written. Nothing in the UI ever sent it — so **"which game keeps people coming back"** and **"when is this game actually played"** were one query parameter away and unreachable.

## It changes the answer

Verified against real data, not assumed:

| | Platform | Grid only |
|---|---|---|
| Peak hour | 15:00 | **17:00** |
| Busiest slot | Tue 16:00 | **Thu 00:00** |
| Retention cohorts | 227 | 60 |

Reading Grid off the platform average would have been wrong about both its peak hour and its busiest day. That's the whole point of the filter — the aggregate hides exactly the thing you'd act on.

## Two design decisions

**The selector is built from the BE registry, not from the response.** A game with zero retention is precisely the one worth selecting, and a data-derived list would hide it exactly when it matters most.

**Clicking the active game clears the filter**, so it can be undone where it was set rather than only via a separate control. A filter you can't undo where you set it is a trap.

The selection already rides in the URL via `useReportFilters` (merged earlier), so **"Grid retention, last 90 days" is a shareable link**.

## Mutation-verified

| Mutation | Result |
|---|---|
| Drop click-to-clear | fails |
| Derive the list from data | fails (4 tests) |
| Remove alphabetical order | fails |

273 tests · types clean · build green.
