### PR TITLE
feat(reports): export any report, not just the Pulse

### DIFF
--- a/app/reports/duration/page.tsx
+++ b/app/reports/duration/page.tsx
@@ -3,6 +3,7 @@
 import type { RangeState } from '@/lib/report-range';
 import { useMemo, useState } from 'react';
 import { DurationTable } from '@/components/reports/DurationTable';
+import { ExportButton } from '@/components/reports/ExportButton';
 import { RangePicker } from '@/components/reports/RangePicker';
 import { ReportError } from '@/components/reports/ReportError';
 import { ReportsShell } from '@/components/reports/ReportsShell';
@@ -53,6 +54,24 @@ export default function DurationPage() {
         includeBots={includeBots}
         onIncludeBotsChange={setIncludeBots}
       />
+
+      <div className="flex justify-end">
+        <ExportButton
+          rows={data?.rows ?? []}
+          view="duration"
+          filters={{ ...rangeToParams(range), bots: includeBots, game }}
+          columns={[
+                    { header: 'Game', value: row => row.game_type },
+                    { header: 'Supported', value: row => row.supported },
+                    { header: 'Sessions', value: row => row.sessions },
+                    { header: 'Measured', value: row => row.measured },
+                    { header: 'Coverage %', value: row => row.coverage_pct },
+                    { header: 'Median seconds', value: row => row.median_seconds },
+                    { header: 'Long sessions', value: row => row.long_sessions },
+                    { header: 'Single sitting', value: row => row.single_sitting },
+                  ]}
+        />
+      </div>
 
       {error
         ? <ReportError error={error} notDeployed={notDeployed} onRetry={refetch} />

--- a/app/reports/games/page.tsx
+++ b/app/reports/games/page.tsx
@@ -8,6 +8,7 @@ import Link from 'next/link';
 import { useMemo, useState } from 'react';
 import { GameBadge } from '@/components/reports/GameBadge';
 import { MetricInfo } from '@/components/reports/MetricInfo';
+import { ExportButton } from '@/components/reports/ExportButton';
 import { RangePicker } from '@/components/reports/RangePicker';
 import { ReportError } from '@/components/reports/ReportError';
 import { ReportsShell } from '@/components/reports/ReportsShell';
@@ -101,6 +102,23 @@ export default function GamesIndexPage() {
         includeBots={includeBots}
         onIncludeBotsChange={setIncludeBots}
       />
+
+      <div className="flex justify-end">
+        <ExportButton
+          rows={rows}
+          view="games"
+          filters={{ ...rangeToParams(range), bots: includeBots, game }}
+          columns={[
+                    { header: 'Game', value: row => row.game_type },
+                    { header: 'Played', value: row => row.games_started },
+                    { header: 'Finished', value: row => row.games_finished },
+                    { header: 'Completion %', value: row => row.completion_pct },
+                    { header: 'Sessions per player', value: row => row.sessions_per_player },
+                    { header: 'Came back %', value: row => row.repeat_rate_pct },
+                    { header: 'Trend %', value: row => row.trend_pct },
+                  ]}
+        />
+      </div>
 
       {error
         ? <ReportError error={error} notDeployed={notDeployed} onRetry={refetch} />

--- a/app/reports/multiplayer/page.tsx
+++ b/app/reports/multiplayer/page.tsx
@@ -5,6 +5,7 @@ import { useMemo, useState } from 'react';
 import { GameBadge } from '@/components/reports/GameBadge';
 import { ModeBreakdown } from '@/components/reports/ModeBreakdown';
 import { MultiplayerFunnel } from '@/components/reports/MultiplayerFunnel';
+import { ExportButton } from '@/components/reports/ExportButton';
 import { RangePicker } from '@/components/reports/RangePicker';
 import { ReportError } from '@/components/reports/ReportError';
 import { ReportsShell } from '@/components/reports/ReportsShell';
@@ -68,6 +69,22 @@ export default function MultiplayerReportPage() {
           <GameBadge gameKey={game} meta={meta} active onClick={() => setGame(null)} />
         </div>
       )}
+
+      <div className="flex justify-end">
+        <ExportButton
+          rows={data?.by_game ?? []}
+          view="multiplayer"
+          filters={{ ...rangeToParams(range), bots: includeBots, game }}
+          columns={[
+                    { header: 'Game', value: row => row.game_type },
+                    { header: 'Rooms created', value: row => row.rooms_created },
+                    { header: 'Started', value: row => row.rooms_started },
+                    { header: 'Finished', value: row => row.rooms_finished },
+                    { header: 'Cancelled', value: row => row.rooms_cancelled },
+                    { header: 'Never started %', value: row => row.never_started_pct },
+                  ]}
+        />
+      </div>
 
       {error
         ? <ReportError error={error} notDeployed={notDeployed} onRetry={refetch} />

--- a/app/reports/patterns/page.tsx
+++ b/app/reports/patterns/page.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import type { RangeState } from '@/lib/report-range';
+import type { HourWeekdayRow } from '@/types/reports';
 import { useMemo, useState } from 'react';
 import { Area, AreaChart, Bar, BarChart, CartesianGrid, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import { ActivityHeatmap } from '@/components/reports/ActivityHeatmap';
 import { MetricInfo } from '@/components/reports/MetricInfo';
+import { ExportButton } from '@/components/reports/ExportButton';
 import { GameFilter } from '@/components/reports/GameFilter';
 import { RangePicker } from '@/components/reports/RangePicker';
 import { ReportError } from '@/components/reports/ReportError';
@@ -78,6 +80,24 @@ export default function PatternsPage() {
       />
 
       <GameFilter meta={meta} value={game} onChange={setGame} />
+
+      <div className="flex justify-end">
+        <ExportButton
+          // The grid is the page's real dataset; the two bar charts are its
+          // margins. Exported one row per weekday with 24 hour columns, which
+          // is the shape a spreadsheet can pivot.
+          rows={data?.by_hour_weekday ?? []}
+          view="patterns"
+          filters={{ ...rangeToParams(range), bots: includeBots, game }}
+          columns={[
+            { header: 'Weekday', value: row => row.name },
+            ...Array.from({ length: 24 }, (_, hour) => ({
+              header: `${String(hour).padStart(2, '0')}:00`,
+              value: (row: HourWeekdayRow) => row.hours[hour],
+            })),
+          ]}
+        />
+      </div>
 
       {error
         ? <ReportError error={error} notDeployed={notDeployed} onRetry={refetch} />

--- a/app/reports/players/page.tsx
+++ b/app/reports/players/page.tsx
@@ -3,6 +3,7 @@
 import type { RangeState } from '@/lib/report-range';
 import { useMemo, useState } from 'react';
 import { GameBadge } from '@/components/reports/GameBadge';
+import { ExportButton } from '@/components/reports/ExportButton';
 import { RangePicker } from '@/components/reports/RangePicker';
 import { ReportError } from '@/components/reports/ReportError';
 import { ReportsShell } from '@/components/reports/ReportsShell';
@@ -80,6 +81,22 @@ export default function PlayersReportPage() {
           <GameBadge gameKey={game} meta={meta} active onClick={() => setGame(null)} />
         </div>
       )}
+
+      <div className="flex justify-end">
+        <ExportButton
+          rows={data?.players ?? []}
+          view="players"
+          filters={{ ...rangeToParams(range), bots: includeBots, game }}
+          columns={[
+                    { header: 'User ID', value: row => row.user_id },
+                    { header: 'Username', value: row => row.username },
+                    { header: 'Played', value: row => row.games_played },
+                    { header: 'Finished', value: row => row.games_finished },
+                    { header: 'Distinct games', value: row => row.distinct_games },
+                    { header: 'Games', value: row => row.games.join(' | ') },
+                  ]}
+        />
+      </div>
 
       {error
         ? <ReportError error={error} notDeployed={notDeployed} onRetry={refetch} />

--- a/app/reports/retention/page.tsx
+++ b/app/reports/retention/page.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import type { RangeState } from '@/lib/report-range';
+import type { RetentionCohort } from '@/types/reports';
 import { useMemo, useState } from 'react';
+import { ExportButton } from '@/components/reports/ExportButton';
 import { GameFilter } from '@/components/reports/GameFilter';
 import { RangePicker } from '@/components/reports/RangePicker';
 import { ReportError } from '@/components/reports/ReportError';
@@ -59,6 +61,30 @@ export default function RetentionPage() {
       />
 
       <GameFilter meta={meta} value={game} onChange={setGame} />
+
+      <div className="flex justify-end">
+        <ExportButton
+          rows={data?.cohorts ?? []}
+          view="retention"
+          filters={{ ...rangeToParams(range), bots: includeBots, game }}
+          columns={[
+                    { header: 'Cohort date', value: row => row.date },
+                    { header: 'Cohort size', value: row => row.cohort_size },
+                    { header: 'Inflated', value: row => row.inflated },
+                    // One column per offset, because a JSON blob in a cell is
+                    // not something a spreadsheet can chart. Null stays empty
+                    // rather than 0: the cohort hasn't reached that day yet.
+                    ...(data?.offsets ?? []).map(offset => ({
+                      header: `D${offset} %`,
+                      value: (row: RetentionCohort) => row.retention[String(offset)]?.pct ?? '',
+                    })),
+                    ...(data?.offsets ?? []).map(offset => ({
+                      header: `D${offset} returned`,
+                      value: (row: RetentionCohort) => row.retention[String(offset)]?.returned ?? '',
+                    })),
+                  ]}
+        />
+      </div>
 
       {error
         ? <ReportError error={error} notDeployed={notDeployed} onRetry={refetch} />

--- a/lib/__tests__/report-filters.test.ts
+++ b/lib/__tests__/report-filters.test.ts
@@ -79,3 +79,41 @@ describe('every report page keeps its filters in the URL', () => {
     ).toEqual([]);
   });
 });
+
+describe('every report page can be exported', () => {
+  it('has no data page without a CSV export', async () => {
+    // ExportButton and the CSV helper existed and were wired into one page out
+    // of seven, so six reports could be read but not taken anywhere. Nothing
+    // failed — the pages simply had no way out of the browser.
+    const { readdirSync, readFileSync } = await import('node:fs');
+    const { join } = await import('node:path');
+
+    const root = join(process.cwd(), 'app', 'reports');
+
+    function pages(dir: string): string[] {
+      return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) return pages(full);
+        return entry.name === 'page.tsx' ? [full] : [];
+      });
+    }
+
+    const found = pages(root);
+    expect(found.length).toBeGreaterThan(5);
+
+    const offenders = found.filter((file) => {
+      const source = readFileSync(file, 'utf8');
+      // The glossary is reference text, and the drill-downs are a single
+      // record — neither is a dataset anyone would take to a spreadsheet.
+      if (file.includes('glossary') || file.includes('[id]') || file.includes('[key]')) return false;
+      // A page with no range picker isn't a data view.
+      if (!source.includes('RangePicker')) return false;
+      return !source.includes('ExportButton');
+    });
+
+    expect(
+      offenders.map(f => f.replace(process.cwd(), '')),
+      'Report pages with no CSV export — the data can be read but not taken anywhere',
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
`ExportButton` and the CSV helper were written complete — including escaping for leading `=`, `+`, `-` and `@`, so a username like `=cmd()` can't execute when a spreadsheet opens the file — and wired into **one page out of seven**.

Six reports could be read but not taken anywhere. Nothing failed; the pages simply had no way out of the browser.

## Two shapes needed thought, not just a column list

**Retention** exports one column per offset. A JSON blob in a cell isn't something a spreadsheet can chart. A cohort that hasn't reached an offset yet exports **empty, never 0** — the same distinction the table already makes on screen, and the one that turns "not yet measured" into a false "nobody came back".

**Patterns** exports the weekday × hour grid — one row per weekday, 24 hour columns. The grid is the page's real dataset; the two bar charts are its *margins*. Exporting a margin would lose the thing the page exists to show, and it's the margins that disagree with the grid about when people actually play.

Everything exports **what's on screen**, with the filters in the filename so a folder of exports stays interpretable.

## The guard

This is the **fourth** capability found built-and-barely-wired, after `ModeBreakdown`, `useReportFilters` and per-game filtering. So: any page with a range picker must offer an export.

The glossary and the two drill-downs are exempt — reference text and single records aren't datasets anyone takes to a spreadsheet.

Mutation-verified: removing the export from one page fails and names the file.

274 tests · types clean · build green.
