### PR TITLE
feat(reports): let the players view show 50 or 100 rows

### DIFF
--- a/app/reports/players/page.tsx
+++ b/app/reports/players/page.tsx
@@ -28,8 +28,9 @@ export default function PlayersReportPage() {
     includeBots: false,
     game: null,
     metric: 'games_started',
+    limit: 25,
   });
-  const { range, includeBots, game } = filters;
+  const { range, includeBots, game, limit } = filters;
   const setRange = (next: RangeState) => update({ range: next });
   const setIncludeBots = (next: boolean) => update({ includeBots: next });
   const setGame = (next: string | null) => update({ game: next });
@@ -38,8 +39,8 @@ export default function PlayersReportPage() {
   const [sortBy, setSortBy] = useState<'played' | 'finished'>('played');
 
   const params = useMemo(
-    () => ({ ...rangeToParams(range), include_bots: includeBots, limit: 25, ...(game ? { game_type: game } : {}) }),
-    [range, includeBots, game],
+    () => ({ ...rangeToParams(range), include_bots: includeBots, limit, ...(game ? { game_type: game } : {}) }),
+    [range, includeBots, game, limit],
   );
 
   const { meta } = useGameMeta(enabled);
@@ -66,7 +67,20 @@ export default function PlayersReportPage() {
       />
 
       <div className="flex flex-wrap items-center gap-2">
-        <span className="text-sm text-gray-600 dark:text-gray-300">Rank by</span>
+        <span className="text-sm text-gray-600 dark:text-gray-300">Show</span>
+        {/* 100 is the API's own cap (MAX_LIMIT); offering more would 400. */}
+        {[25, 50, 100].map(size => (
+          <Button
+            key={size}
+            size="sm"
+            variant={limit === size ? 'default' : 'outline'}
+            onClick={() => update({ limit: size })}
+          >
+            {size}
+          </Button>
+        ))}
+
+        <span className="ml-2 text-sm text-gray-600 dark:text-gray-300">Rank by</span>
         <Button size="sm" variant={sortBy === 'played' ? 'default' : 'outline'} onClick={() => setSortBy('played')}>
           Played
         </Button>

--- a/hooks/use-report-filters.ts
+++ b/hooks/use-report-filters.ts
@@ -22,9 +22,17 @@ export type ReportFilters = {
   includeBots: boolean;
   game: string | null;
   metric: MetricKey;
+  /** Rows on the leaderboard views. Bounded by the API's own cap. */
+  limit: number;
 };
 
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+/** MAX_LIMIT in core/reporting_views.py — a larger value is rejected with a 400. */
+const MAX_LIMIT = 100;
+
+/** Only the leaderboard views paginate, so the rest never mention a limit. */
+const DEFAULT_LIMIT = 25;
 
 function parse(search: string, fallback: ReportFilters): ReportFilters {
   const params = new URLSearchParams(search);
@@ -41,11 +49,20 @@ function parse(search: string, fallback: ReportFilters): ReportFilters {
   // rather than to an error panel.
   const hasRange = !!start && ISO_DATE.test(start) && (!end || ISO_DATE.test(end));
 
+  // Out-of-range or non-numeric limits fall back to the default rather than
+  // being passed on: the API rejects them with a 400, and a shared link with a
+  // typo should degrade to the default view rather than to an error panel.
+  const rawLimit = Number(params.get('limit'));
+  const limit = Number.isInteger(rawLimit) && rawLimit >= 1 && rawLimit <= MAX_LIMIT
+    ? rawLimit
+    : fallback.limit;
+
   return {
     range: hasRange ? { window, start, end: end ?? undefined } : { window },
     includeBots: params.get('bots') === '1',
     game: params.get('game') || null,
     metric: (params.get('metric') as MetricKey) || fallback.metric,
+    limit,
   };
 }
 
@@ -70,11 +87,20 @@ function serialise(filters: ReportFilters, defaults: ReportFilters): string {
   if (filters.metric !== defaults.metric) {
     params.set('metric', filters.metric);
   }
+  if (filters.limit !== defaults.limit) {
+    params.set('limit', String(filters.limit));
+  }
   const query = params.toString();
   return query ? `?${query}` : '';
 }
 
-export function useReportFilters(defaults: ReportFilters) {
+export function useReportFilters(
+  // `limit` is optional: only the leaderboard views paginate, and requiring it
+  // on the other seven pages would put a number in front of readers that means
+  // nothing there.
+  suppliedDefaults: Omit<ReportFilters, 'limit'> & { limit?: number },
+) {
+  const defaults: ReportFilters = { limit: DEFAULT_LIMIT, ...suppliedDefaults };
   const [filters, setFilters] = useState<ReportFilters>(defaults);
   const [hydrated, setHydrated] = useState(false);
 

--- a/lib/__tests__/report-filters.test.ts
+++ b/lib/__tests__/report-filters.test.ts
@@ -9,9 +9,25 @@ const defaults = {
   includeBots: false,
   game: null,
   metric: 'games_started' as const,
+  limit: 25,
 };
 
 describe('report filter URL state', () => {
+  it('carries a chosen row limit, and drops it when it is the default', () => {
+    expect(__test.serialise({ ...defaults, limit: 100 }, defaults)).toBe('?limit=100');
+    expect(__test.serialise({ ...defaults, limit: 25 }, defaults)).toBe('');
+    expect(__test.parse('?limit=100', defaults).limit).toBe(100);
+  });
+
+  it('ignores a limit the API would reject rather than passing it on', () => {
+    // MAX_LIMIT is 100 server-side; anything else 400s. A shared link with a
+    // silly value should degrade to the default view, like a malformed date.
+    expect(__test.parse('?limit=9999', defaults).limit).toBe(25);
+    expect(__test.parse('?limit=0', defaults).limit).toBe(25);
+    expect(__test.parse('?limit=abc', defaults).limit).toBe(25);
+    expect(__test.parse('?limit=12.5', defaults).limit).toBe(25);
+  });
+
   it('round-trips a custom range', () => {
     const filters = { ...defaults, range: { window: 30 as const, start: '2026-06-01', end: '2026-06-30' } };
     const query = __test.serialise(filters, defaults);


### PR DESCRIPTION
`limit` was the last parameter the API accepted that the UI never sent. The players view asked for 25 rows and offered no way to change it, so a top-50 or top-100 view was unreachable despite the API supporting it.

It rides in the URL like every other filter, so **"top 100 Grid players, last 90 days" is a link**.

## Invalid values degrade rather than error

The API caps at 100 and 400s anything outside 1–100 — already pinned by its own tests. So a shared link carrying `?limit=9999` would render an *error panel* instead of a report.

The parser falls back to the default instead, which is the same rule the hook already applies to malformed dates: a shared link with a typo should degrade to the default view, not to a failure. Tests cover `9999`, `0`, `abc` and `12.5`.

## One design note

`limit` is **optional** in the hook's defaults. Only the leaderboard views paginate, and requiring it on the other seven pages would put a number in front of readers that means nothing there.

276 tests · types clean · build green.