### PR TITLE
feat(reports): let the anomaly panel's sensitivity be changed

### DIFF
--- a/app/reports/page.tsx
+++ b/app/reports/page.tsx
@@ -1,9 +1,11 @@
 'use client';
 
+import type { Sensitivity } from '@/components/reports/AnomalySensitivity';
 import type { GameTotals } from '@/types/reports';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { ActivityChart } from '@/components/reports/ActivityChart';
 import { AnomalyPanel } from '@/components/reports/AnomalyPanel';
+import { AnomalySensitivity, SENSITIVITY_PRESETS } from '@/components/reports/AnomalySensitivity';
 import { ExportButton } from '@/components/reports/ExportButton';
 import { GameBadge } from '@/components/reports/GameBadge';
 import { GameLeaderboard } from '@/components/reports/GameLeaderboard';
@@ -53,7 +55,19 @@ export default function ReportsPage() {
   const activity = useReport(ReportsAPI.getActivity, params, enabled, 'The reporting activity endpoint');
   // Unfiltered on purpose: "what needs attention" must surface a game you
   // haven't selected, which is exactly the one you'd otherwise miss.
-  const anomalies = useReport(ReportsAPI.getAnomalies, allGamesParams, enabled, 'The anomalies reporting endpoint');
+  // Kept local rather than in the URL: it changes what counts as worth
+  // reporting, not what the report covers, so a shared link should carry the
+  // period and games — not the reader's tolerance for noise.
+  const [sensitivity, setSensitivity] = useState<Sensitivity>('default');
+  const anomalyParams = useMemo(
+    () => ({
+      ...allGamesParams,
+      min_volume: SENSITIVITY_PRESETS[sensitivity].min_volume,
+      min_change_pct: SENSITIVITY_PRESETS[sensitivity].min_change_pct,
+    }),
+    [allGamesParams, sensitivity],
+  );
+  const anomalies = useReport(ReportsAPI.getAnomalies, anomalyParams, enabled, 'The anomalies reporting endpoint');
 
   const selectedLabel = game ? (meta[game]?.label ?? game) : null;
 
@@ -79,7 +93,12 @@ export default function ReportsPage() {
         </div>
       )}
 
-      {anomalies.data && <AnomalyPanel data={anomalies.data} meta={meta} />}
+      {anomalies.data && (
+        <div className="space-y-2">
+          <AnomalyPanel data={anomalies.data} meta={meta} />
+          <AnomalySensitivity value={sensitivity} onChange={setSensitivity} />
+        </div>
+      )}
 
       {summary.error
         ? <ReportError error={summary.error} notDeployed={summary.notDeployed} onRetry={summary.refetch} />

--- a/components/reports/AnomalySensitivity.tsx
+++ b/components/reports/AnomalySensitivity.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+
+/**
+ * How much movement is worth interrupting someone for.
+ *
+ * The thresholds used to be constants — a reasonable guess that nobody could
+ * check. A panel tuned too loose gets ignored, one tuned too tight stays quiet
+ * through a real decline, and there was no way to find out which without
+ * editing the backend.
+ *
+ * Presets rather than free numbers: two spinboxes invite fiddling and produce
+ * values nobody can justify later. These are three defensible positions, and
+ * the response echoes whichever was used.
+ */
+export type Sensitivity = 'broad' | 'default' | 'strict';
+
+export const SENSITIVITY_PRESETS: Record<Sensitivity, {
+  label: string;
+  hint: string;
+  min_volume: number;
+  min_change_pct: number;
+}> = {
+  broad: {
+    label: 'Broad',
+    hint: 'Smaller games and gentler moves. Expect more noise.',
+    min_volume: 10,
+    min_change_pct: 15,
+  },
+  default: {
+    label: 'Balanced',
+    hint: 'The shipped defaults: 30+ sessions, moves over 25%.',
+    min_volume: 30,
+    min_change_pct: 25,
+  },
+  strict: {
+    label: 'Strict',
+    hint: 'Only big games moving a lot. Quiet by design.',
+    min_volume: 100,
+    min_change_pct: 50,
+  },
+};
+
+export function AnomalySensitivity({ value, onChange }: {
+  value: Sensitivity;
+  onChange: (next: Sensitivity) => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <span className="text-sm text-gray-600 dark:text-gray-300">Sensitivity</span>
+      {(Object.keys(SENSITIVITY_PRESETS) as Sensitivity[]).map((key) => {
+        const preset = SENSITIVITY_PRESETS[key];
+        return (
+          <Button
+            key={key}
+            size="sm"
+            variant={value === key ? 'default' : 'outline'}
+            title={preset.hint}
+            onClick={() => onChange(key)}
+          >
+            {preset.label}
+          </Button>
+        );
+      })}
+      <span className="text-xs text-gray-500 dark:text-gray-400">
+        {SENSITIVITY_PRESETS[value].hint}
+      </span>
+    </div>
+  );
+}

--- a/components/reports/__tests__/AnomalySensitivity.test.tsx
+++ b/components/reports/__tests__/AnomalySensitivity.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { AnomalySensitivity, SENSITIVITY_PRESETS } from '@/components/reports/AnomalySensitivity';
+
+describe('anomalySensitivity', () => {
+  it('keeps the shipped defaults as the balanced preset', () => {
+    // If these drift from the BE constants the "Balanced" label becomes a lie,
+    // and the panel silently behaves differently from the documented default.
+    expect(SENSITIVITY_PRESETS.default.min_volume).toBe(30);
+    expect(SENSITIVITY_PRESETS.default.min_change_pct).toBe(25);
+  });
+
+  it('orders the presets from noisiest to quietest', () => {
+    // A preset that is stricter on one knob and looser on the other would make
+    // "Broad" and "Strict" meaningless as a single axis.
+    const { broad, default: balanced, strict } = SENSITIVITY_PRESETS;
+
+    expect(broad.min_volume).toBeLessThan(balanced.min_volume);
+    expect(balanced.min_volume).toBeLessThan(strict.min_volume);
+    expect(broad.min_change_pct).toBeLessThan(balanced.min_change_pct);
+    expect(balanced.min_change_pct).toBeLessThan(strict.min_change_pct);
+  });
+
+  it('stays inside the bounds the API accepts', () => {
+    // The API 400s outside these; a preset that could not be requested would
+    // turn the control into an error panel.
+    for (const preset of Object.values(SENSITIVITY_PRESETS)) {
+      expect(preset.min_volume).toBeGreaterThanOrEqual(0);
+      expect(preset.min_volume).toBeLessThanOrEqual(10_000);
+      expect(preset.min_change_pct).toBeGreaterThanOrEqual(1);
+      expect(preset.min_change_pct).toBeLessThanOrEqual(500);
+    }
+  });
+
+  it('says what the current setting means, not just its name', () => {
+    render(<AnomalySensitivity value="strict" onChange={() => {}} />);
+
+    expect(screen.getByText(/only big games moving a lot/i)).toBeTruthy();
+  });
+
+  it('reports the chosen preset', async () => {
+    const onChange = vi.fn();
+    render(<AnomalySensitivity value="default" onChange={onChange} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Broad' }));
+
+    expect(onChange).toHaveBeenCalledWith('broad');
+  });
+});

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -146,6 +146,9 @@ export type ReportParams = {
   game_type?: string;
   include_bots?: boolean;
   limit?: number;
+  /** Anomaly knobs. Bounded server-side; out-of-range values are rejected. */
+  min_volume?: number;
+  min_change_pct?: number;
 };
 
 /**


### PR DESCRIPTION
Consumes the tunable thresholds from [App #1446](https://github.com/FootballExtraTime/App/pull/1446).

I asked last iteration whether the panel cries wolf or stays silent. Handing over the control is a better answer than asking you to judge fixed constants.

## Presets, not number inputs

Two spinboxes invite fiddling and produce values nobody can justify later. These are three defensible positions:

| | sessions | move | reads as |
|---|---|---|---|
| **Broad** | 10+ | 15% | smaller games, gentler moves — expect noise |
| **Balanced** | 30+ | 25% | the shipped defaults |
| **Strict** | 100+ | 50% | big games moving a lot — quiet by design |

The panel already echoes whichever thresholds were used, so a short list stays interpretable rather than mysterious.

## Not in the URL, on purpose

Every other filter is shareable. This one isn't, because it changes **what counts as worth reporting**, not what the report covers — a shared link should carry the period and the games, not the reader's tolerance for noise.

## Three guards

Each pins something that would quietly make the control wrong rather than broken:

- **Balanced must equal the BE defaults**, or the label is a lie and the panel behaves differently from the documented default.
- **Presets must move together on both knobs**, or "Broad" and "Strict" stop meaning anything as a single axis.
- **Every preset must sit inside the API's bounds**, or the control renders an error panel instead of a report.

Mutation-verified: drifting a preset, breaking the ordering, and stepping outside the bounds each fail.

281 tests · types clean · build green.