### PR TITLE
feat(reports): warn when the rollup behind the numbers is incomplete

### DIFF
--- a/app/reports/page.tsx
+++ b/app/reports/page.tsx
@@ -5,6 +5,7 @@ import type { GameTotals } from '@/types/reports';
 import { useMemo, useState } from 'react';
 import { ActivityChart } from '@/components/reports/ActivityChart';
 import { AnomalyPanel } from '@/components/reports/AnomalyPanel';
+import { RollupHealthBanner } from '@/components/reports/RollupHealthBanner';
 import { AnomalySensitivity, SENSITIVITY_PRESETS } from '@/components/reports/AnomalySensitivity';
 import { ExportButton } from '@/components/reports/ExportButton';
 import { GameBadge } from '@/components/reports/GameBadge';
@@ -92,6 +93,10 @@ export default function ReportsPage() {
           <GameBadge gameKey={game} meta={meta} active onClick={() => update({ game: null })} />
         </div>
       )}
+
+      {/* Above the anomalies: if the rollup is incomplete, "nothing moved" is
+          not a finding, and every panel below inherits that doubt. */}
+      <RollupHealthBanner />
 
       {anomalies.data && (
         <div className="space-y-2">

--- a/components/reports/RollupHealthBanner.tsx
+++ b/components/reports/RollupHealthBanner.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import type { RollupHealth } from '@/types/reports';
+import { AlertTriangle } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { ReportsAPI } from '@/lib/reports-api';
+
+/**
+ * Says when the numbers below can't be trusted, and what to run about it.
+ *
+ * Every report already flags coverage for its own window. This answers the
+ * different question — is the rollup itself complete — and it only appears when
+ * the answer is no. A banner that is always present is one people stop reading,
+ * which would make it worse than nothing.
+ *
+ * One day behind is the normal state between nightly runs, not a problem, so it
+ * stays silent for that.
+ */
+const NORMAL_LAG_DAYS = 1;
+
+export function RollupHealthBanner() {
+  const [health, setHealth] = useState<RollupHealth | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    ReportsAPI.getRollupHealth()
+      .then((data) => {
+        if (!cancelled) {
+          setHealth(data);
+        }
+      })
+      // A failure here must not take the page down: the reports are still
+      // readable, we simply can't vouch for the rollup behind them.
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (!health) {
+    return null;
+  }
+
+  const stale = health.stale_days ?? 0;
+  const unhealthy = !health.has_data || health.gap_count > 0 || stale > NORMAL_LAG_DAYS;
+  if (!unhealthy) {
+    return null;
+  }
+
+  const problem = !health.has_data
+    ? 'The reporting rollup has never been computed, so every figure below is unknown rather than zero.'
+    : health.gap_count > 0
+      ? `${health.gap_count} day${health.gap_count === 1 ? '' : 's'} inside the covered range were never computed, so any window including them is incomplete.`
+      : `The rollup is ${stale} days behind, so recent days read as quiet rather than uncounted.`;
+
+  return (
+    <div className="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm dark:border-amber-800 dark:bg-amber-900/20">
+      <p className="flex items-start gap-2 font-medium text-amber-900 dark:text-amber-100">
+        <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+        {problem}
+      </p>
+      {health.suggested_command && (
+        <pre className="mt-2 overflow-x-auto rounded bg-amber-100/70 p-2 text-xs text-amber-950 dark:bg-slate-900/60 dark:text-amber-100">
+          {health.suggested_command}
+        </pre>
+      )}
+      {health.has_data && (
+        <p className="mt-2 text-xs text-amber-800 dark:text-amber-200">
+          {/* What IS covered, so the warning above is bounded rather than
+              alarming — a three-day gap in ninety is a different problem from
+              three days being all there is. */}
+          Covering
+          {' '}
+          {health.earliest}
+          {' → '}
+          {health.latest}
+          {` (${health.days_covered} days computed).`}
+        </p>
+      )}
+
+      {health.gaps_truncated && (
+        <p className="mt-1 text-xs text-amber-800 dark:text-amber-200">
+          Showing the first missing days only — the command above spans them all.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/components/reports/__tests__/RollupHealthBanner.test.tsx
+++ b/components/reports/__tests__/RollupHealthBanner.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { RollupHealthBanner } from '@/components/reports/RollupHealthBanner';
+import { ReportsAPI } from '@/lib/reports-api';
+
+function health(overrides = {}) {
+  return {
+    has_data: true,
+    earliest: '2026-05-14',
+    latest: '2026-08-11',
+    days_covered: 90,
+    gap_count: 0,
+    gaps: [],
+    gaps_truncated: false,
+    stale_days: 1,
+    suggested_command: null,
+    ...overrides,
+  };
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('rollupHealthBanner', () => {
+  it('stays silent when the rollup is complete and current', async () => {
+    // A banner that is always there is one people stop reading. One day behind
+    // is the normal state between nightly runs, not a problem.
+    vi.spyOn(ReportsAPI, 'getRollupHealth').mockResolvedValue(health() as never);
+
+    const { container } = render(<RollupHealthBanner />);
+    await new Promise(resolve => setTimeout(resolve, 30));
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('warns about holes inside the covered range', async () => {
+    vi.spyOn(ReportsAPI, 'getRollupHealth').mockResolvedValue(health({
+      gap_count: 3,
+      suggested_command: 'python manage.py backfill_daily_game_activity --start 2026-06-01 --end 2026-06-03',
+    }) as never);
+
+    render(<RollupHealthBanner />);
+
+    expect(await screen.findByText(/3 days inside the covered range were never computed/)).toBeTruthy();
+    expect(screen.getByText(/--start 2026-06-01/)).toBeTruthy();
+  });
+
+  it('distinguishes a stale rollup from one with holes', async () => {
+    // Different problems with different fixes: one needs catching up, the other
+    // needs specific days rebuilt.
+    vi.spyOn(ReportsAPI, 'getRollupHealth').mockResolvedValue(health({
+      stale_days: 6,
+      suggested_command: 'python manage.py backfill_daily_game_activity --start 2026-08-07 --end 2026-08-12',
+    }) as never);
+
+    render(<RollupHealthBanner />);
+
+    expect(await screen.findByText(/6 days behind/)).toBeTruthy();
+  });
+
+  it('says an empty rollup makes every figure unknown, not zero', async () => {
+    vi.spyOn(ReportsAPI, 'getRollupHealth').mockResolvedValue(health({
+      has_data: false, days_covered: 0, stale_days: null,
+      suggested_command: 'python manage.py backfill_daily_game_activity --days 90',
+    }) as never);
+
+    render(<RollupHealthBanner />);
+
+    expect(await screen.findByText(/unknown rather than zero/)).toBeTruthy();
+  });
+
+  it('bounds the warning by saying what IS covered', async () => {
+    // Three missing days out of ninety is a very different problem from three
+    // days being the entire dataset.
+    vi.spyOn(ReportsAPI, 'getRollupHealth').mockResolvedValue(health({
+      gap_count: 3, suggested_command: 'python manage.py backfill_daily_game_activity',
+    }) as never);
+
+    render(<RollupHealthBanner />);
+
+    expect(await screen.findByText(/90 days computed/)).toBeTruthy();
+    expect(screen.getByText(/2026-05-14/)).toBeTruthy();
+  });
+
+  it('does not take the page down when the check itself fails', async () => {
+    // The reports are still readable; we just can't vouch for the rollup.
+    vi.spyOn(ReportsAPI, 'getRollupHealth').mockRejectedValue(new Error('offline'));
+
+    const { container } = render(<RollupHealthBanner />);
+    await new Promise(resolve => setTimeout(resolve, 30));
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/lib/reports-api.ts
+++ b/lib/reports-api.ts
@@ -1,5 +1,6 @@
 import type {
   ActivityResponse,
+  RollupHealth,
   GlossaryResponse,
   AnomaliesResponse,
   DurationResponse,
@@ -61,6 +62,11 @@ export class ReportsAPI {
    */
   static async getGames(): Promise<GamesResponse> {
     return apiFetcher<GamesResponse>('core/reporting/games/');
+  }
+
+  /** GET /core/reporting/rollup-health/ — is the rollup complete and current. */
+  static async getRollupHealth(): Promise<RollupHealth> {
+    return apiFetcher<RollupHealth>('core/reporting/rollup-health/');
   }
 
   /** GET /core/reporting/glossary/ — what every reported number means. */

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -269,6 +269,22 @@ export type MetricDefinition = {
 
 export type GlossaryResponse = { metrics: MetricDefinition[] };
 
+/** State of the rollup every report is built on. Not range-filtered. */
+export type RollupHealth = {
+  has_data: boolean;
+  earliest: string | null;
+  latest: string | null;
+  days_covered: number;
+  gap_count: number;
+  /** Capped server-side; `gaps_truncated` says when there are more. */
+  gaps: string[];
+  gaps_truncated: boolean;
+  /** Days behind yesterday. Null when nothing has ever been computed. */
+  stale_days: number | null;
+  /** The exact backfill command, or null when there is nothing to run. */
+  suggested_command: string | null;
+};
+
 /** Which activity metric a chart or table is currently showing. */
 export const METRIC_OPTIONS = [
   { key: 'games_started', label: 'Played' },


### PR DESCRIPTION
Consumes the rollup-health endpoint from [App #1447](https://github.com/FootballExtraTime/App/pull/1447).

A banner that appears **only when there is something to do**, above the anomalies panel — because if the rollup is incomplete then "nothing moved" isn't a finding, and every panel below inherits that doubt.

## Silent at one day behind

That's the normal state between nightly runs. A banner that's always present is one people stop reading, which would make it worse than nothing.

## Three cases, three fixes

| state | what it means | fix |
|---|---|---|
| **Empty** | every figure is *unknown*, not zero | full backfill |
| **Holes** | any window including them is incomplete | rebuild those days |
| **Stale** | recent days read as quiet rather than uncounted | catch up |

Each shows the exact command to run.

## It states what IS covered

Three missing days out of ninety is a very different problem from three days being the whole dataset — so the banner bounds its own warning.

That line exists **because my own guard failed**: `response-fields-used` flagged `earliest`, `latest` and `days_covered` as fetched-but-never-rendered. Rendering them was the better answer than exempting them, which is exactly the choice the guard is meant to force.

## Failures are swallowed

If the health check itself fails, the banner renders nothing. The reports are still readable; we just can't vouch for the rollup behind them, and taking the page down over that would be a worse trade.

## Mutation-verified

| Mutation | Result |
|---|---|
| Warn at the normal one-day lag | fails |
| Treat an empty rollup as merely stale | fails |
| Let a failed check crash the page | unhandled rejection |

Worth noting: two of these tests initially passed **for the wrong reason** — they asserted on a component I'd forgotten to `render()`. The empty `<body />` in the failure output is what gave it away.

287 tests · types clean · build green.