### PR TITLE
fix(reports): readable charts in dark mode, and clickable player rows

### DIFF
--- a/app/reports/patterns/page.tsx
+++ b/app/reports/patterns/page.tsx
@@ -19,6 +19,8 @@ import { useReportFilters } from '@/hooks/use-report-filters';
 import { useAuth } from '@/lib/auth';
 import { rangeToParams } from '@/lib/report-range';
 import { ReportsAPI } from '@/lib/reports-api';
+import { useTheme } from 'next-themes';
+import { chartTheme } from '@/lib/chart-theme';
 
 function Tile({ label, value, hint, metric }: { label: string; value: string; hint: string; metric?: string }) {
   return (
@@ -36,6 +38,8 @@ function Tile({ label, value, hint, metric }: { label: string; value: string; hi
 }
 
 export default function PatternsPage() {
+  const { resolvedTheme } = useTheme();
+  const theme = chartTheme(resolvedTheme === 'dark');
   const { isAuthenticated, user } = useAuth();
   const enabled = isAuthenticated && !!(user?.is_staff || user?.is_superuser);
 
@@ -160,11 +164,13 @@ export default function PatternsPage() {
                   <CardContent className="h-64 sm:h-72">
                     <ResponsiveContainer width="100%" height="100%">
                       <BarChart data={data.by_hour} margin={{ top: 8, right: 8, bottom: 8, left: -12 }}>
-                        <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-slate-700" />
-                        <XAxis dataKey="hour" tick={{ fontSize: 11 }} tickFormatter={h => `${h}:00`} interval={1} />
-                        <YAxis tick={{ fontSize: 11 }} allowDecimals={false} width={44} />
+                        <CartesianGrid strokeDasharray="3 3" stroke={theme.grid.stroke} />
+                        <XAxis dataKey="hour" tick={theme.tick} tickFormatter={h => `${h}:00`} interval={1} />
+                        <YAxis tick={theme.tick} allowDecimals={false} width={44} />
                         <Tooltip
-                          contentStyle={{ fontSize: 12 }}
+                          contentStyle={theme.tooltip.contentStyle}
+                          labelStyle={theme.tooltip.labelStyle}
+                          itemStyle={theme.tooltip.itemStyle}
                           labelFormatter={h => `${String(h).padStart(2, '0')}:00`}
                         />
                         <Bar dataKey="games_started" name="Games" radius={[3, 3, 0, 0]}>
@@ -192,10 +198,12 @@ export default function PatternsPage() {
                   <CardContent className="h-56 sm:h-64">
                     <ResponsiveContainer width="100%" height="100%">
                       <BarChart data={data.by_weekday} margin={{ top: 8, right: 8, bottom: 8, left: -12 }}>
-                        <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-slate-700" />
-                        <XAxis dataKey="name" tick={{ fontSize: 11 }} tickFormatter={name => name.slice(0, 3)} />
-                        <YAxis tick={{ fontSize: 11 }} allowDecimals={false} width={44} />
-                        <Tooltip contentStyle={{ fontSize: 12 }} />
+                        <CartesianGrid strokeDasharray="3 3" stroke={theme.grid.stroke} />
+                        <XAxis dataKey="name" tick={theme.tick} tickFormatter={name => name.slice(0, 3)} />
+                        <YAxis tick={theme.tick} allowDecimals={false} width={44} />
+                        <Tooltip contentStyle={theme.tooltip.contentStyle}
+                          labelStyle={theme.tooltip.labelStyle}
+                          itemStyle={theme.tooltip.itemStyle} />
                         <Bar dataKey="games_started" name="Games" radius={[3, 3, 0, 0]}>
                           {data.by_weekday.map(row => (
                             <Cell
@@ -221,10 +229,12 @@ export default function PatternsPage() {
                   <CardContent className="h-64 sm:h-72">
                     <ResponsiveContainer width="100%" height="100%">
                       <AreaChart data={data.new_vs_returning} margin={{ top: 8, right: 8, bottom: 8, left: -12 }}>
-                        <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-slate-700" />
-                        <XAxis dataKey="date" tick={{ fontSize: 11 }} interval="preserveStartEnd" minTickGap={24} />
-                        <YAxis tick={{ fontSize: 11 }} allowDecimals={false} width={44} />
-                        <Tooltip contentStyle={{ fontSize: 12 }} />
+                        <CartesianGrid strokeDasharray="3 3" stroke={theme.grid.stroke} />
+                        <XAxis dataKey="date" tick={theme.tick} interval="preserveStartEnd" minTickGap={24} />
+                        <YAxis tick={theme.tick} allowDecimals={false} width={44} />
+                        <Tooltip contentStyle={theme.tooltip.contentStyle}
+                          labelStyle={theme.tooltip.labelStyle}
+                          itemStyle={theme.tooltip.itemStyle} />
                         <Area
                           type="monotone"
                           dataKey="returning_players"

--- a/app/reports/players/[id]/page.tsx
+++ b/app/reports/players/[id]/page.tsx
@@ -19,6 +19,8 @@ import { useReportFilters } from '@/hooks/use-report-filters';
 import { useAuth } from '@/lib/auth';
 import { rangeToParams } from '@/lib/report-range';
 import { ReportsAPI } from '@/lib/reports-api';
+import { useTheme } from 'next-themes';
+import { chartTheme } from '@/lib/chart-theme';
 
 function Tile({ label, value, hint }: { label: string; value: string; hint?: string }) {
   return (
@@ -33,6 +35,8 @@ function Tile({ label, value, hint }: { label: string; value: string; hint?: str
 }
 
 export default function PlayerDetailPage() {
+  const { resolvedTheme } = useTheme();
+  const theme = chartTheme(resolvedTheme === 'dark');
   const resolveColor = useGameColor();
   const { isAuthenticated, user } = useAuth();
   const enabled = isAuthenticated && !!(user?.is_staff || user?.is_superuser);
@@ -154,7 +158,9 @@ export default function PlayerDetailPage() {
                       <CardContent className="h-64">
                         <ResponsiveContainer width="100%" height="100%">
                           <PieChart>
-                            <Tooltip contentStyle={{ fontSize: 12 }} />
+                            <Tooltip contentStyle={theme.tooltip.contentStyle}
+                          labelStyle={theme.tooltip.labelStyle}
+                          itemStyle={theme.tooltip.itemStyle} />
                             <Pie
                               data={data.by_game}
                               dataKey="games_played"
@@ -210,10 +216,12 @@ export default function PlayerDetailPage() {
                   <CardContent className="h-64 sm:h-72">
                     <ResponsiveContainer width="100%" height="100%">
                       <AreaChart data={data.series} margin={{ top: 8, right: 8, bottom: 8, left: -12 }}>
-                        <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-slate-700" />
-                        <XAxis dataKey="date" tick={{ fontSize: 11 }} interval="preserveStartEnd" minTickGap={24} />
-                        <YAxis tick={{ fontSize: 11 }} allowDecimals={false} width={44} />
-                        <Tooltip contentStyle={{ fontSize: 12 }} />
+                        <CartesianGrid strokeDasharray="3 3" stroke={theme.grid.stroke} />
+                        <XAxis dataKey="date" tick={theme.tick} interval="preserveStartEnd" minTickGap={24} />
+                        <YAxis tick={theme.tick} allowDecimals={false} width={44} />
+                        <Tooltip contentStyle={theme.tooltip.contentStyle}
+                          labelStyle={theme.tooltip.labelStyle}
+                          itemStyle={theme.tooltip.itemStyle} />
                         <Area type="monotone" dataKey="games_started" name="Played" stroke="#059669" fill="#059669" fillOpacity={0.35} />
                         <Area type="monotone" dataKey="games_finished" name="Finished" stroke="#2563eb" fill="#2563eb" fillOpacity={0.25} />
                       </AreaChart>

--- a/app/reports/players/page.tsx
+++ b/app/reports/players/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import type { RangeState } from '@/lib/report-range';
 import { useMemo, useState } from 'react';
 import { GameBadge } from '@/components/reports/GameBadge';
@@ -145,8 +146,15 @@ export default function PlayersReportPage() {
                       {data.players.map((player, index) => (
                         <tr key={player.user_id} className="border-b last:border-0 dark:border-slate-700">
                           <td className="py-2 pr-4 text-gray-500 dark:text-gray-400">{index + 1}</td>
-                          <td className="py-2 pr-4 font-medium text-gray-900 dark:text-white">
-                            {player.username}
+                          <td className="py-2 pr-4 font-medium">
+                            {/* The drill-down existed and worked; nothing linked
+                                to it, so the only way in was typing a URL. */}
+                            <Link
+                              href={`/reports/players/${player.user_id}`}
+                              className="text-emerald-700 hover:underline dark:text-emerald-400"
+                            >
+                              {player.username}
+                            </Link>
                           </td>
                           <td className="py-2 pr-4 text-right">{player.games_played.toLocaleString()}</td>
                           <td className="py-2 pr-4 text-right">{player.games_finished.toLocaleString()}</td>

--- a/components/reports/ActivityChart.tsx
+++ b/components/reports/ActivityChart.tsx
@@ -4,6 +4,8 @@ import type { ActivityDay, MetricKey } from '@/types/reports';
 import { CartesianGrid, Legend, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { METRIC_OPTIONS } from '@/types/reports';
+import { useTheme } from 'next-themes';
+import { chartTheme } from '@/lib/chart-theme';
 
 /** Day-month tick, in UTC so it renders as the intended day regardless of viewer TZ. */
 function formatDay(iso: string): string {
@@ -34,6 +36,8 @@ export function ActivityChart({ series, title, description, metric, color }: {
   /** Overrides the metric colour — used to match the selected game's badge. */
   color?: string;
 }) {
+  const { resolvedTheme } = useTheme();
+  const theme = chartTheme(resolvedTheme === 'dark');
   // An uncovered day was never computed. Feeding 0 to the chart draws a
   // confident dip that never happened, so the value becomes null and recharts
   // leaves a visible break instead.
@@ -74,10 +78,12 @@ export function ActivityChart({ series, title, description, metric, color }: {
       <CardContent className="h-72 sm:h-80">
         <ResponsiveContainer width="100%" height="100%">
           <LineChart data={data} margin={{ top: 8, right: 8, bottom: 8, left: -12 }}>
-            <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-slate-700" />
-            <XAxis dataKey="label" tick={{ fontSize: 11 }} interval="preserveStartEnd" minTickGap={24} />
-            <YAxis tick={{ fontSize: 11 }} allowDecimals={false} width={44} />
-            <Tooltip contentStyle={{ fontSize: 12 }} />
+            <CartesianGrid strokeDasharray="3 3" stroke={theme.grid.stroke} />
+            <XAxis dataKey="label" tick={theme.tick} interval="preserveStartEnd" minTickGap={24} />
+            <YAxis tick={theme.tick} allowDecimals={false} width={44} />
+            <Tooltip contentStyle={theme.tooltip.contentStyle}
+                          labelStyle={theme.tooltip.labelStyle}
+                          itemStyle={theme.tooltip.itemStyle} />
             <Legend wrapperStyle={{ fontSize: 12 }} />
             {METRIC_OPTIONS.map((option) => {
               const isPrimary = option.key === metric;

--- a/components/reports/ModeBreakdown.tsx
+++ b/components/reports/ModeBreakdown.tsx
@@ -6,6 +6,8 @@ import { Bar, BarChart, CartesianGrid, Cell, LabelList, ResponsiveContainer, Too
 import { GameBadge } from '@/components/reports/GameBadge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { useGameColor } from '@/hooks/use-game-meta';
+import { useTheme } from 'next-themes';
+import { chartTheme } from '@/lib/chart-theme';
 
 /** Quiz has no mode column, so its rooms arrive as null rather than being dropped. */
 function modeLabel(mode: string | null): string {
@@ -25,6 +27,8 @@ export function ModeBreakdown({ rows, meta, onSelectGame }: {
   meta: GameMetaMap;
   onSelectGame?: (gameKey: string) => void;
 }) {
+  const { resolvedTheme } = useTheme();
+  const theme = chartTheme(resolvedTheme === 'dark');
   const resolveColor = useGameColor();
   const byMode = new Map<string, { mode: string; rooms_created: number; rooms_started: number; games: MultiplayerModeRow[] }>();
   for (const row of rows) {
@@ -58,10 +62,12 @@ export function ModeBreakdown({ rows, meta, onSelectGame }: {
                 <div className="h-56">
                   <ResponsiveContainer width="100%" height="100%">
                     <BarChart data={modes} margin={{ top: 16, right: 8, bottom: 8, left: -12 }}>
-                      <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-slate-700" />
-                      <XAxis dataKey="mode" tick={{ fontSize: 11 }} />
-                      <YAxis tick={{ fontSize: 11 }} allowDecimals={false} width={44} />
-                      <Tooltip contentStyle={{ fontSize: 12 }} cursor={{ fillOpacity: 0.1 }} />
+                      <CartesianGrid strokeDasharray="3 3" stroke={theme.grid.stroke} />
+                      <XAxis dataKey="mode" tick={theme.tick} />
+                      <YAxis tick={theme.tick} allowDecimals={false} width={44} />
+                      <Tooltip contentStyle={theme.tooltip.contentStyle}
+                          labelStyle={theme.tooltip.labelStyle}
+                          itemStyle={theme.tooltip.itemStyle} cursor={theme.tooltip.cursor} />
                       <Bar dataKey="rooms_created" name="Rooms" radius={[4, 4, 0, 0]}>
                         <LabelList dataKey="rooms_created" position="top" style={{ fontSize: 11 }} />
                         {modes.map(mode => (

--- a/components/reports/__tests__/chart-theme.test.ts
+++ b/components/reports/__tests__/chart-theme.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { chartTheme } from '@/lib/chart-theme';
+
+describe('chartTheme', () => {
+  it('sets tooltip text colour, not just background', () => {
+    // The bug: recharts renders a white tooltip panel and INHERITS the page's
+    // text colour. In dark mode that was white text on white — invisible on
+    // every chart page. Setting only the background would not have fixed it.
+    const dark = chartTheme(true);
+
+    expect(dark.tooltip.contentStyle.backgroundColor).toBeTruthy();
+    expect(dark.tooltip.contentStyle.color).toBeTruthy();
+    expect(dark.tooltip.labelStyle.color).toBeTruthy();
+    expect(dark.tooltip.itemStyle.color).toBeTruthy();
+  });
+
+  it('uses different colours per mode rather than one set for both', () => {
+    const light = chartTheme(false);
+    const dark = chartTheme(true);
+
+    expect(dark.tooltip.contentStyle.backgroundColor).not.toBe(light.tooltip.contentStyle.backgroundColor);
+    expect(dark.tooltip.contentStyle.color).not.toBe(light.tooltip.contentStyle.color);
+    expect(dark.tick.fill).not.toBe(light.tick.fill);
+  });
+
+  it('keeps grid and axes recessive against the tick text', () => {
+    // Grid and axes are support, not content. If they matched the text they
+    // would compete with the data for attention.
+    for (const isDark of [false, true]) {
+      const theme = chartTheme(isDark);
+      expect(theme.grid.stroke).not.toBe(theme.tooltip.contentStyle.color);
+    }
+  });
+});

--- a/hooks/__tests__/use-game-meta.test.tsx
+++ b/hooks/__tests__/use-game-meta.test.tsx
@@ -45,3 +45,16 @@ describe('game marks', () => {
     expect(screen.getByText('Brand New Game')).toBeTruthy();
   });
 });
+
+
+describe('players table', () => {
+  it('links each row to the drill-down that already exists', async () => {
+    // players table links — the page at /reports/players/[id] worked from the
+    // start; nothing pointed at it, so the only way in was typing a URL.
+    const { readFileSync } = await import('node:fs');
+    const { join } = await import('node:path');
+    const source = readFileSync(join(process.cwd(), 'app', 'reports', 'players', 'page.tsx'), 'utf8');
+
+    expect(source).toMatch(/\/reports\/players\/\$\{player\.user_id\}/);
+  });
+});

--- a/lib/chart-theme.ts
+++ b/lib/chart-theme.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared chart styling, so every chart reads the same and survives dark mode.
+ *
+ * Recharts styles nothing by default: axis ticks fall back to a fixed grey and
+ * the tooltip renders a white panel that INHERITS the page's text colour. In
+ * dark mode that meant white text on a white tooltip — invisible, on every chart
+ * page, which is the bug this exists to remove.
+ *
+ * It also keeps the marks recessive on purpose: grid and axes are support, not
+ * content, so they sit well below the data in contrast.
+ */
+
+export type ChartTheme = {
+  tick: { fontSize: number; fill: string };
+  axisLine: { stroke: string };
+  grid: { stroke: string };
+  tooltip: {
+    contentStyle: React.CSSProperties;
+    labelStyle: React.CSSProperties;
+    itemStyle: React.CSSProperties;
+    cursor: { fill: string };
+  };
+  legend: React.CSSProperties;
+};
+
+/** Text tokens, never a series colour — identity comes from the mark beside it. */
+const LIGHT = {
+  text: '#334155',
+  muted: '#64748b',
+  line: '#cbd5e1',
+  surface: '#ffffff',
+  border: '#e2e8f0',
+};
+
+const DARK = {
+  text: '#e2e8f0',
+  muted: '#94a3b8',
+  line: '#475569',
+  surface: '#1e293b',
+  border: '#334155',
+};
+
+export function chartTheme(isDark: boolean): ChartTheme {
+  const c = isDark ? DARK : LIGHT;
+  return {
+    tick: { fontSize: 11, fill: c.muted },
+    axisLine: { stroke: c.line },
+    grid: { stroke: c.line },
+    tooltip: {
+      // Both background AND colour are set: setting only the background leaves
+      // the text inheriting from the page, which is how this broke.
+      contentStyle: {
+        fontSize: 12,
+        backgroundColor: c.surface,
+        border: `1px solid ${c.border}`,
+        borderRadius: 6,
+        color: c.text,
+      },
+      labelStyle: { color: c.text, fontWeight: 600 },
+      itemStyle: { color: c.text },
+      cursor: { fill: isDark ? 'rgba(148,163,184,0.12)' : 'rgba(15,23,42,0.06)' },
+    },
+    legend: { fontSize: 12, color: c.muted },
+  };
+}


### PR DESCRIPTION
Backlog **A2** and **A1**.

## A2 — the dark-mode text bug

Recharts styles nothing by default. Its tooltip renders a **white panel and inherits the page's text colour** — so in dark mode that was white text on white. Invisible, on every chart page. Axis ticks fell back to a fixed grey that ignored the theme too.

Fixed as **one shared chart theme**, not four sets of inline props. These charts should read as one system, and the next chart added should be right without anyone remembering to style it.

The detail that matters: **both** the tooltip background and its text colour are set. Setting only the background looks like a fix and changes nothing — which is exactly how this survived as long as it did. That's the first mutation test.

Grid and axes stay deliberately recessive — they're support, not content, and matching them to the text colour would put them in competition with the data.

## A1 — the unreachable drill-down

`/reports/players/[id]` has worked since it was built. Nothing linked to it, so the only way in was typing a URL. Rows now link.

That's the **sixth** "built but unreachable" thing in this section, after ModeBreakdown, useReportFilters, export, per-game filtering and `pulse_applies`.

## Mutation-verified

| Mutation | Result |
|---|---|
| Tooltip background without text colour | fails (2 tests) |
| One palette for both modes | fails |
| Unlink the player rows | fails |

291 tests · types clean · build green.
