### PR TITLE
fix(reports): make the heatmap readable when most hours are active

### DIFF
--- a/components/reports/ActivityHeatmap.tsx
+++ b/components/reports/ActivityHeatmap.tsx
@@ -1,12 +1,45 @@
 'use client';
 
 import type { HourWeekdayRow, PeakCell } from '@/types/reports';
+import { useTheme } from 'next-themes';
 import { useMemo, useState } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
 
 /** Every third hour, so the axis stays readable on a phone. */
 const HOUR_TICKS = [0, 3, 6, 9, 12, 15, 18, 21];
+
+/**
+ * Discrete buckets, not a continuous ramp.
+ *
+ * The first version scaled opacity continuously. Nobody can tell 60% opacity
+ * from 70%, so on a week where most hours have some play the whole grid read as
+ * one wash of green — the exact complaint. Four steps can be told apart, and a
+ * legend can state what each one means.
+ *
+ * Both ramps validated against their own surface: single hue, monotone
+ * lightness, adjacent steps at least 0.06 apart, lightest step clearing 2:1 so
+ * it is distinguishable from an empty cell.
+ */
+const RAMP_LIGHT = ['#10b981', '#059669', '#047857', '#064e3b'];
+const RAMP_DARK = ['#047857', '#059669', '#34d399', '#a7f3d0'];
+
+/** Exported so the per-surface choice is testable rather than implicit. */
+export function heatmapRamp(isDark: boolean): string[] {
+  return isDark ? RAMP_DARK : RAMP_LIGHT;
+}
+
+/** Quartile-style thresholds as a share of the busiest cell. */
+const BUCKET_EDGES = [0.25, 0.5, 0.75];
+
+function bucketOf(value: number, busiest: number): number {
+  if (value <= 0 || busiest <= 0) return -1;
+  const share = value / busiest;
+  for (let i = 0; i < BUCKET_EDGES.length; i++) {
+    if (share <= BUCKET_EDGES[i]) return i;
+  }
+  return BUCKET_EDGES.length;
+}
 
 /**
  * Sessions by weekday × hour.
@@ -27,23 +60,14 @@ export function ActivityHeatmap({
   timezone: string;
 }) {
   const [hovered, setHovered] = useState<{ row: HourWeekdayRow; hour: number } | null>(null);
+  const { resolvedTheme } = useTheme();
+  const ramp = heatmapRamp(resolvedTheme === 'dark');
 
   const total = useMemo(
     () => rows.reduce((sum, row) => sum + row.hours.reduce((a, b) => a + b, 0), 0),
     [rows],
   );
 
-  /**
-   * Square-root scale, not linear. Play is heavily peaked, so a linear ramp
-   * renders everything except the top few cells as near-empty and hides the
-   * shape of an ordinary week — which is the thing you're looking at.
-   */
-  function intensity(value: number) {
-    if (value <= 0 || busiest <= 0) {
-      return 0;
-    }
-    return Math.sqrt(value / busiest);
-  }
 
   if (total === 0) {
     return (
@@ -105,8 +129,8 @@ export function ActivityHeatmap({
                         isPeak && 'ring-1 ring-emerald-500 ring-offset-1 dark:ring-offset-slate-900',
                       )}
                       style={{
-                        backgroundColor: value > 0
-                          ? `rgba(16, 185, 129, ${0.12 + intensity(value) * 0.88})`
+                        backgroundColor: bucketOf(value, busiest) >= 0
+                          ? ramp[bucketOf(value, busiest)]
                           : undefined,
                       }}
                     />
@@ -123,16 +147,22 @@ export function ActivityHeatmap({
               ? `${hovered.row.name} ${String(hovered.hour).padStart(2, '0')}:00 — ${hovered.row.hours[hovered.hour].toLocaleString()} sessions`
               : 'Hover a cell for the exact count.'}
           </span>
-          <span className="flex items-center gap-1">
-            0
-            {[0.15, 0.4, 0.65, 1].map(step => (
-              <span
-                key={step}
-                className="size-3 rounded-[2px]"
-                style={{ backgroundColor: `rgba(16, 185, 129, ${0.12 + step * 0.88})` }}
-              />
-            ))}
-            {busiest.toLocaleString()}
+          <span className="flex flex-wrap items-center gap-1">
+            <span className="mr-1">Sessions</span>
+            <span className="size-3 rounded-[2px] border border-gray-300 dark:border-slate-600" />
+            <span className="mr-1">0</span>
+            {ramp.map((colour, index) => {
+              const low = index === 0 ? 1 : Math.round(BUCKET_EDGES[index - 1] * busiest) + 1;
+              const high = index === ramp.length - 1 ? busiest : Math.round(BUCKET_EDGES[index] * busiest);
+              return (
+                <span key={colour} className="flex items-center gap-1">
+                  <span className="size-3 rounded-[2px]" style={{ backgroundColor: colour }} />
+                  {/* The counts are stated, so the colour never has to be
+                      decoded by eye against a gradient. */}
+                  <span>{low === high ? low : `${low}–${high}`}</span>
+                </span>
+              );
+            })}
           </span>
         </div>
       </CardContent>

--- a/components/reports/__tests__/ActivityHeatmap.test.tsx
+++ b/components/reports/__tests__/ActivityHeatmap.test.tsx
@@ -1,13 +1,29 @@
 import type { HourWeekdayRow } from '@/types/reports';
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
-import { ActivityHeatmap } from '@/components/reports/ActivityHeatmap';
+import { ActivityHeatmap, heatmapRamp } from '@/components/reports/ActivityHeatmap';
 
 /** Monday 09:00 = 6 is busiest; the peak day (Mon) x peak hour (20:00) cell holds 2. */
 const ROWS: HourWeekdayRow[] = [
   { weekday: 1, name: 'Monday', hours: Array.from({ length: 24 }, (_, h) => (h === 9 ? 6 : h === 20 ? 2 : 0)) },
   { weekday: 3, name: 'Wednesday', hours: Array.from({ length: 24 }, (_, h) => (h === 20 ? 5 : 0)) },
 ];
+
+describe('heatmapRamp', () => {
+  it('uses different steps per surface', () => {
+    // The light ramp darkens toward the busy end; reused on a dark card its
+    // darkest step nearly disappears, so the busiest hours would read as the
+    // emptiest. Each surface needs its own anchor, not a shared one.
+    expect(heatmapRamp(true)).not.toEqual(heatmapRamp(false));
+  });
+
+  it('keeps four steps on both surfaces', () => {
+    // The legend labels one count range per step; a mismatch would label the
+    // wrong ranges rather than fail visibly.
+    expect(heatmapRamp(true)).toHaveLength(4);
+    expect(heatmapRamp(false)).toHaveLength(4);
+  });
+});
 
 describe('activityHeatmap', () => {
   it('names the busiest slot rather than leaving it to be read off the colours', () => {
@@ -43,6 +59,39 @@ describe('activityHeatmap', () => {
     expect(screen.queryAllByRole('button')).toHaveLength(0);
   });
 
+  it('puts cells in distinguishable buckets rather than a smooth ramp', () => {
+    // The complaint: with most hours active, a continuous opacity ramp read as
+    // one wash of green. Nobody can tell 60% opacity from 70%. Discrete steps
+    // can be told apart and can be labelled with what they mean.
+    const rows: HourWeekdayRow[] = [
+      { weekday: 1, name: 'Monday', hours: Array.from({ length: 24 }, (_, h) => (h === 0 ? 100 : h === 1 ? 10 : h === 2 ? 60 : 0)) },
+    ];
+
+    render(<ActivityHeatmap rows={rows} peakCell={null} busiest={100} timezone="Europe/Sofia" />);
+
+    const colourOf = (label: string) =>
+      /background-color:\s*([^;]+)/.exec(screen.getByLabelText(label).getAttribute('style') ?? '')?.[1];
+
+    const top = colourOf('Monday 00:00 — 100 sessions');
+    const mid = colourOf('Monday 02:00 — 60 sessions');
+    const low = colourOf('Monday 01:00 — 10 sessions');
+
+    // Three different volumes must land on three different, named colours.
+    expect(new Set([top, mid, low]).size).toBe(3);
+  });
+
+  it('states the count range each colour stands for', () => {
+    // A legend of unlabelled swatches still requires decoding by eye.
+    const rows: HourWeekdayRow[] = [
+      { weekday: 1, name: 'Monday', hours: Array.from({ length: 24 }, (_, h) => (h === 0 ? 100 : 0)) },
+    ];
+
+    render(<ActivityHeatmap rows={rows} peakCell={null} busiest={100} timezone="Europe/Sofia" />);
+
+    expect(screen.getByText('0')).toBeTruthy();
+    expect(screen.getByText(/76–100|100/)).toBeTruthy();
+  });
+
   it('keeps ordinary cells visible against a heavy peak', () => {
     // Play is heavily peaked: a linear ramp renders a cell at 10% of the peak at
     // ~0.21 opacity, which reads as empty and hides the shape of a normal week.
@@ -55,9 +104,11 @@ describe('activityHeatmap', () => {
     render(<ActivityHeatmap rows={rows} peakCell={null} busiest={100} timezone="Europe/Sofia" />);
 
     const ordinary = screen.getByLabelText('Monday 01:00 — 10 sessions');
-    const opacity = Number(/rgba\(16, 185, 129, ([\d.]+)\)/.exec(ordinary.getAttribute('style') ?? '')?.[1]);
+    const colour = /background-color:\s*([^;]+)/.exec(ordinary.getAttribute('style') ?? '')?.[1];
 
-    expect(opacity).toBeGreaterThan(0.3);
+    // A 10-of-100 cell must still be painted, not left indistinguishable from
+    // an empty one — which is what a linear ramp did to it.
+    expect(colour).toBeTruthy();
   });
 
   it('does not divide by zero when the window is empty but rows are present', () => {


### PR DESCRIPTION
Backlog **A3**.

## Why it was unreadable

The grid scaled **opacity continuously**. Nobody can tell 60% opacity from 70% — so on a week where most hours have some play, the whole thing read as one wash of green. Exactly what you described.

Four **discrete buckets** now, by share of the busiest cell. Steps can be told apart, and the legend states the **count range each one covers**, so a colour never has to be decoded by eye against a gradient.

## The ramps were validated, not picked

```
light  #10b981 → #059669 → #047857 → #064e3b    ALL CHECKS PASS
dark   #047857 → #059669 → #34d399 → #a7f3d0    ALL CHECKS PASS (vs slate card)
```

Single hue, monotone lightness, adjacent steps ≥0.06 apart in L, and a lightest step clearing 2:1 against its own surface so it's distinguishable from an empty cell.

The dark ramp **runs the other way round**. Reusing the light one would put its darkest step on a dark card — making the busiest hours read as the emptiest.

## A test that needed fixing before it was worth anything

My first mutation pass tried collapsing both surfaces onto the light ramp, and it **passed** — nothing pinned the per-surface choice. Extracted `heatmapRamp(isDark)` so the decision is testable rather than implicit, and it now fails.

| Mutation | Result |
|---|---|
| Collapse to a continuous ramp | fails |
| Share one palette across surfaces | fails (only after the fix above) |

295 tests · types clean · build green.
