### PR TITLE
fix(reports): make the bots and row-count controls read as what they are

### DIFF
--- a/app/reports/players/page.tsx
+++ b/app/reports/players/page.tsx
@@ -17,6 +17,7 @@ import { useReportFilters } from '@/hooks/use-report-filters';
 import { useAuth } from '@/lib/auth';
 import { rangeToParams } from '@/lib/report-range';
 import { ReportsAPI } from '@/lib/reports-api';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 
 export default function PlayersReportPage() {
   const { isAuthenticated, user } = useAuth();
@@ -68,18 +69,21 @@ export default function PlayersReportPage() {
       />
 
       <div className="flex flex-wrap items-center gap-2">
-        <span className="text-sm text-gray-600 dark:text-gray-300">Show</span>
-        {/* 100 is the API's own cap (MAX_LIMIT); offering more would 400. */}
-        {[25, 50, 100].map(size => (
-          <Button
-            key={size}
-            size="sm"
-            variant={limit === size ? 'default' : 'outline'}
-            onClick={() => update({ limit: size })}
-          >
-            {size}
-          </Button>
-        ))}
+        <label htmlFor="row-limit" className="text-sm text-gray-600 dark:text-gray-300">Show</label>
+        {/* A dropdown, not three buttons. Row count is a single choice from a
+            closed set, which is what a select is for — and three more filled/
+            outlined buttons beside the range presets made it read as another
+            filter rather than a page size. 100 is the API's own cap. */}
+        <Select value={String(limit)} onValueChange={next => update({ limit: Number(next) })}>
+          <SelectTrigger id="row-limit" className="h-8 w-[88px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {[25, 50, 100].map(size => (
+              <SelectItem key={size} value={String(size)}>{size}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
 
         <span className="ml-2 text-sm text-gray-600 dark:text-gray-300">Rank by</span>
         <Button size="sm" variant={sortBy === 'played' ? 'default' : 'outline'} onClick={() => setSortBy('played')}>

--- a/components/reports/RangePicker.tsx
+++ b/components/reports/RangePicker.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { isoDay } from '@/lib/report-range';
 import { REPORT_WINDOWS } from '@/types/reports';
+import { Switch } from '@/components/ui/switch';
 
 /**
  * Presets for the common case, explicit dates for everything else.
@@ -67,14 +68,24 @@ export function RangePicker({ value, onChange, includeBots, onIncludeBotsChange 
         )}
       </Button>
 
-      <Button
-        size="sm"
-        variant={includeBots ? 'default' : 'outline'}
-        onClick={() => onIncludeBotsChange(!includeBots)}
-        title="Bot/simulation accounts (is_dummy) are excluded by default"
+      {/* A switch, not a button. Button labels read as actions, so "Bots
+          excluded" in an unfilled style read as "click to exclude bots" —
+          implying they currently weren't. A switch reads as state: off means
+          off, and the label never has to be interpreted as an instruction. It
+          also stops the control competing with the window presets beside it,
+          where filled genuinely does mean "selected". */}
+      <label
+        htmlFor="include-bots"
+        className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300"
+        title="Bot and simulation accounts (is_dummy). Off by default — Anonymous players are real people and are always counted."
       >
-        {includeBots ? 'Bots included' : 'Bots excluded'}
-      </Button>
+        <Switch
+          id="include-bots"
+          checked={includeBots}
+          onCheckedChange={onIncludeBotsChange}
+        />
+        Include bots
+      </label>
 
       {open && (
         <div className="flex w-full flex-wrap items-end gap-2 rounded-md border bg-white p-3 dark:border-slate-700 dark:bg-slate-800">

--- a/components/reports/__tests__/RangePicker.test.tsx
+++ b/components/reports/__tests__/RangePicker.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { RangePicker } from '@/components/reports/RangePicker';
+
+function setup(includeBots = false) {
+  const onIncludeBotsChange = vi.fn();
+  render(
+    <RangePicker
+      value={{ window: 30 }}
+      onChange={() => {}}
+      includeBots={includeBots}
+      onIncludeBotsChange={onIncludeBotsChange}
+    />,
+  );
+  return { onIncludeBotsChange };
+}
+
+describe('bots control', () => {
+  it('reads as state, not as an instruction', () => {
+    // The bug: it was a Button labelled "Bots excluded". Button labels read as
+    // actions, so an unfilled "Bots excluded" read as "click to exclude bots" —
+    // implying they currently weren't. A switch has an unambiguous off state.
+    setup(false);
+
+    const control = screen.getByRole('switch', { name: /include bots/i });
+    expect(control.getAttribute('aria-checked')).toBe('false');
+  });
+
+  it('shows on when bots are actually included', () => {
+    setup(true);
+
+    expect(screen.getByRole('switch', { name: /include bots/i }).getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('does not present itself as a selected filter beside the window presets', () => {
+    // It used to be a Button in the same row as the 7/30/90 presets, where
+    // filled genuinely means "selected" — so it competed with them.
+    setup(false);
+
+    const buttons = screen.getAllByRole('button').map(b => b.textContent);
+    expect(buttons.some(label => /bots/i.test(label ?? ''))).toBe(false);
+  });
+
+  it('toggles', async () => {
+    const { onIncludeBotsChange } = setup(false);
+
+    await userEvent.click(screen.getByRole('switch', { name: /include bots/i }));
+
+    expect(onIncludeBotsChange).toHaveBeenCalledWith(true);
+  });
+});


### PR DESCRIPTION
Backlog **E1** and **B5** — the same underlying problem, so fixed together.

## E1 — the bots control

Bots were already excluded everywhere; the control just said otherwise. It was a `Button` labelled **"Bots excluded"**, and button labels read as *actions* — so an unfilled "Bots excluded" reads as *"click to exclude bots"*, implying they currently weren't.

Worse, it sat in the same row as the window presets, where filled genuinely **does** mean "selected". So it competed with them for the same visual language while meaning something different.

It's now a **switch**. Off means off, and the label is never an instruction.

This is why I asked rather than guessed — I'd verified the data was right and had no way to see the labelling problem from the code alone.

## B5 — the row count

25/50/100 is a single choice from a closed set, which is what a `Select` is for. As three more filled/outlined buttons beside the range presets, it read as another *filter* rather than a page size.

## Why one PR

Both are "a control whose appearance doesn't match what it controls", in the same row. Splitting them would have left that row half-consistent, which is worse than either state.

Mutation-verified: restoring the state-labelled Button fails all four switch tests.

299 tests · types clean · build green.
