### PR TITLE
feat(reports): name games by their name, not their metric title

### DIFF
--- a/app/reports/multiplayer/page.tsx
+++ b/app/reports/multiplayer/page.tsx
@@ -11,13 +11,13 @@ import { ReportError } from '@/components/reports/ReportError';
 import { ReportsShell } from '@/components/reports/ReportsShell';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
-import { useGameMeta } from '@/hooks/use-game-meta';
+import { gameName, useGameMeta } from '@/hooks/use-game-meta';
 import { useReport } from '@/hooks/use-report';
 import { useReportFilters } from '@/hooks/use-report-filters';
 import { useAuth } from '@/lib/auth';
 import { rangeToParams } from '@/lib/report-range';
 import { ReportsAPI } from '@/lib/reports-api';
-import { prettySlug } from '@/lib/user-hub-format';
+
 
 export default function MultiplayerReportPage() {
   const { isAuthenticated, user } = useAuth();
@@ -145,7 +145,7 @@ export default function MultiplayerReportPage() {
                         {data.by_game.map(row => (
                           <tr key={row.game_type} className="border-b last:border-0 dark:border-slate-700">
                             <td className="py-2 pr-4 font-medium text-gray-900 dark:text-white">
-                              {prettySlug(row.game_type)}
+                              {gameName(meta[row.game_type], row.game_type)}
                             </td>
                             <td className="py-2 pr-4 text-right">{row.rooms_created.toLocaleString()}</td>
                             <td className="py-2 pr-4 text-right">{row.rooms_started.toLocaleString()}</td>

--- a/components/reports/DurationTable.tsx
+++ b/components/reports/DurationTable.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { GameMetaMap } from '@/hooks/use-game-meta';
-import { useGameColor } from '@/hooks/use-game-meta';
+import { gameName, useGameColor } from '@/hooks/use-game-meta';
 import type { DurationResponse } from '@/types/reports';
 import { Info } from 'lucide-react';
 import { ExportButton } from '@/components/reports/ExportButton';
@@ -87,7 +87,7 @@ export function DurationTable({ data, meta }: { data: DurationResponse; meta: Ga
               {data.longest_single_sitting_game && (
                 <>
                   {' Longest single sitting: '}
-                  <strong>{meta[data.longest_single_sitting_game]?.label ?? data.longest_single_sitting_game}</strong>
+                  <strong>{gameName(meta[data.longest_single_sitting_game], data.longest_single_sitting_game)}</strong>
                   .
                 </>
               )}
@@ -149,7 +149,7 @@ export function DurationTable({ data, meta }: { data: DurationResponse; meta: Ga
         <p className="text-xs text-gray-500 dark:text-gray-400">
           No session length available for
           {' '}
-          {unsupported.map(row => meta[row.game_type]?.label ?? row.game_type).join(' and ')}
+          {unsupported.map(row => gameName(meta[row.game_type], row.game_type)).join(' and ')}
           {' — '}
           {unsupported[0]?.reason}
           .

--- a/components/reports/GameBadge.tsx
+++ b/components/reports/GameBadge.tsx
@@ -2,7 +2,7 @@
 
 import type { GameMetaMap } from '@/hooks/use-game-meta';
 import { X } from 'lucide-react';
-import { useGameColor } from '@/hooks/use-game-meta';
+import { gameName, useGameColor } from '@/hooks/use-game-meta';
 import { prettySlug } from '@/lib/user-hub-format';
 import { cn } from '@/lib/utils';
 
@@ -24,7 +24,7 @@ export function GameBadge({ gameKey, meta, active, onClick, count }: {
 }) {
   const resolveColor = useGameColor();
   const color = resolveColor(meta, gameKey);
-  const label = meta[gameKey]?.label ?? prettySlug(gameKey);
+  const label = gameName(meta[gameKey], gameKey);
   const interactive = !!onClick;
 
   const style = active

--- a/components/reports/GameFilter.tsx
+++ b/components/reports/GameFilter.tsx
@@ -2,6 +2,7 @@
 
 import type { GameMetaMap } from '@/hooks/use-game-meta';
 import { GameBadge } from '@/components/reports/GameBadge';
+import { gameName } from '@/hooks/use-game-meta';
 
 /**
  * Pick one game, or all of them.
@@ -20,7 +21,11 @@ export function GameFilter({ meta, value, onChange }: {
   value: string | null;
   onChange: (game: string | null) => void;
 }) {
-  const games = Object.values(meta).sort((a, b) => a.label.localeCompare(b.label));
+  // Sorted by what is displayed. Sorting by `label` put games in an order the
+  // reader can't see, because the visible names differ from it.
+  const games = Object.values(meta).sort(
+    (a, b) => gameName(a, a.key).localeCompare(gameName(b, b.key)),
+  );
 
   if (games.length === 0) {
     return null;

--- a/components/reports/__tests__/game-name.test.tsx
+++ b/components/reports/__tests__/game-name.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { GameBadge } from '@/components/reports/GameBadge';
+import { gameName } from '@/hooks/use-game-meta';
+
+describe('gameName', () => {
+  it('uses the game name, not the metric title', () => {
+    // `label` is a dashboard card title: right above a number, wrong in a table
+    // row, where eleven rows all ended in "... Game Sessions".
+    expect(gameName({ key: 'grid', label: 'Grid Game Sessions', display_name: 'Grid', color: '#f97316' }, 'grid'))
+      .toBe('Grid');
+  });
+
+  it('falls back to the label while a backend without display_name is deployed', () => {
+    // A clumsy name beats a raw slug during the window between deploys.
+    expect(gameName({ key: 'grid', label: 'Grid Game Sessions', color: '#f97316' }, 'grid'))
+      .toBe('Grid Game Sessions');
+  });
+
+  it('prettifies the key for a game the backend has not described', () => {
+    expect(gameName(undefined, 'brand_new_game')).toBe('Brand New Game');
+  });
+
+  it('does not fall through to the slug when display_name is an empty string', () => {
+    // An empty display_name is a data problem, not a reason to show a slug.
+    expect(gameName({ key: 'grid', label: 'Grid Game Sessions', display_name: '', color: '#f97316' }, 'grid'))
+      .toBe('Grid Game Sessions');
+  });
+});
+
+describe('gameBadge', () => {
+  it('renders the game name', () => {
+    render(
+      <GameBadge
+        gameKey="career_path"
+        meta={{ career_path: { key: 'career_path', label: 'CareerPath Game Sessions', display_name: 'Career Path', color: '#6d28d9' } }}
+      />,
+    );
+
+    expect(screen.getByText('Career Path')).toBeTruthy();
+    expect(screen.queryByText(/Game Sessions/)).toBeNull();
+  });
+});

--- a/hooks/use-game-meta.ts
+++ b/hooks/use-game-meta.ts
@@ -10,6 +10,7 @@ import type { GameMeta } from '@/types/reports';
 import { useTheme } from 'next-themes';
 import { useCallback, useEffect, useState } from 'react';
 import { ReportsAPI } from '@/lib/reports-api';
+import { prettySlug } from '@/lib/user-hub-format';
 
 export type GameMetaMap = Record<string, GameMeta>;
 
@@ -24,6 +25,17 @@ export const FALLBACK_COLOR = '#94a3b8';
  * reads as a smudge rather than a colour. `color_dark` is optional, so a BE
  * that predates it degrades to the light colour rather than to grey.
  */
+/**
+ * What to call a game on screen.
+ *
+ * Prefers `display_name` ("Grid"). Falls back to `label` ("Grid Game Sessions")
+ * only while a backend predating display_name is deployed — a clumsy name beats
+ * a raw slug. Falls back to the prettified key when the game is unknown.
+ */
+export function gameName(meta: GameMeta | undefined, gameKey: string): string {
+  return meta?.display_name || meta?.label || prettySlug(gameKey);
+}
+
 export function gameColor(meta: GameMeta | undefined, isDark: boolean): string {
   if (!meta) {
     return FALLBACK_COLOR;

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -244,6 +244,12 @@ export type PlayerDetailResponse = {
 export type GameMeta = {
   key: string;
   label: string;
+  /**
+   * The game's own name — "Grid", not "Grid Game Sessions". Use this wherever a
+   * game is named; `label` is a dashboard card title that reads as a metric.
+   * Optional so a backend predating it degrades to `label` rather than to a slug.
+   */
+  display_name?: string;
   /** Hex for a light surface. Same colour the Django admin dashboard draws the game with. */
   color: string;
   /**


### PR DESCRIPTION
Backlog **D2**, frontend half. Consumes `display_name` from [App#1455](https://github.com/FootballExtraTime/App/pull/1455).

## What was wrong

Badges, filters, the multiplayer table and the duration prose all rendered `label` — a dashboard **card title** that reads as a measurement. So a column of games ended in "... Game Sessions" eleven times over: three words carrying no information at that position.

The multiplayer table didn't even use the registry — it ran the raw key through a slug prettifier, which is where **"Club_connection"** came from.

## One helper

`gameName(meta, key)`, so every surface names a game the same way and the next one gets it right without deciding again.

**Falls back to `label`, not to the slug.** During the window between the backend and frontend deploys, a clumsy name beats a raw key. An empty `display_name` falls back too — that's a data problem, not a reason to show a slug.

## One thing I changed beyond the ask

The game filter sorted by `label`. Since the visible names now differ from it, that put games in an order **the reader can't see** — alphabetical by a string never shown. It now sorts by what's displayed.

## Mutation-verified

| Mutation | Result |
|---|---|
| Prefer `label` over `display_name` | fails (2 tests) |
| Drop the `label` fallback | fails (2 tests) |

304 tests · types clean · build green.
