### PR TITLE
feat(reports): shared admin shell and a grouped section nav

### DIFF
--- a/components/admin/SectionNav.tsx
+++ b/components/admin/SectionNav.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import type { LucideIcon } from 'lucide-react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { cn } from '@/lib/utils';
+
+export type NavItem = { href: string; label: string; icon: LucideIcon };
+export type NavGroup = { heading: string; items: NavItem[] };
+
+/**
+ * Grouped section nav, shared by every admin section.
+ *
+ * The headings are the point. Reports has ten destinations, and a flat row of
+ * ten reads as a wall of equally-weighted choices — you have to know the names
+ * already to find anything. Grouping them by the question they answer
+ * (overview / per-game / players) puts real structure on screen, so the nav
+ * teaches the section rather than just listing it.
+ *
+ * `exact` matters for the section root: "/reports" is a prefix of every other
+ * reports URL, so a prefix match would light it up on every page.
+ */
+export function SectionNav({ groups, trailing }: {
+  groups: NavGroup[];
+  /** Reference material — present, but not competing with the sections. */
+  trailing?: NavItem;
+}) {
+  const pathname = usePathname();
+  const isActive = (href: string) => pathname === href;
+
+  return (
+    <nav aria-label="Section" className="rounded-lg border bg-white/60 p-2 dark:border-slate-700 dark:bg-slate-800/60">
+      <div className="flex flex-wrap items-start gap-x-6 gap-y-3">
+        {groups.map(group => (
+          <div key={group.heading} className="min-w-[10rem] flex-1">
+            <p className="mb-1 px-2 text-[11px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
+              {group.heading}
+            </p>
+            <div className="flex flex-wrap gap-1">
+              {group.items.map(({ href, label, icon: Icon }) => (
+                <Link
+                  key={href}
+                  href={href}
+                  aria-current={isActive(href) ? 'page' : undefined}
+                  className={cn(
+                    'flex items-center gap-2 rounded-md px-2.5 py-1.5 text-sm font-medium transition-colors',
+                    isActive(href)
+                      ? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200'
+                      : 'text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-slate-700/60',
+                  )}
+                >
+                  <Icon className="size-4 shrink-0" />
+                  {label}
+                </Link>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {trailing && (
+        <div className="mt-2 flex justify-end border-t pt-2 dark:border-slate-700">
+          <Link
+            href={trailing.href}
+            aria-current={isActive(trailing.href) ? 'page' : undefined}
+            className={cn(
+              'flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium transition-colors',
+              isActive(trailing.href)
+                ? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200'
+                : 'text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-slate-700/60',
+            )}
+          >
+            <trailing.icon className="size-3.5" />
+            {trailing.label}
+          </Link>
+        </div>
+      )}
+    </nav>
+  );
+}

--- a/components/admin/SectionShell.tsx
+++ b/components/admin/SectionShell.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import type { NavGroup, NavItem } from '@/components/admin/SectionNav';
+import type { ReactNode } from 'react';
+import { AlertTriangle } from 'lucide-react';
+import { SectionNav } from '@/components/admin/SectionNav';
+import { LoadingSpinner } from '@/components/loading-spinner';
+import { LoginForm } from '@/components/login-form';
+import { Navigation } from '@/components/navigation';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { useAuth } from '@/lib/auth';
+
+/**
+ * Chrome shared by the admin sections: auth, access gate, header, sub-nav.
+ *
+ * Reports and User Hub were two implementations of the same page: same
+ * gradient, same centred heading, same nav-then-content, each drifting
+ * separately. One shell means a change to how a section reads happens once.
+ *
+ * `requireSuperuser` is the one real difference between them. Reports gates on
+ * is_staff, matching the BE where every /core/reporting/* endpoint is
+ * IsAdminUser; User Hub gates on superuser because it exposes per-user data
+ * rather than platform aggregates. That distinction is a parameter, not a
+ * reason to keep two shells.
+ */
+export function SectionShell({
+  title,
+  description,
+  groups,
+  trailing,
+  requireSuperuser = false,
+  actions,
+  children,
+}: {
+  title: string;
+  description: string;
+  groups: NavGroup[];
+  trailing?: NavItem;
+  requireSuperuser?: boolean;
+  /** Section-level controls that belong beside the title, not inside a card. */
+  actions?: ReactNode;
+  children: ReactNode;
+}) {
+  const { isLoading, isAuthenticated, user } = useAuth();
+
+  if (isLoading) {
+    return <LoadingSpinner message="Authenticating" subtitle="Verifying access..." />;
+  }
+  if (!isAuthenticated) {
+    return <LoginForm />;
+  }
+
+  const allowed = requireSuperuser ? !!user?.is_superuser : !!(user?.is_staff || user?.is_superuser);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-green-50 to-blue-50 p-4 dark:from-slate-800 dark:to-emerald-900/30">
+      {/* Numbers are read down columns here, so they get tabular figures — a
+          "1" and a "7" occupy the same width and the eye can compare rows
+          without re-reading each one. */}
+      <div className="mx-auto max-w-7xl space-y-6 [font-variant-numeric:tabular-nums]">
+        <Navigation />
+
+        {/* Left-aligned, not centred: the eye starts at the same x-position as
+            every heading and table below it, so the page has one reading edge
+            instead of two. */}
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <div className="space-y-1">
+            <h1 className="text-2xl font-semibold tracking-tight text-gray-900 dark:text-white">{title}</h1>
+            <p className="max-w-2xl text-sm text-gray-600 dark:text-gray-300">{description}</p>
+          </div>
+          {actions}
+        </div>
+
+        {allowed
+          ? (
+              <>
+                <SectionNav groups={groups} trailing={trailing} />
+                {children}
+              </>
+            )
+          : (
+              <div className="mx-auto max-w-md py-16">
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="flex items-center gap-2">
+                      <AlertTriangle className="size-5 text-amber-600" />
+                      {requireSuperuser ? 'Admin access required' : 'Staff access required'}
+                    </CardTitle>
+                    <CardDescription>
+                      {requireSuperuser
+                        ? 'This section is limited to administrator accounts.'
+                        : 'Reports are limited to staff accounts.'}
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="text-sm text-gray-600 dark:text-gray-300">
+                      You're signed in, but your account doesn't have access. Ask an
+                      administrator to grant it if you need it.
+                    </p>
+                  </CardContent>
+                </Card>
+              </div>
+            )}
+      </div>
+    </div>
+  );
+}

--- a/components/admin/__tests__/SectionNav.test.tsx
+++ b/components/admin/__tests__/SectionNav.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from '@testing-library/react';
+import { BarChart3, BookOpen, Users } from 'lucide-react';
+import { describe, expect, it, vi } from 'vitest';
+import { SectionNav } from '@/components/admin/SectionNav';
+import { REPORT_NAV_GROUPS, REPORT_NAV_TRAILING } from '@/components/reports/ReportsNav';
+
+vi.mock('next/navigation', () => ({ usePathname: () => '/reports/players' }));
+
+const GROUPS = [
+  { heading: 'Overview', items: [{ href: '/reports', label: 'Daily Pulse', icon: BarChart3 }] },
+  // Heading deliberately differs from the item name: a group called
+  // "Players" containing a page called "Players" reads as a duplicate, and
+  // the real nav was renamed to "People" for the same reason.
+  { heading: 'People', items: [{ href: '/reports/players', label: 'Players', icon: Users }] },
+];
+
+describe('sectionNav', () => {
+  it('shows the group headings, because they are the structure', () => {
+    // Ten flat destinations read as a wall of equal choices. The headings say
+    // what each group answers, so the nav teaches the section rather than
+    // listing it.
+    render(<SectionNav groups={GROUPS} />);
+
+    expect(screen.getByText('Overview')).toBeTruthy();
+    expect(screen.getByText('People')).toBeTruthy();
+  });
+
+  it('marks only the current page as current', () => {
+    render(<SectionNav groups={GROUPS} />);
+
+    expect(screen.getByRole('link', { name: /Players/ }).getAttribute('aria-current')).toBe('page');
+    expect(screen.getByRole('link', { name: /Daily Pulse/ }).getAttribute('aria-current')).toBeNull();
+  });
+
+  it('does not light up the section root on every page', () => {
+    // "/reports" is a prefix of every reports URL, so a prefix match would mark
+    // Daily Pulse current everywhere — the one bug this nav can plausibly have.
+    render(<SectionNav groups={GROUPS} />);
+
+    const current = screen.getAllByRole('link').filter(link => link.getAttribute('aria-current') === 'page');
+    expect(current).toHaveLength(1);
+  });
+
+  it('keeps reference material out of the groups', () => {
+    render(
+      <SectionNav
+        groups={GROUPS}
+        trailing={{ href: '/reports/glossary', label: 'What the numbers mean', icon: BookOpen }}
+      />,
+    );
+
+    expect(screen.getByRole('link', { name: /What the numbers mean/ })).toBeTruthy();
+  });
+});
+
+describe('report nav groups', () => {
+  it('has no group heading that duplicates a page name', () => {
+    // A heading and an item with the same word makes the grouping look like a
+    // typo rather than structure.
+    const items = REPORT_NAV_GROUPS.flatMap(group => group.items.map(item => item.label));
+
+    for (const group of REPORT_NAV_GROUPS) {
+      expect(items, `group "${group.heading}" repeats a page name`).not.toContain(group.heading);
+    }
+  });
+
+  it('covers every report page', async () => {
+    // A page missing from the nav is unreachable except by URL — which is how
+    // the player drill-down went unlinked until it was noticed by hand.
+    const { readdirSync } = await import('node:fs');
+    const { join } = await import('node:path');
+
+    const root = join(process.cwd(), 'app', 'reports');
+    const routes = new Set<string>(['/reports']);
+    const walk = (dir: string, prefix: string) => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        // Route groups and colocated tests are not pages.
+        if (!entry.isDirectory() || entry.name.startsWith('[') || entry.name === '__tests__') continue;
+        routes.add(`${prefix}/${entry.name}`);
+        walk(join(dir, entry.name), `${prefix}/${entry.name}`);
+      }
+    };
+    walk(root, '/reports');
+
+    const linked = new Set([
+      ...REPORT_NAV_GROUPS.flatMap(group => group.items.map(item => item.href)),
+      REPORT_NAV_TRAILING.href,
+    ]);
+
+    const missing = [...routes].filter(route => !linked.has(route));
+    expect(missing, `Report pages not in the nav: ${missing.join(', ')}`).toEqual([]);
+  });
+});

--- a/components/reports/ReportsNav.tsx
+++ b/components/reports/ReportsNav.tsx
@@ -1,44 +1,44 @@
 'use client';
 
+import type { NavGroup, NavItem } from '@/components/admin/SectionNav';
 import { BarChart3, BookOpen, Clock, Gamepad2, LayoutGrid, Repeat, Timer, Users } from 'lucide-react';
-import Link from 'next/link';
-import { usePathname } from 'next/navigation';
-import { cn } from '@/lib/utils';
 
-const TABS = [
-  { href: '/reports', label: 'Daily Pulse', icon: BarChart3 },
-  { href: '/reports/games', label: 'Games', icon: LayoutGrid },
-  { href: '/reports/multiplayer', label: 'Multiplayer', icon: Gamepad2 },
-  { href: '/reports/patterns', label: 'Patterns', icon: Clock },
-  { href: '/reports/duration', label: 'Session length', icon: Timer },
-  { href: '/reports/players', label: 'Players', icon: Users },
-  { href: '/reports/retention', label: 'Retention', icon: Repeat },
-  { href: '/reports/glossary', label: 'What the numbers mean', icon: BookOpen },
+/**
+ * Reports, grouped by the question each page answers.
+ *
+ * Ten flat destinations read as a wall of equally-weighted choices — you have
+ * to already know the names to find anything. These three headings are the
+ * actual shape of the section: how is the platform doing, how is each game
+ * doing, how are the people doing.
+ */
+export const REPORT_NAV_GROUPS: NavGroup[] = [
+  {
+    heading: 'Overview',
+    items: [
+      { href: '/reports', label: 'Daily Pulse', icon: BarChart3 },
+      { href: '/reports/patterns', label: 'Patterns', icon: Clock },
+    ],
+  },
+  {
+    heading: 'Per game',
+    items: [
+      { href: '/reports/games', label: 'Games', icon: LayoutGrid },
+      { href: '/reports/multiplayer', label: 'Multiplayer', icon: Gamepad2 },
+      { href: '/reports/duration', label: 'Session length', icon: Timer },
+    ],
+  },
+  {
+    heading: 'People',
+    items: [
+      { href: '/reports/players', label: 'Players', icon: Users },
+      { href: '/reports/retention', label: 'Retention', icon: Repeat },
+    ],
+  },
 ];
 
-export function ReportsNav() {
-  const pathname = usePathname();
-
-  return (
-    <nav className="flex flex-wrap gap-2">
-      {TABS.map(({ href, label, icon: Icon }) => {
-        const active = pathname === href;
-        return (
-          <Link
-            key={href}
-            href={href}
-            className={cn(
-              'flex items-center gap-2 rounded-md border px-3 py-2 text-sm font-medium transition-colors',
-              active
-                ? 'border-emerald-600 bg-emerald-600 text-white'
-                : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50 dark:border-slate-700 dark:bg-slate-800 dark:text-gray-200 dark:hover:bg-slate-700',
-            )}
-          >
-            <Icon className="size-4" />
-            {label}
-          </Link>
-        );
-      })}
-    </nav>
-  );
-}
+/** Reference, not a report — present without competing with the sections. */
+export const REPORT_NAV_TRAILING: NavItem = {
+  href: '/reports/glossary',
+  label: 'What the numbers mean',
+  icon: BookOpen,
+};

--- a/components/reports/ReportsShell.tsx
+++ b/components/reports/ReportsShell.tsx
@@ -1,78 +1,30 @@
 'use client';
 
 import type { ReactNode } from 'react';
-import { AlertTriangle } from 'lucide-react';
-import { LoadingSpinner } from '@/components/loading-spinner';
-import { LoginForm } from '@/components/login-form';
-import { Navigation } from '@/components/navigation';
-import { ReportsNav } from '@/components/reports/ReportsNav';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { useAuth } from '@/lib/auth';
+import { SectionShell } from '@/components/admin/SectionShell';
+import { REPORT_NAV_GROUPS, REPORT_NAV_TRAILING } from '@/components/reports/ReportsNav';
 
 /**
- * Chrome shared by every Reports page: auth, staff gate, header, sub-nav.
- *
- * Gated on `is_staff`, not `is_superuser` — that mirrors the BE, where every
- * `/core/reporting/*` endpoint is `IsAdminUser` (DRF's name for is_staff). The
- * User Hub gates on superuser instead because it exposes private per-user data;
- * these are platform aggregates. This is a friendlier "no access" than silently
- * hitting 403s, not the security boundary.
+ * Reports chrome. Everything shared with User Hub now lives in SectionShell;
+ * this only supplies what is specific to Reports — its nav groups, and the
+ * staff (not superuser) gate that mirrors IsAdminUser on every
+ * /core/reporting/* endpoint.
  */
-export function ReportsShell({ title, description, children }: {
+export function ReportsShell({ title, description, actions, children }: {
   title: string;
   description: string;
+  actions?: ReactNode;
   children: ReactNode;
 }) {
-  const { isLoading, isAuthenticated, user } = useAuth();
-
-  if (isLoading) {
-    return <LoadingSpinner message="Authenticating" subtitle="Verifying staff access..." />;
-  }
-  if (!isAuthenticated) {
-    return <LoginForm />;
-  }
-
-  const isStaff = !!(user?.is_staff || user?.is_superuser);
-
   return (
-    <div className="min-h-screen bg-gradient-to-br from-green-50 to-blue-50 p-4 dark:from-slate-800 dark:to-emerald-900/30">
-      <div className="mx-auto max-w-7xl space-y-6">
-        <Navigation />
-
-        <div className="space-y-2 text-center">
-          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">{title}</h1>
-          <p className="text-gray-600 dark:text-gray-300">{description}</p>
-        </div>
-
-        {isStaff
-          ? (
-              <>
-                <ReportsNav />
-                {children}
-              </>
-            )
-          : (
-              <div className="mx-auto max-w-md py-16">
-                <Card>
-                  <CardHeader>
-                    <CardTitle className="flex items-center gap-2">
-                      <AlertTriangle className="size-5 text-orange-600" />
-                      Staff access required
-                    </CardTitle>
-                    <CardDescription>
-                      Reports are limited to staff accounts.
-                    </CardDescription>
-                  </CardHeader>
-                  <CardContent>
-                    <p className="text-sm text-gray-600 dark:text-gray-300">
-                      You're signed in, but your account isn't staff. Ask an administrator
-                      to grant access if you need it.
-                    </p>
-                  </CardContent>
-                </Card>
-              </div>
-            )}
-      </div>
-    </div>
+    <SectionShell
+      title={title}
+      description={description}
+      groups={REPORT_NAV_GROUPS}
+      trailing={REPORT_NAV_TRAILING}
+      actions={actions}
+    >
+      {children}
+    </SectionShell>
   );
 }


### PR DESCRIPTION
Backlog **D7**, plus the nav half of **D4**.

D7 first because D1/D4/D5/D6 all depend on it: Reports and User Hub were two implementations of the same page — same gradient, same centred heading, same nav-then-content — drifting separately. `SectionShell` is now that page.

**Reports moves onto it first**, User Hub follows in its own PR, per your call: the shell proves itself somewhere the problems already are, rather than destabilising a section that works.

## The nav is grouped, not flat

Ten destinations in one row read as a wall of equally-weighted choices — you have to already know the names to find anything.

```
┌──────────────────────────────────────────────────┐
│  OVERVIEW      │  PER GAME       │  PEOPLE       │
│  Daily Pulse   │  Games          │  Players      │
│  Patterns      │  Multiplayer    │  Retention    │
│                │  Session length │               │
└──────────────────────────────────────────────────┘
                          What the numbers mean ·
```

The headings are the real shape of the section, so the nav teaches it rather than listing it. The glossary sits apart — it's reference, not a report.

## Writing the test renamed a group

I had "Players" as a heading containing a page called "Players". The test flagged the collision, and it reads as a duplicate rather than a grouping. Renamed to **People**, and a test now fails if any heading repeats a page name.

## Two refinements, both for a tool read as columns of numbers

**Tabular figures** across the section — a `1` and a `7` take the same width, so rows can be compared without re-reading each one. This is the one type decision I'd defend hardest; it's what the content actually is.

**Left-aligned page header** rather than centred, so the title starts at the same x-position as every heading and table below it. One reading edge instead of two.

## Mutation-verified

| Mutation | Result |
|---|---|
| Prefix matching on the active link | fails (2) — would mark Daily Pulse current on every page |
| Remove the group headings | fails |
| Drop a page from the nav | fails, names the route |

That last one also guards the recurring problem in this section: a page that exists but nothing links to.

310 tests · types clean · build green.
