### PR TITLE
feat(reports): each panel owns its loading and error state

### DIFF
--- a/app/reports/page.tsx
+++ b/app/reports/page.tsx
@@ -13,9 +13,8 @@ import { GameLeaderboard } from '@/components/reports/GameLeaderboard';
 import { MetricToggle } from '@/components/reports/MetricToggle';
 import { PulseTiles } from '@/components/reports/PulseTiles';
 import { RangePicker } from '@/components/reports/RangePicker';
-import { ReportError } from '@/components/reports/ReportError';
+import { ReportPanel } from '@/components/reports/ReportPanel';
 import { ReportsShell } from '@/components/reports/ReportsShell';
-import { Skeleton } from '@/components/ui/skeleton';
 import { useGameMeta, useGameColor } from '@/hooks/use-game-meta';
 import { useReport } from '@/hooks/use-report';
 import { useReportFilters } from '@/hooks/use-report-filters';
@@ -98,34 +97,36 @@ export default function ReportsPage() {
           not a finding, and every panel below inherits that doubt. */}
       <RollupHealthBanner />
 
-      {anomalies.data && (
-        <div className="space-y-2">
-          <AnomalyPanel data={anomalies.data} meta={meta} />
-          <AnomalySensitivity value={sensitivity} onChange={setSensitivity} />
-        </div>
-      )}
+      {/* Was `anomalies.data && …`, so a failed request made the panel vanish
+          without saying so — the one panel whose silence reads as "nothing
+          moved". It now reports its own failure. */}
+      <ReportPanel state={anomalies} skeletonClassName="h-24 w-full">
+        {data => (
+          <div className="space-y-2">
+            <AnomalyPanel data={data} meta={meta} />
+            <AnomalySensitivity value={sensitivity} onChange={setSensitivity} />
+          </div>
+        )}
+      </ReportPanel>
 
-      {summary.error
-        ? <ReportError error={summary.error} notDeployed={summary.notDeployed} onRetry={summary.refetch} />
-        : summary.isLoading || !summary.data
-          ? <Skeleton className="h-32 w-full" />
-          : (
-              <>
+      <ReportPanel state={summary} skeletonClassName="h-32 w-full">
+        {data => (
+          <>
                 {/* The pulse always describes TODAY, whatever range is selected —
                     the BE sends pulse_applies to say so. Rendering it beside
                     comparison tiles that DO follow the range invites reading
                     today's numbers as the selected period's. */}
-                {summary.data.pulse_applies
+            {data.pulse_applies
                   ? (
                       <>
-                        <PulseTiles pulse={summary.data.pulse} />
+                <PulseTiles pulse={data.pulse} />
                         <p className="text-center text-xs text-gray-500 dark:text-gray-400">
                           {selectedLabel ? `${selectedLabel} · ` : ''}
                           compared with the mean of the last
                           {' '}
-                          {summary.data.pulse.baseline_weeks}
+                  {data.pulse.baseline_weeks}
                           {' '}
-                          {summary.data.pulse.weekday}
+                  {data.pulse.weekday}
                           s — not with yesterday, which would make every Monday look like a crash.
                         </p>
                       </>
@@ -134,27 +135,26 @@ export default function ReportsPage() {
                       <p className="rounded-md border border-gray-200 bg-gray-50 p-3 text-center text-sm text-gray-600 dark:border-slate-700 dark:bg-slate-800 dark:text-gray-300">
                         Today's pulse is hidden because this range ends on
                         {' '}
-                        {summary.data.end}
+                {data.end}
                         . It only ever describes today, so showing it here would
                         read as the selected period. Everything below follows your range.
                       </p>
-                    )}
-              </>
-            )}
+              )}
+          </>
+        )}
+      </ReportPanel>
 
-      {activity.error
-        ? <ReportError error={activity.error} notDeployed={activity.notDeployed} onRetry={activity.refetch} />
-        : activity.isLoading || !activity.data
-          ? <Skeleton className="h-80 w-full" />
-          : (
-              <ActivityChart
-                series={activity.data.series}
-                metric={metric}
-                color={game ? resolveColor(meta, game) : undefined}
-                title={`${selectedLabel ?? 'All games'} — last ${activity.data.window} days`}
-                description={`${activity.data.totals.games_started.toLocaleString()} played, ${activity.data.totals.games_finished.toLocaleString()} finished, ${activity.data.totals.distinct_players.toLocaleString()} distinct players.`}
-              />
-            )}
+      <ReportPanel state={activity} skeletonClassName="h-80 w-full">
+        {data => (
+          <ActivityChart
+            series={data.series}
+            metric={metric}
+            color={game ? resolveColor(meta, game) : undefined}
+            title={`${selectedLabel ?? 'All games'} — last ${data.window} days`}
+            description={`${data.totals.games_started.toLocaleString()} played, ${data.totals.games_finished.toLocaleString()} finished, ${data.totals.distinct_players.toLocaleString()} distinct players.`}
+          />
+        )}
+      </ReportPanel>
 
       {allGames.data && (
         <div className="flex justify-end">

--- a/components/reports/ReportPanel.tsx
+++ b/components/reports/ReportPanel.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import type { UseReport } from '@/hooks/use-report';
+import type { ReactNode } from 'react';
+import { ReportError } from '@/components/reports/ReportError';
+import { Skeleton } from '@/components/ui/skeleton';
+
+/**
+ * One panel that owns its own loading, error and content.
+ *
+ * The reports handled all three at PAGE level, so a page making four requests
+ * showed nothing until the slowest returned, and one failing endpoint replaced
+ * every panel — including the three that had loaded fine. A failure in the
+ * anomalies endpoint should not take the activity chart with it.
+ *
+ * The retry is inside the panel for the same reason: retrying should refetch
+ * the thing that failed, not the whole page.
+ *
+ * `children` is a function so `data` is non-null inside it, which removes the
+ * `!data` guard every call site used to repeat and the "loaded but empty"
+ * branch that guard quietly created.
+ */
+export function ReportPanel<T>({ state, skeletonClassName = 'h-64 w-full', children }: {
+  state: UseReport<T>;
+  /** Sized per panel so the page doesn't reflow as each one lands. */
+  skeletonClassName?: string;
+  children: (data: T) => ReactNode;
+}) {
+  if (state.error) {
+    return (
+      <ReportError
+        error={state.error}
+        notDeployed={state.notDeployed}
+        onRetry={state.refetch}
+      />
+    );
+  }
+
+  // Skeleton only before there is anything to show. On a refetch — changing the
+  // range, toggling bots — the previous numbers stay on screen: they are one
+  // filter out of date for a moment, which beats every panel flashing to grey
+  // and the page jumping as each one lands again.
+  if (!state.data) {
+    return <Skeleton className={skeletonClassName} />;
+  }
+
+  return (
+    <div className={state.isLoading ? 'opacity-60 transition-opacity' : undefined}>
+      {children(state.data)}
+    </div>
+  );
+}

--- a/components/reports/__tests__/ReportPanel.test.tsx
+++ b/components/reports/__tests__/ReportPanel.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ReportPanel } from '@/components/reports/ReportPanel';
+
+function state(overrides = {}) {
+  return { data: null, isLoading: false, error: null, notDeployed: false, refetch: vi.fn(), ...overrides };
+}
+
+describe('reportPanel', () => {
+  it('reports its own failure instead of the page reporting it', async () => {
+    // The pages handled errors at page level, so one failing endpoint replaced
+    // every panel — including the ones that had loaded fine.
+    render(
+      <ReportPanel state={state({ error: 'Boom' }) as never}>
+        {() => <div>content</div>}
+      </ReportPanel>,
+    );
+
+    expect(await screen.findByText(/Boom/)).toBeTruthy();
+    expect(screen.queryByText('content')).toBeNull();
+  });
+
+  it('retries only itself', async () => {
+    // Retrying should refetch the thing that failed, not the whole page.
+    const refetch = vi.fn();
+    render(
+      <ReportPanel state={state({ error: 'Boom', refetch }) as never}>
+        {() => <div>content</div>}
+      </ReportPanel>,
+    );
+
+    (await screen.findByRole('button', { name: /retry|try again/i })).click();
+
+    expect(refetch).toHaveBeenCalled();
+  });
+
+  it('shows content once its own data arrives, regardless of other panels', () => {
+    render(
+      <ReportPanel state={state({ data: { ok: true } }) as never}>
+        {data => <div>{`loaded-${(data as { ok: boolean }).ok}`}</div>}
+      </ReportPanel>,
+    );
+
+    expect(screen.getByText('loaded-true')).toBeTruthy();
+  });
+
+  it('gives children non-null data, so no call site repeats the guard', () => {
+    // The render prop is the point: `!data` guards at every call site quietly
+    // created a "loaded but empty" branch that rendered nothing at all.
+    const child = vi.fn(() => <div>ok</div>);
+    render(<ReportPanel state={state({ data: { value: 1 } }) as never}>{child as never}</ReportPanel>);
+
+    expect(child).toHaveBeenCalledWith({ value: 1 });
+  });
+
+  it('shows a skeleton only before there is anything to show', () => {
+    render(
+      <ReportPanel state={state({ isLoading: true }) as never}>
+        {() => <div>content</div>}
+      </ReportPanel>,
+    );
+
+    expect(screen.queryByText('content')).toBeNull();
+  });
+
+  it('keeps the previous numbers on screen while refetching', () => {
+    // Changing a filter refetches every panel. Blanking them all to skeletons
+    // flashes the page and makes it jump as each one lands again — one
+    // filter-out-of-date numbers, dimmed, are more useful than grey boxes.
+    render(
+      <ReportPanel state={state({ data: { ok: true }, isLoading: true }) as never}>
+        {() => <div>content</div>}
+      </ReportPanel>,
+    );
+
+    expect(screen.getByText('content')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Backlog **D5**, first half.

## The problem

Loading, error and content were handled at **page** level. The Daily Pulse makes **four** requests, so it showed nothing until the slowest returned — and one failing endpoint replaced every panel, including the three that had loaded fine.

The anomalies panel was worse: it rendered on `anomalies.data && …`, so a failed request made it **disappear silently**. That's the one panel whose absence reads as a finding — *"nothing needs attention"*. It now reports its own failure.

Retry moved into the panel too: retrying should refetch the thing that failed, not the whole page.

## The render prop earns its keep

`children` is a function, so `data` is non-null inside it. That removes the `!data` guard every call site repeated — and with it the "loaded but empty" branch those guards quietly created, where a panel rendered nothing and said nothing.

## One behaviour change I didn't plan

Mutation testing caught that my first version blanked to a skeleton whenever `isLoading` — including on **refetch**. Since changing a filter refetches every panel, that flashed the whole page to grey and made it jump as each panel landed again.

Panels now keep their previous numbers on screen while refetching, dimmed. Numbers one filter out of date beat grey boxes.

That's the second time this session a mutation test found a design problem rather than a missing assertion.

| Mutation | Result |
|---|---|
| Swallow errors (panel vanishes) | fails (2) |
| Blank to a skeleton on every refetch | fails |

316 tests · types clean · build green.

**Next:** the remaining D5 items — chart-owned controls in card headers, granularity-aware date formatting, and bringing `AdoptionTrendsChart` onto the shared `chartTheme` (it still has the dark-mode issue A2 fixed).
