### PR TITLE
feat(reports): group the activity chart by week or month

### DIFF
--- a/components/reports/ActivityChart.tsx
+++ b/components/reports/ActivityChart.tsx
@@ -6,13 +6,23 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { METRIC_OPTIONS } from '@/types/reports';
 import { useTheme } from 'next-themes';
 import { chartTheme } from '@/lib/chart-theme';
+import type { Granularity } from '@/lib/report-granularity';
+import { useState } from 'react';
+import { aggregateSeries, canAggregate, GRANULARITIES } from '@/lib/report-granularity';
+import { cn } from '@/lib/utils';
 
 /** Day-month tick, in UTC so it renders as the intended day regardless of viewer TZ. */
-function formatDay(iso: string): string {
+/** Labels follow the bucket: a month bar labelled "1 Aug" reads as one day. */
+function formatBucket(iso: string, granularity: Granularity): string {
   const d = new Date(iso);
-  return Number.isNaN(d.getTime())
-    ? iso
-    : new Intl.DateTimeFormat('en-GB', { day: 'numeric', month: 'short', timeZone: 'UTC' }).format(d);
+  if (Number.isNaN(d.getTime())) {
+    return iso;
+  }
+  if (granularity === 'month') {
+    return new Intl.DateTimeFormat('en-GB', { month: 'short', year: '2-digit', timeZone: 'UTC' }).format(d);
+  }
+  const day = new Intl.DateTimeFormat('en-GB', { day: 'numeric', month: 'short', timeZone: 'UTC' }).format(d);
+  return granularity === 'week' ? `w/c ${day}` : day;
 }
 
 const DEFAULT_COLORS: Record<MetricKey, string> = {
@@ -38,12 +48,21 @@ export function ActivityChart({ series, title, description, metric, color }: {
 }) {
   const { resolvedTheme } = useTheme();
   const theme = chartTheme(resolvedTheme === 'dark');
+  // Chart-owned, not page-owned: it changes how this chart reads and nothing
+  // else on the page, so it belongs in this header rather than the filter bar.
+  const [granularity, setGranularity] = useState<Granularity>('day');
+  const aggregatable = canAggregate(metric);
+  // Distinct players cannot be summed across days, so the control falls back to
+  // daily rather than drawing an inflated line. Silently ignoring the choice
+  // would be worse: the button would look selected and the data wouldn't match.
+  const effective: Granularity = aggregatable ? granularity : 'day';
+  const rows = aggregateSeries(series, effective);
   // An uncovered day was never computed. Feeding 0 to the chart draws a
   // confident dip that never happened, so the value becomes null and recharts
   // leaves a visible break instead.
-  const data = series.map(row => ({
+  const data = rows.map(row => ({
     ...row,
-    label: formatDay(row.date),
+    label: formatBucket(row.date, effective),
     ...(row.covered
       ? {}
       : {
@@ -53,15 +72,48 @@ export function ActivityChart({ series, title, description, metric, color }: {
           mp_player_sessions: null,
         }),
   }));
-  const uncovered = series.filter(row => !row.covered).length;
+  const uncovered = rows.filter(row => !row.covered).length;
   const primaryColor = color ?? DEFAULT_COLORS[metric];
 
   return (
     <Card>
-      <CardHeader>
-        <CardTitle>{title}</CardTitle>
+      <CardHeader className="space-y-2">
+        <div className="flex flex-wrap items-start justify-between gap-2">
+          <CardTitle>{title}</CardTitle>
+          <div className="flex gap-1 rounded-md border p-0.5 dark:border-slate-700">
+            {GRANULARITIES.map(option => (
+              <button
+                key={option}
+                type="button"
+                disabled={!aggregatable && option !== 'day'}
+                aria-pressed={effective === option}
+                title={aggregatable
+                  ? `Group by ${option}`
+                  : 'Distinct players cannot be added up across days, so this metric is only shown daily'}
+                onClick={() => setGranularity(option)}
+                className={cn(
+                  'rounded px-2 py-0.5 text-xs font-medium capitalize transition-colors',
+                  effective === option
+                    ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300'
+                    : 'text-gray-500 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40 dark:hover:bg-slate-700/50',
+                )}
+              >
+                {option}
+              </button>
+            ))}
+          </div>
+        </div>
         <CardDescription>
           {description}
+          {!aggregatable && (
+            <>
+              {' '}
+              <span className="text-gray-500 dark:text-gray-400">
+                Shown daily: distinct players can't be added up across days, so a
+                weekly total would count the same person more than once.
+              </span>
+            </>
+          )}
           {uncovered > 0 && (
             <>
               {' '}

--- a/components/user-hub/AdoptionTrendsChart.tsx
+++ b/components/user-hub/AdoptionTrendsChart.tsx
@@ -7,6 +7,8 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { formatTrendDate } from '@/lib/user-hub-analytics';
 import { cn } from '@/lib/utils';
+import { useTheme } from 'next-themes';
+import { chartTheme } from '@/lib/chart-theme';
 
 type Props = {
   data: AdoptionTrendsResponse | null;
@@ -52,6 +54,8 @@ function TrendTooltip({
 const PILLS: TrendGranularity[] = ['day', 'week'];
 
 export function AdoptionTrendsChart({ data, isLoading, error, notDeployed, granularity, onGranularityChange, onRetry }: Props) {
+  const { resolvedTheme } = useTheme();
+  const theme = chartTheme(resolvedTheme === 'dark');
   if (notDeployed) {
     return null;
   }
@@ -102,9 +106,9 @@ export function AdoptionTrendsChart({ data, isLoading, error, notDeployed, granu
             <div className="h-64 w-full">
               <ResponsiveContainer width="100%" height="100%">
                 <AreaChart data={points} margin={{ left: 4, right: 8, top: 4 }}>
-                  <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-gray-700" />
-                  <XAxis dataKey="date" tick={{ fontSize: 12 }} tickFormatter={v => formatTrendDate(v, granularity)} minTickGap={24} />
-                  <YAxis allowDecimals={false} tick={{ fontSize: 12 }} width={36} />
+                  <CartesianGrid strokeDasharray="3 3" stroke={theme.grid.stroke} />
+                  <XAxis dataKey="date" tick={theme.tick} tickFormatter={v => formatTrendDate(v, granularity)} minTickGap={24} />
+                  <YAxis allowDecimals={false} tick={theme.tick} width={36} />
                   <Tooltip content={<TrendTooltip granularity={granularity} />} />
                   <Legend wrapperStyle={{ fontSize: 12 }} />
                   <Area type="monotone" dataKey="cumulative_users" name="Cumulative users" stroke="#10b981" fill="#10b981" fillOpacity={0.2} />

--- a/lib/__tests__/report-granularity.test.ts
+++ b/lib/__tests__/report-granularity.test.ts
@@ -1,0 +1,79 @@
+import type { ActivityDay } from '@/types/reports';
+import { describe, expect, it } from 'vitest';
+import { aggregateSeries, canAggregate } from '@/lib/report-granularity';
+
+function day(date: string, started: number, players: number, covered = true): ActivityDay {
+  return {
+    date,
+    games_started: started,
+    games_finished: started,
+    distinct_players: players,
+    mp_player_sessions: 0,
+    covered,
+  } as ActivityDay;
+}
+
+describe('canAggregate', () => {
+  it('refuses distinct players', () => {
+    // Someone playing Monday and Thursday is one player that week, not two.
+    // Summing daily distinct counts is what once made a platform total read
+    // 5.6x too high, and a weekly count cannot be recovered from daily ones.
+    expect(canAggregate('distinct_players')).toBe(false);
+  });
+
+  it('allows the metrics that genuinely sum', () => {
+    expect(canAggregate('games_started')).toBe(true);
+    expect(canAggregate('games_finished')).toBe(true);
+    expect(canAggregate('mp_player_sessions')).toBe(true);
+  });
+});
+
+describe('aggregateSeries', () => {
+  const week = [
+    day('2026-08-03', 10, 5), // Monday
+    day('2026-08-04', 20, 6),
+    day('2026-08-05', 30, 7),
+    day('2026-08-10', 40, 8), // the following Monday
+  ];
+
+  it('sums the additive metrics into weekly buckets', () => {
+    const rows = aggregateSeries(week, 'week');
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0].games_started).toBe(60);
+    expect(rows[1].games_started).toBe(40);
+  });
+
+  it('never sums distinct players', () => {
+    // The whole point. 5 + 6 + 7 = 18 would be a plausible, wrong number.
+    const rows = aggregateSeries(week, 'week');
+
+    expect(rows[0].distinct_players).not.toBe(18);
+    expect(rows[0].distinct_players).toBe(7);
+  });
+
+  it('buckets weeks from Monday', () => {
+    const rows = aggregateSeries(week, 'week');
+
+    expect(rows[0].date).toBe('2026-08-03');
+    expect(rows[1].date).toBe('2026-08-10');
+  });
+
+  it('marks a bucket uncovered if any day in it was never computed', () => {
+    // A gap hidden inside a wider bar is worse than a gap in a daily line —
+    // the bar looks like a complete week.
+    const rows = aggregateSeries([day('2026-08-03', 10, 5), day('2026-08-04', 20, 6, false)], 'week');
+
+    expect(rows[0].covered).toBe(false);
+  });
+
+  it('groups months by calendar month', () => {
+    const rows = aggregateSeries([day('2026-07-31', 5, 2), day('2026-08-01', 7, 3)], 'month');
+
+    expect(rows.map(r => r.date)).toEqual(['2026-07-01', '2026-08-01']);
+  });
+
+  it('returns the series untouched for daily', () => {
+    expect(aggregateSeries(week, 'day')).toBe(week);
+  });
+});

--- a/lib/report-granularity.ts
+++ b/lib/report-granularity.ts
@@ -1,0 +1,85 @@
+import type { ActivityDay, MetricKey } from '@/types/reports';
+
+/**
+ * Rolling the daily activity series up to weeks or months.
+ *
+ * A 90-day daily line is mostly noise — the weekly shape is what you actually
+ * read. But rolling up is only valid for metrics that sum.
+ *
+ * `distinct_players` does not. Someone who plays on Monday and Thursday is one
+ * player that week, not two, so adding the daily figures inflates it — the same
+ * mistake that once made the platform total read 5.6× too high. There is no way
+ * to recover a weekly distinct count from daily distinct counts; it needs a
+ * query the client doesn't have. So this refuses to aggregate it rather than
+ * producing a number that looks plausible and is wrong.
+ */
+
+export type Granularity = 'day' | 'week' | 'month';
+
+export const GRANULARITIES: Granularity[] = ['day', 'week', 'month'];
+
+/** Mirrors ADDITIVE_METRICS in core/reporting_queries.py. */
+const ADDITIVE: MetricKey[] = ['games_started', 'games_finished', 'mp_player_sessions'];
+
+export function canAggregate(metric: MetricKey): boolean {
+  return ADDITIVE.includes(metric);
+}
+
+/** ISO week start (Monday), so buckets line up with how weeks are read. */
+function startOfWeek(date: Date): Date {
+  const out = new Date(date);
+  const weekday = (out.getUTCDay() + 6) % 7;
+  out.setUTCDate(out.getUTCDate() - weekday);
+  return out;
+}
+
+function bucketKey(iso: string, granularity: Granularity): string {
+  if (granularity === 'day') {
+    return iso;
+  }
+  const date = new Date(`${iso}T00:00:00Z`);
+  if (Number.isNaN(date.getTime())) {
+    return iso;
+  }
+  if (granularity === 'month') {
+    return `${iso.slice(0, 7)}-01`;
+  }
+  return startOfWeek(date).toISOString().slice(0, 10);
+}
+
+/**
+ * Group the series into buckets, summing the additive metrics.
+ *
+ * `covered` survives as AND: a bucket containing an uncomputed day is not fully
+ * covered, and saying otherwise would hide a gap inside a wider bar.
+ */
+export function aggregateSeries(series: ActivityDay[], granularity: Granularity): ActivityDay[] {
+  if (granularity === 'day') {
+    return series;
+  }
+
+  const buckets = new Map<string, ActivityDay>();
+  for (const row of series) {
+    const key = bucketKey(row.date, granularity);
+    const existing = buckets.get(key);
+    if (!existing) {
+      buckets.set(key, { ...row, date: key });
+      continue;
+    }
+    for (const metric of ADDITIVE) {
+      existing[metric] += row[metric];
+    }
+    // Deliberately not summed — see the note above. Carried as the largest
+    // single day in the bucket, which is a true lower bound for the period
+    // rather than an invented total.
+    existing.distinct_players = Math.max(existing.distinct_players, row.distinct_players);
+    existing.covered = existing.covered && row.covered;
+  }
+
+  return [...buckets.values()].sort((a, b) => a.date.localeCompare(b.date));
+}
+
+/** How many days each bucket represents, for labelling. */
+export function bucketLabel(granularity: Granularity): string {
+  return granularity === 'day' ? 'day' : granularity === 'week' ? 'week' : 'month';
+}


### PR DESCRIPTION
The rest of **D5**.

## Group by week or month

A 90-day daily line is mostly noise — the weekly shape is what you actually read. The control sits in the **chart's own header**, not the page filter bar, because it changes how this one chart reads and nothing else on the page.

## The part that needed care

Rolling up is only valid for metrics that **sum**, and distinct players don't. Someone playing Monday and Thursday is one player that week, not two.

Summing daily distinct counts is the exact mistake that once made the platform total read **5.6× too high** — and a weekly distinct count can't be recovered from daily ones at all. It needs a query the client doesn't have.

So the control **refuses** rather than producing a plausible wrong number: for distinct players the week/month options are disabled, the chart stays daily, and the description says why.

Quietly ignoring the click would have been worse — the button would look selected while the line disagreed with it.

## Two details

**Coverage survives as AND.** A bucket containing an uncomputed day isn't covered. Saying otherwise would hide a gap *inside a wider bar*, where it's much harder to spot than a break in a daily line.

**Labels follow the bucket** — `w/c 3 Aug` for a week, `Aug 26` for a month. A month bar labelled "1 Aug" reads as a single day.

## Also: AdoptionTrendsChart

Brought onto the shared `chartTheme`. It still used Tailwind grid strokes and hardcoded tick sizes, so it had the **same dark-mode problem** fixed everywhere else in #60 — which is exactly why D5 flagged it.

| Mutation | Result |
|---|---|
| Sum distinct players | fails |
| Mark distinct players additive | fails (2) |
| Coverage as OR | fails |

324 tests · types clean · build green.
