### PR TITLE
feat(reports): anomalies get their own page

### DIFF
--- a/app/reports/anomalies/page.tsx
+++ b/app/reports/anomalies/page.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import type { Sensitivity } from '@/components/reports/AnomalySensitivity';
+import { useMemo, useState } from 'react';
+import { AnomalyPanel } from '@/components/reports/AnomalyPanel';
+import { AnomalySensitivity, SENSITIVITY_PRESETS } from '@/components/reports/AnomalySensitivity';
+import { RangePicker } from '@/components/reports/RangePicker';
+import { ReportPanel } from '@/components/reports/ReportPanel';
+import { ReportsShell } from '@/components/reports/ReportsShell';
+import { useGameMeta } from '@/hooks/use-game-meta';
+import { useReport } from '@/hooks/use-report';
+import { useReportFilters } from '@/hooks/use-report-filters';
+import { useAuth } from '@/lib/auth';
+import { rangeToParams } from '@/lib/report-range';
+import { ReportsAPI } from '@/lib/reports-api';
+import { ExportButton } from '@/components/reports/ExportButton';
+
+/**
+ * What moved enough to be worth attention.
+ *
+ * Moved off the Daily Pulse, which is about today: anomalies compare a window
+ * against the one before it, so the two answered different questions while
+ * sitting in the same column. Given its own page it also has room for the
+ * sensitivity control and a range that belongs to it rather than to the pulse.
+ */
+export default function AnomaliesPage() {
+  const { isAuthenticated, user } = useAuth();
+  const enabled = isAuthenticated && !!(user?.is_staff || user?.is_superuser);
+
+  const { filters, update } = useReportFilters({
+    range: { window: 30 },
+    includeBots: false,
+    game: null,
+    metric: 'games_started',
+  });
+  const { range, includeBots } = filters;
+  const setRange = (next: typeof range) => update({ range: next });
+  const setIncludeBots = (next: boolean) => update({ includeBots: next });
+
+  // Deliberately not in the URL: sensitivity changes what counts as worth
+  // reporting, not what the report covers, so a shared link carries the period
+  // and not the reader's tolerance for noise.
+  const [sensitivity, setSensitivity] = useState<Sensitivity>('default');
+
+  const params = useMemo(
+    () => ({
+      ...rangeToParams(range),
+      include_bots: includeBots,
+      min_volume: SENSITIVITY_PRESETS[sensitivity].min_volume,
+      min_change_pct: SENSITIVITY_PRESETS[sensitivity].min_change_pct,
+    }),
+    [range, includeBots, sensitivity],
+  );
+
+  const { meta } = useGameMeta(enabled);
+  const anomalies = useReport(ReportsAPI.getAnomalies, params, enabled, 'The anomalies reporting endpoint');
+
+  return (
+    <ReportsShell
+      title="Needs attention"
+      description="What moved enough to be worth interrupting you for, compared with the window before it."
+    >
+      <RangePicker
+        value={range}
+        onChange={setRange}
+        includeBots={includeBots}
+        onIncludeBotsChange={setIncludeBots}
+      />
+
+      {/* No game filter on purpose: the point of this page is to surface the
+          game you would not have thought to look at. */}
+      <AnomalySensitivity value={sensitivity} onChange={setSensitivity} />
+
+      <div className="flex justify-end">
+        <ExportButton
+          rows={anomalies.data?.findings ?? []}
+          view="anomalies"
+          filters={{ ...rangeToParams(range), bots: includeBots, sensitivity }}
+          columns={[
+            { header: 'Severity', value: row => row.severity },
+            { header: 'Scope', value: row => row.scope },
+            { header: 'Game', value: row => row.game_type ?? 'platform' },
+            { header: 'Metric', value: row => row.metric },
+            { header: 'Change %', value: row => row.change_pct },
+            { header: 'Current', value: row => row.current },
+            { header: 'Previous', value: row => row.previous },
+            { header: 'Headline', value: row => row.headline },
+            { header: 'Detail', value: row => row.detail },
+          ]}
+        />
+      </div>
+
+      <ReportPanel state={anomalies} skeletonClassName="h-40 w-full">
+        {data => <AnomalyPanel data={data} meta={meta} />}
+      </ReportPanel>
+    </ReportsShell>
+  );
+}

--- a/app/reports/page.tsx
+++ b/app/reports/page.tsx
@@ -1,13 +1,10 @@
 'use client';
 
-import type { Sensitivity } from '@/components/reports/AnomalySensitivity';
 import type { GameTotals } from '@/types/reports';
 import type { Granularity } from '@/types/reports';
 import { useMemo, useState } from 'react';
 import { ActivityChart } from '@/components/reports/ActivityChart';
-import { AnomalyPanel } from '@/components/reports/AnomalyPanel';
 import { RollupHealthBanner } from '@/components/reports/RollupHealthBanner';
-import { AnomalySensitivity, SENSITIVITY_PRESETS } from '@/components/reports/AnomalySensitivity';
 import { ExportButton } from '@/components/reports/ExportButton';
 import { GameBadge } from '@/components/reports/GameBadge';
 import { GameLeaderboard } from '@/components/reports/GameLeaderboard';
@@ -64,19 +61,6 @@ export default function ReportsPage() {
   const activity = useReport(ReportsAPI.getActivity, activityParams, enabled, 'The reporting activity endpoint');
   // Unfiltered on purpose: "what needs attention" must surface a game you
   // haven't selected, which is exactly the one you'd otherwise miss.
-  // Kept local rather than in the URL: it changes what counts as worth
-  // reporting, not what the report covers, so a shared link should carry the
-  // period and games — not the reader's tolerance for noise.
-  const [sensitivity, setSensitivity] = useState<Sensitivity>('default');
-  const anomalyParams = useMemo(
-    () => ({
-      ...allGamesParams,
-      min_volume: SENSITIVITY_PRESETS[sensitivity].min_volume,
-      min_change_pct: SENSITIVITY_PRESETS[sensitivity].min_change_pct,
-    }),
-    [allGamesParams, sensitivity],
-  );
-  const anomalies = useReport(ReportsAPI.getAnomalies, anomalyParams, enabled, 'The anomalies reporting endpoint');
 
   const selectedLabel = game ? (meta[game]?.label ?? game) : null;
 
@@ -102,21 +86,10 @@ export default function ReportsPage() {
         </div>
       )}
 
-      {/* Above the anomalies: if the rollup is incomplete, "nothing moved" is
-          not a finding, and every panel below inherits that doubt. */}
+      {/* First on the page: if the rollup is incomplete, every number below
+          inherits that doubt — a quiet day and an uncomputed one look the
+          same. */}
       <RollupHealthBanner />
-
-      {/* Was `anomalies.data && …`, so a failed request made the panel vanish
-          without saying so — the one panel whose silence reads as "nothing
-          moved". It now reports its own failure. */}
-      <ReportPanel state={anomalies} skeletonClassName="h-24 w-full">
-        {data => (
-          <div className="space-y-2">
-            <AnomalyPanel data={data} meta={meta} />
-            <AnomalySensitivity value={sensitivity} onChange={setSensitivity} />
-          </div>
-        )}
-      </ReportPanel>
 
       <ReportPanel state={summary} skeletonClassName="h-32 w-full">
         {data => (

--- a/components/reports/ReportsNav.tsx
+++ b/components/reports/ReportsNav.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { NavGroup, NavItem } from '@/components/admin/SectionNav';
-import { BarChart3, BookOpen, Clock, Gamepad2, LayoutGrid, Repeat, Timer, Users } from 'lucide-react';
+import { BarChart3, BookOpen, Clock, Gamepad2, LayoutGrid, Repeat, Timer, TriangleAlert, Users } from 'lucide-react';
 
 /**
  * Reports, grouped by the question each page answers.
@@ -16,6 +16,7 @@ export const REPORT_NAV_GROUPS: NavGroup[] = [
     heading: 'Overview',
     items: [
       { href: '/reports', label: 'Daily Pulse', icon: BarChart3 },
+      { href: '/reports/anomalies', label: 'Needs attention', icon: TriangleAlert },
       { href: '/reports/patterns', label: 'Patterns', icon: Clock },
     ],
   },


### PR DESCRIPTION
Backlog **D3**, per your decision.

## Why it didn't belong on the Pulse

The Daily Pulse is about **today**. Anomalies compare a window against **the one before it**. Two different questions sharing a column — and the panel had no room for its own range or sensitivity without competing with the pulse's filters.

On its own page it carries both, and gets an export: findings are a list worth taking somewhere, and the CSV keeps the sensitivity in the filename so a file can be interpreted later.

## Still no game filter, deliberately

The point of the page is to surface the game you **wouldn't have thought to look at**. Filtering to one defeats it. Same reasoning as when the panel first shipped ignoring the Pulse's game selection.

Sensitivity stays out of the URL: it changes what counts as worth reporting, not what the report covers — a shared link should carry the period, not the reader's tolerance for noise.

## Both guards caught the new page

Before wiring, the nav-coverage test and the export test each failed and named it:

```
Report pages not in the nav: /reports/anomalies
Report pages with no CSV export: /app/reports/anomalies/page.tsx
```

That's the sixth "built but unreachable" case those two now prevent — the failure mode that produced ModeBreakdown, unshared filters, missing exports, per-game filtering, `pulse_applies` and the unlinked player drill-down.

322 tests · types clean · build green.
