### PR TITLE
feat(reports): session length on the Games comparison

### DIFF
--- a/app/reports/games/page.tsx
+++ b/app/reports/games/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { RangeState } from '@/lib/report-range';
-import type { GameSortKey } from '@/lib/report-sort';
+import type { GameRowWithDuration, GameSortKey } from '@/lib/report-sort';
 import type { GameTotals } from '@/types/reports';
 import { ArrowDown, ArrowUp } from 'lucide-react';
 import Link from 'next/link';
@@ -20,6 +20,8 @@ import { useReportFilters } from '@/hooks/use-report-filters';
 import { useAuth } from '@/lib/auth';
 import { rangeToParams } from '@/lib/report-range';
 import { ReportsAPI } from '@/lib/reports-api';
+import { formatDuration } from '@/lib/format-duration';
+import { sortGameTotals } from '@/lib/report-sort';
 
 /** `metric` keys into the BE glossary so the column explains itself. */
 const COLUMNS: { key: GameSortKey; label: string; hint: string; metric: string }[] = [
@@ -28,6 +30,7 @@ const COLUMNS: { key: GameSortKey; label: string; hint: string; metric: string }
   { key: 'sessions_per_player', label: 'Per player', hint: 'Sessions per distinct player — depth of engagement', metric: 'sessions_per_player' },
   { key: 'repeat_rate_pct', label: 'Came back', hint: 'Share of players who returned on another day', metric: 'repeat_rate_pct' },
   { key: 'trend_pct', label: 'Trend', hint: 'vs the immediately preceding window of equal length', metric: 'trend_pct' },
+  { key: 'median_seconds', label: 'Typical session', hint: 'Median session length. Campaign-shaped games are marked — their sessions span days, not sittings', metric: 'median_duration' },
 ];
 
 /**
@@ -61,6 +64,10 @@ export default function GamesIndexPage() {
   );
 
   const { meta } = useGameMeta(enabled);
+  // Session length is a per-game property but lives on another endpoint, so the
+  // comparison table had to be read beside a second page to answer "which game
+  // holds attention". Merged in here instead.
+  const duration = useReport(ReportsAPI.getDuration, params, enabled, 'The session duration endpoint');
   const { data, isLoading, error, notDeployed, refetch } = useReport(
     ReportsAPI.getSummary,
     params,
@@ -72,24 +79,17 @@ export default function GamesIndexPage() {
     if (!data) {
       return [];
     }
-    // Nulls sort last regardless of direction: a game with no measurable rate
-    // isn't "worst", it's unmeasured, and floating it to either end of a
-    // ranking makes a claim the data doesn't support.
-    return [...data.by_game].sort((a, b) => {
-      const left = a[sortBy];
-      const right = b[sortBy];
-      if (left === null && right === null) {
-        return 0;
-      }
-      if (left === null) {
-        return 1;
-      }
-      if (right === null) {
-        return -1;
-      }
-      return right - left;
-    });
-  }, [data, sortBy]);
+    const byGame = new Map((duration.data?.rows ?? []).map(row => [row.game_type, row]));
+    const merged: GameRowWithDuration[] = data.by_game.map(row => ({
+      ...row,
+      median_seconds: byGame.get(row.game_type)?.median_seconds ?? null,
+      single_sitting: byGame.get(row.game_type)?.single_sitting ?? null,
+    }));
+    // The shared helper rather than a local copy: the null rule it encodes —
+    // unmeasured sorts last, never as a low value — is the part that is easy to
+    // get wrong, and it is tested in one place.
+    return sortGameTotals(merged, sortBy);
+  }, [data, duration.data, sortBy]);
 
   return (
     <ReportsShell
@@ -159,7 +159,7 @@ export default function GamesIndexPage() {
                       </tr>
                     </thead>
                     <tbody>
-                      {rows.map((row: GameTotals) => (
+                      {rows.map((row: GameRowWithDuration) => (
                         <tr key={row.game_type} className="border-b last:border-0 dark:border-slate-700">
                           <td className="py-2 pr-4">
                             <Link href={`/reports/games/${row.game_type}`}>
@@ -172,6 +172,21 @@ export default function GamesIndexPage() {
                           <td className="py-2 pr-4 text-right">{num(row.completion_pct, '%')}</td>
                           <td className="py-2 pr-4 text-right">{num(row.sessions_per_player)}</td>
                           <td className="py-2 pr-4 text-right">{num(row.repeat_rate_pct, '%')}</td>
+                          <td className="py-2 pr-4 text-right">
+                            {row.median_seconds === null || row.median_seconds === undefined
+                              ? <span className="text-gray-400">—</span>
+                              : (
+                                  <span
+                                    className={row.single_sitting === false ? 'text-amber-700 dark:text-amber-300' : undefined}
+                                    title={row.single_sitting === false
+                                      ? 'A session here spans days, not a sitting — not comparable with the others'
+                                      : undefined}
+                                  >
+                                    {formatDuration(row.median_seconds)}
+                                    {row.single_sitting === false && ' *'}
+                                  </span>
+                                )}
+                          </td>
                           <td className="py-2 pr-4 text-right">
                             {row.trend_pct === null
                               ? <span className="text-gray-400">—</span>

--- a/lib/__tests__/report-sort.test.ts
+++ b/lib/__tests__/report-sort.test.ts
@@ -1,8 +1,9 @@
 import type { GameTotals } from '@/types/reports';
 import { describe, expect, it } from 'vitest';
+import type { GameRowWithDuration } from '@/lib/report-sort';
 import { sortGameTotals } from '@/lib/report-sort';
 
-function game(game_type: string, overrides: Partial<GameTotals> = {}): GameTotals {
+function game(game_type: string, overrides: Partial<GameRowWithDuration> = {}): GameRowWithDuration {
   return {
     game_type,
     games_started: 0,
@@ -17,7 +18,7 @@ function game(game_type: string, overrides: Partial<GameTotals> = {}): GameTotal
     previous_games_started: 0,
     trend_pct: null,
     ...overrides,
-  } as GameTotals;
+  } as GameRowWithDuration;
 }
 
 describe('sortGameTotals', () => {
@@ -51,6 +52,28 @@ describe('sortGameTotals', () => {
 
     expect(sortGameTotals(rows, 'trend_pct').map(r => r.game_type))
       .toEqual(['slipping', 'falling', 'unmeasured']);
+  });
+
+  it('sorts by session length with campaign games included', () => {
+    // Session length lives on a different endpoint and is merged in, so it can
+    // be absent for a game the duration report can't measure. Absent must sort
+    // last, like every other unmeasured value.
+    const rows = [
+      game('grid', { median_seconds: 192 }),
+      game('conquest', { median_seconds: 86_424 }),
+      game('quiz', { median_seconds: null }),
+    ];
+
+    expect(sortGameTotals(rows, 'median_seconds').map(r => r.game_type))
+      .toEqual(['conquest', 'grid', 'quiz']);
+  });
+
+  it('treats a missing session length as unmeasured, not as zero', () => {
+    // `undefined` reaches this when the duration request hasn't landed yet —
+    // sorting it as 0 would reshuffle the table as the second request arrives.
+    const rows = [game('a', { median_seconds: 60 }), game('b', {})];
+
+    expect(sortGameTotals(rows, 'median_seconds').map(r => r.game_type)).toEqual(['a', 'b']);
   });
 
   it('does not mutate the input', () => {

--- a/lib/report-sort.ts
+++ b/lib/report-sort.ts
@@ -1,7 +1,15 @@
 import type { GameTotals } from '@/types/reports';
 
 export type GameSortKey
-  = 'games_started' | 'completion_pct' | 'trend_pct' | 'repeat_rate_pct' | 'sessions_per_player';
+  = 'games_started' | 'completion_pct' | 'trend_pct' | 'repeat_rate_pct'
+    | 'sessions_per_player' | 'median_seconds';
+
+/** A game row with its session length merged in, which lives on another endpoint. */
+export type GameRowWithDuration = GameTotals & {
+  median_seconds?: number | null;
+  /** False for campaign-shaped games — real, but not comparable with a sitting. */
+  single_sitting?: boolean | null;
+};
 
 /**
  * Rank games by one metric, descending, with unmeasured games last.
@@ -11,10 +19,10 @@ export type GameSortKey
  * null must never be ordered as if it were a low value. Sorting it to the
  * bottom of "worst completion" would state something the data doesn't say.
  */
-export function sortGameTotals(rows: GameTotals[], key: GameSortKey): GameTotals[] {
+export function sortGameTotals<T extends GameRowWithDuration>(rows: T[], key: GameSortKey): T[] {
   return [...rows].sort((a, b) => {
-    const left = a[key];
-    const right = b[key];
+    const left = a[key] ?? null;
+    const right = b[key] ?? null;
     if (left === null && right === null) {
       return 0;
     }


### PR DESCRIPTION
Backlog **C6**.

Session length is a per-game property that lived only on its own page, so *"which game holds attention"* meant reading two tables side by side. It's now a sortable column on Games — and the badges already lead to `/reports/games/<key>`, so one page explains a game.

## Campaign games are marked, not hidden

Conquest's median really is 24 hours. That's **true**, just not comparable with a sitting — so it shows with a marker and an explanation on hover, rather than being dropped from the column or silently ranked first.

## What I found while wiring it

**This page had an inline copy of the sort.** `sortGameTotals` was extracted and tested in #42, and the page never used it — so the null rule (*unmeasured sorts last, never as a low value*) was implemented twice, with only one copy covered by tests.

That's the same duplication shape as the metric definitions and the client-side aggregation, both deleted for the same reason. The page now uses the helper, and the mutation test confirms an inline copy no longer even compiles.

## One detail worth stating

A missing session length sorts as **unmeasured, not zero**. It arrives from a *second* request, so it's briefly `undefined` for every row — sorting that as 0 would reshuffle the whole table as the second response lands.

| Mutation | Result |
|---|---|
| Treat a missing length as 0 | fails |
| Replace the shared sort with an inline copy | 4 type errors |

324 tests · types clean · build green.
