### PR TITLE
feat(reports): find a specific player by username

### DIFF
--- a/app/reports/players/page.tsx
+++ b/app/reports/players/page.tsx
@@ -40,10 +40,14 @@ export default function PlayersReportPage() {
   const [draftSearch, setDraftSearch] = useState(search);
   useEffect(() => setDraftSearch(search), [search]);
   useEffect(() => {
-    if (draftSearch === search) {
+    // Compare what will actually be committed. Comparing the raw draft meant
+    // typing a trailing space scheduled an update to a value already held —
+    // a wasted state change and a pointless replaceState.
+    const next = draftSearch.trim();
+    if (next === search) {
       return;
     }
-    const timer = setTimeout(() => update({ search: draftSearch.trim() }), 300);
+    const timer = setTimeout(() => update({ search: next }), 300);
     return () => clearTimeout(timer);
   }, [draftSearch, search, update]);
   const setRange = (next: RangeState) => update({ range: next });

--- a/app/reports/players/page.tsx
+++ b/app/reports/players/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import type { RangeState } from '@/lib/report-range';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { GameBadge } from '@/components/reports/GameBadge';
 import { ExportButton } from '@/components/reports/ExportButton';
 import { RangePicker } from '@/components/reports/RangePicker';
@@ -18,6 +18,7 @@ import { useAuth } from '@/lib/auth';
 import { rangeToParams } from '@/lib/report-range';
 import { ReportsAPI } from '@/lib/reports-api';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Input } from '@/components/ui/input';
 
 export default function PlayersReportPage() {
   const { isAuthenticated, user } = useAuth();
@@ -32,7 +33,19 @@ export default function PlayersReportPage() {
     metric: 'games_started',
     limit: 25,
   });
-  const { range, includeBots, game, limit } = filters;
+  const { range, includeBots, game, limit, search } = filters;
+  // Local copy so typing stays responsive; the committed value is what the
+  // request keys on. Without the split, every keystroke would refetch — and
+  // useReport keys on params by value, so it genuinely would fire each time.
+  const [draftSearch, setDraftSearch] = useState(search);
+  useEffect(() => setDraftSearch(search), [search]);
+  useEffect(() => {
+    if (draftSearch === search) {
+      return;
+    }
+    const timer = setTimeout(() => update({ search: draftSearch.trim() }), 300);
+    return () => clearTimeout(timer);
+  }, [draftSearch, search, update]);
   const setRange = (next: RangeState) => update({ range: next });
   const setIncludeBots = (next: boolean) => update({ includeBots: next });
   const setGame = (next: string | null) => update({ game: next });
@@ -41,8 +54,14 @@ export default function PlayersReportPage() {
   const [sortBy, setSortBy] = useState<'played' | 'finished'>('played');
 
   const params = useMemo(
-    () => ({ ...rangeToParams(range), include_bots: includeBots, limit, ...(game ? { game_type: game } : {}) }),
-    [range, includeBots, game, limit],
+    () => ({
+      ...rangeToParams(range),
+      include_bots: includeBots,
+      limit,
+      ...(game ? { game_type: game } : {}),
+      ...(search ? { search } : {}),
+    }),
+    [range, includeBots, game, limit, search],
   );
 
   const { meta } = useGameMeta(enabled);
@@ -69,6 +88,20 @@ export default function PlayersReportPage() {
       />
 
       <div className="flex flex-wrap items-center gap-2">
+        <label htmlFor="player-search" className="text-sm text-gray-600 dark:text-gray-300">Find</label>
+        <Input
+          id="player-search"
+          value={draftSearch}
+          onChange={event => setDraftSearch(event.target.value)}
+          placeholder="Username"
+          className="h-8 w-48"
+        />
+        {search && (
+          <Button size="sm" variant="ghost" onClick={() => setDraftSearch('')}>
+            Clear
+          </Button>
+        )}
+
         <label htmlFor="row-limit" className="text-sm text-gray-600 dark:text-gray-300">Show</label>
         {/* A dropdown, not three buttons. Row count is a single choice from a
             closed set, which is what a select is for — and three more filled/
@@ -181,7 +214,9 @@ export default function PlayersReportPage() {
                   </table>
                   {data.players.length === 0 && (
                     <p className="py-6 text-center text-sm text-gray-500 dark:text-gray-400">
-                      Nobody played in this window.
+                      {search
+                      ? `No player matching "${search}" played in this window.`
+                      : 'Nobody played in this window.'}
                     </p>
                   )}
                 </CardContent>

--- a/hooks/use-report-filters.ts
+++ b/hooks/use-report-filters.ts
@@ -24,6 +24,8 @@ export type ReportFilters = {
   metric: MetricKey;
   /** Rows on the leaderboard views. Bounded by the API's own cap. */
   limit: number;
+  /** Username fragment on the players view. Empty means no filter, not "match nothing". */
+  search: string;
 };
 
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
@@ -52,6 +54,10 @@ function parse(search: string, fallback: ReportFilters): ReportFilters {
   // Out-of-range or non-numeric limits fall back to the default rather than
   // being passed on: the API rejects them with a 400, and a shared link with a
   // typo should degrade to the default view rather than to an error panel.
+  // Trimmed here as well as server-side: "  " in a shared link would otherwise
+  // put the box in a filtered-looking state while matching everyone.
+  const searchTerm = (params.get('search') ?? '').trim();
+
   const rawLimit = Number(params.get('limit'));
   const limit = Number.isInteger(rawLimit) && rawLimit >= 1 && rawLimit <= MAX_LIMIT
     ? rawLimit
@@ -63,6 +69,7 @@ function parse(search: string, fallback: ReportFilters): ReportFilters {
     game: params.get('game') || null,
     metric: (params.get('metric') as MetricKey) || fallback.metric,
     limit,
+    search: searchTerm,
   };
 }
 
@@ -90,6 +97,10 @@ function serialise(filters: ReportFilters, defaults: ReportFilters): string {
   if (filters.limit !== defaults.limit) {
     params.set('limit', String(filters.limit));
   }
+  // In the URL so "find this player" is a link someone can be sent.
+  if (filters.search) {
+    params.set('search', filters.search);
+  }
   const query = params.toString();
   return query ? `?${query}` : '';
 }
@@ -98,9 +109,9 @@ export function useReportFilters(
   // `limit` is optional: only the leaderboard views paginate, and requiring it
   // on the other seven pages would put a number in front of readers that means
   // nothing there.
-  suppliedDefaults: Omit<ReportFilters, 'limit'> & { limit?: number },
+  suppliedDefaults: Omit<ReportFilters, 'limit' | 'search'> & { limit?: number; search?: string },
 ) {
-  const defaults: ReportFilters = { limit: DEFAULT_LIMIT, ...suppliedDefaults };
+  const defaults: ReportFilters = { limit: DEFAULT_LIMIT, search: '', ...suppliedDefaults };
   const [filters, setFilters] = useState<ReportFilters>(defaults);
   const [hydrated, setHydrated] = useState(false);
 

--- a/lib/__tests__/report-filters.test.ts
+++ b/lib/__tests__/report-filters.test.ts
@@ -10,9 +10,20 @@ const defaults = {
   game: null,
   metric: 'games_started' as const,
   limit: 25,
+  search: '',
 };
 
 describe('report filter URL state', () => {
+  it('carries a player search, and treats blank as no filter', () => {
+    // In the URL so "find this player" is a link that can be sent. Trimmed,
+    // because "  " in a shared link would show a filtered-looking box while
+    // matching everyone.
+    expect(__test.serialise({ ...defaults, search: 'kalin' }, defaults)).toBe('?search=kalin');
+    expect(__test.serialise({ ...defaults, search: '' }, defaults)).toBe('');
+    expect(__test.parse('?search=kalin', defaults).search).toBe('kalin');
+    expect(__test.parse('?search=%20%20', defaults).search).toBe('');
+  });
+
   it('carries a chosen row limit, and drops it when it is the default', () => {
     expect(__test.serialise({ ...defaults, limit: 100 }, defaults)).toBe('?limit=100');
     expect(__test.serialise({ ...defaults, limit: 25 }, defaults)).toBe('');

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -132,6 +132,8 @@ export type TopPlayer = {
 
 export type TopPlayersResponse = {
   limit: number;
+  /** Echoed so an empty list reads as "no matches" rather than "no data". */
+  search: string | null;
   players: TopPlayer[];
 } & ResolvedRange;
 
@@ -153,6 +155,8 @@ export type ReportParams = {
   min_change_pct?: number;
   /** Bucket size for the activity series. Rejected server-side if unknown. */
   granularity?: Granularity;
+  /** Username fragment, case-insensitive. Narrows who is counted, not who survives. */
+  search?: string;
 };
 
 /**


### PR DESCRIPTION
Backlog **B7**, frontend half. Consumes the search parameter from [App#1457](https://github.com/FootballExtraTime/App/pull/1457).

The list ranks the busiest N, so a quiet player was unreachable without knowing their user id and typing the URL. The box narrows **who is counted**, not who survives, so a match outside the top N still appears.

## Three details

**Debounced, with a draft/committed split.** `useReport` keys on params *by value*, so without the split every keystroke would be a request.

**The search rides in the URL**, so "find this player" is a link you can send — and it's trimmed on the way in, because `"  "` in a shared link would show a filtered-looking box while matching everyone.

**The empty state names the search.** "Nobody played in this window" would be false — someone played, just nobody matching.

| Mutation | Result |
|---|---|
| Treat a blank search as a filter | fails |
| Drop the search from the URL | fails |

325 tests · types clean · build green.

---

First PR under the new rule — holding this for your Copilot review before merging.
