### PR TITLE
Show the daily pulse's comparison basis

### DIFF
--- a/components/reports/PulseTiles.tsx
+++ b/components/reports/PulseTiles.tsx
@@ -59,16 +59,11 @@ function Delta({ metric }: { metric: PulseMetric }) {
   );
 }
 
-/** "today to 14:00" reads better than a share, and says what was compared. */
-function elapsedLabel(share: number): string {
-  if (share >= 0.999) {
-    return 'the whole day';
-  }
-  return `${Math.round(share * 100)}% of a typical day`;
-}
-
 export function PulseTiles({ pulse }: { pulse: Pulse }) {
+  // Below 1 the day is still running, so today is only part of a day and every
+  // comparison on this panel is a partial one.
   const partial = pulse.elapsed_share < 0.999;
+  const sharePct = Math.round(pulse.elapsed_share * 100);
 
   return (
     <div className="space-y-2">
@@ -91,9 +86,9 @@ export function PulseTiles({ pulse }: { pulse: Pulse }) {
           survive. */}
       {partial && (
         <p className="text-xs text-gray-500 dark:text-gray-400">
-          {`Today so far, against the same ${elapsedLabel(pulse.elapsed_share)} — `}
+          {`Today so far, against the same ${sharePct}% of a typical day — `}
           {`by this point a typical ${pulse.weekday} has seen `}
-          {`${Math.round(pulse.elapsed_share * 100)}% of its play, so the comparison is like for like.`}
+          {`${sharePct}% of its play, so the comparison is like for like.`}
         </p>
       )}
 
@@ -113,7 +108,10 @@ export function PulseTiles({ pulse }: { pulse: Pulse }) {
                   {' · '}
                   {metric.baseline_same_weekday === null
                     ? `no typical ${pulse.weekday} to compare with yet`
-                    : `typical ${pulse.weekday} by now: ${metric.baseline_same_weekday.toLocaleString()}`}
+                    // "by now" only while the day is running. Once it is over
+                    // the baseline IS the whole weekday, and saying "by now"
+                    // would keep implying a partial comparison that has ended.
+                    : `typical ${pulse.weekday}${partial ? ' by now' : ''}: ${metric.baseline_same_weekday.toLocaleString()}`}
                 </p>
                 {/* On a part-day, the whole-day figure answers a different
                     question — what today is heading for, not how it compares. */}

--- a/components/reports/PulseTiles.tsx
+++ b/components/reports/PulseTiles.tsx
@@ -59,7 +59,17 @@ function Delta({ metric }: { metric: PulseMetric }) {
   );
 }
 
+/** "today to 14:00" reads better than a share, and says what was compared. */
+function elapsedLabel(share: number): string {
+  if (share >= 0.999) {
+    return 'the whole day';
+  }
+  return `${Math.round(share * 100)}% of a typical day`;
+}
+
 export function PulseTiles({ pulse }: { pulse: Pulse }) {
+  const partial = pulse.elapsed_share < 0.999;
+
   return (
     <div className="space-y-2">
       {!pulse.baseline_covered && (
@@ -75,6 +85,18 @@ export function PulseTiles({ pulse }: { pulse: Pulse }) {
           Run the reporting backfill to fill them.
         </p>
       )}
+      {/* The basis, stated. The comparison used to weigh today-so-far against
+          four COMPLETE weekdays, so every metric read as down all morning — and
+          nothing on screen said what it was comparing, which is what let that
+          survive. */}
+      {partial && (
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          {`Today so far, against the same ${elapsedLabel(pulse.elapsed_share)} — `}
+          {`by this point a typical ${pulse.weekday} has seen `}
+          {`${Math.round(pulse.elapsed_share * 100)}% of its play, so the comparison is like for like.`}
+        </p>
+      )}
+
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
         {TILES.map(({ key, label, hint }) => {
           const metric = pulse.metrics[key];
@@ -91,8 +113,15 @@ export function PulseTiles({ pulse }: { pulse: Pulse }) {
                   {' · '}
                   {metric.baseline_same_weekday === null
                     ? `no typical ${pulse.weekday} to compare with yet`
-                    : `typical ${pulse.weekday}: ${metric.baseline_same_weekday.toLocaleString()}`}
+                    : `typical ${pulse.weekday} by now: ${metric.baseline_same_weekday.toLocaleString()}`}
                 </p>
+                {/* On a part-day, the whole-day figure answers a different
+                    question — what today is heading for, not how it compares. */}
+                {partial && metric.baseline_full_day !== null && (
+                  <p className="text-xs text-gray-400 dark:text-gray-500">
+                    {`Full ${pulse.weekday}: ${metric.baseline_full_day.toLocaleString()}`}
+                  </p>
+                )}
               </CardContent>
             </Card>
           );

--- a/components/reports/__tests__/PulseTiles.test.tsx
+++ b/components/reports/__tests__/PulseTiles.test.tsx
@@ -49,7 +49,18 @@ describe('pulseTiles', () => {
     // "On track for X" is not the same question as "normal so far".
     render(<PulseTiles pulse={pulse(0.5) as never} />);
 
-    expect(screen.getByText('Full Thursday: 548.8')).toBeTruthy();
+    // Built with the same formatter the component uses: a literal "548.8"
+    // would assert the runtime's decimal separator, not the behaviour.
+    expect(screen.getByText(`Full Thursday: ${(548.8).toLocaleString()}`)).toBeTruthy();
+  });
+
+  it('drops "by now" from the baseline once the day is complete', () => {
+    // The baseline then IS the whole weekday; "by now" would keep implying a
+    // partial comparison that has already ended.
+    render(<PulseTiles pulse={pulse(1) as never} />);
+
+    expect(screen.queryByText(/by now/)).toBeNull();
+    expect(screen.getAllByText(new RegExp(`typical Thursday: ${(206.1).toLocaleString()}`)).length).toBeGreaterThan(0);
   });
 
   it('drops the basis line once the day is complete', () => {

--- a/components/reports/__tests__/PulseTiles.test.tsx
+++ b/components/reports/__tests__/PulseTiles.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { PulseTiles } from '@/components/reports/PulseTiles';
+
+function metric(today: number, byNow: number | null, fullDay: number | null, delta: number | null) {
+  return {
+    today,
+    yesterday: 0,
+    baseline_same_weekday: byNow,
+    baseline_full_day: fullDay,
+    delta_pct_vs_baseline: delta,
+  };
+}
+
+function pulse(elapsed: number) {
+  return {
+    date: '2026-08-13',
+    weekday: 'Thursday',
+    baseline_weeks: 4,
+    baseline_covered: true,
+    baseline_missing_days: [],
+    elapsed_share: elapsed,
+    metrics: {
+      games_started: metric(275, 274.4, 548.8, 0.2),
+      games_finished: metric(122, 206.1, 412.2, -40.8),
+      distinct_players: metric(27, 24.6, 49.2, 9.8),
+      mp_player_sessions: metric(0, 18.2, 36.5, -100),
+    },
+  };
+}
+
+describe('pulseTiles', () => {
+  it('states what it compared, mid-day', () => {
+    // The comparison used to weigh today-so-far against four COMPLETE weekdays,
+    // so every metric read as down all morning — and nothing on screen said what
+    // was being compared, which is what let that survive unnoticed.
+    render(<PulseTiles pulse={pulse(0.5) as never} />);
+
+    expect(screen.getByText(/Today so far, against the same 50% of a typical day/)).toBeTruthy();
+  });
+
+  it('says "by now" on the baseline, not just "typical Thursday"', () => {
+    render(<PulseTiles pulse={pulse(0.5) as never} />);
+
+    expect(screen.getAllByText(/typical Thursday by now/).length).toBeGreaterThan(0);
+  });
+
+  it('shows the whole-day figure too, which answers a different question', () => {
+    // "On track for X" is not the same question as "normal so far".
+    render(<PulseTiles pulse={pulse(0.5) as never} />);
+
+    expect(screen.getByText('Full Thursday: 548.8')).toBeTruthy();
+  });
+
+  it('drops the basis line once the day is complete', () => {
+    // At the end of the day the comparison is whole against whole, so the
+    // explanation would be noise.
+    render(<PulseTiles pulse={pulse(1) as never} />);
+
+    expect(screen.queryByText(/Today so far, against/)).toBeNull();
+    expect(screen.queryByText(/Full Thursday:/)).toBeNull();
+  });
+});

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -33,6 +33,8 @@ export type ActivityResponse = {
 
 /** One headline metric: today, against the same-weekday baseline. */
 export type PulseMetric = {
+  /** The whole-day figure — "on track for X", as opposed to "normal so far". */
+  baseline_full_day: number | null;
   today: number;
   yesterday: number;
   /** Mean of the previous N same weekdays. */
@@ -49,6 +51,12 @@ export type Pulse = {
   /** False when a baseline day was never rolled up — show "no baseline", not 0. */
   baseline_covered: boolean;
   baseline_missing_days: string[];
+  /**
+   * How much of a typical day has happened, 0..1 — from the observed hour
+   * distribution, not the clock. The baseline is scaled by it so today-so-far
+   * is compared with the same share of a typical day rather than four whole ones.
+   */
+  elapsed_share: number;
   metrics: Record<keyof ActivityMetrics, PulseMetric>;
 };
 


### PR DESCRIPTION
The UI half of the daily-pulse fix. Backend: FootballExtraTime/App#1458.

## The problem

The daily pulse compared today-so-far against the last four same-weekdays — but against those days **complete**. At noon on a normal Monday the tiles read −49.9%, −70.4%, −45.2%, −100%: a healthy morning rendered as a collapse, every single day, because half a day was being weighed against four whole ones.

App#1458 fixed the arithmetic — the baseline is now scaled by `elapsed_share`, the share of a typical day that has happened by this hour, taken from the observed hour distribution rather than the clock.

This PR does the other half: **the panel now says what it compared.**

That isn't cosmetic. A comparison whose basis is invisible is precisely what let the original error pass as a real decline for weeks. Nobody could see it was wrong because nothing on screen said what "typical Thursday" meant.

## What changed

- A basis line above the tiles: *"Today so far, against the same 55% of a typical day — by this point a typical Thursday has seen 55% of its play, so the comparison is like for like."*
- Each tile's baseline now reads **"typical Thursday by now"** rather than "typical Thursday". The number moves through the day; the label should admit that.
- The whole-day figure sits beside it — *"Full Thursday: 548.8"*. "On track for X" is a different question from "normal so far", and both are worth answering.
- All three disappear once the day is complete. Whole against whole needs no explanation, and a caption that never goes away stops being read.

## Types

`Pulse.elapsed_share` and `PulseMetric.baseline_full_day` from App#1458.

## Tests

4 new tests in `components/reports/__tests__/PulseTiles.test.tsx`, mutation-tested:

| Mutation | Result |
|---|---|
| `partial = false` (never show the basis) | 2 tests fail |
| `partial = true` (show it on a complete day) | 1 test fails |

Full suite: 329 passed.