### PR TITLE
Say why a game's sessions are long, per game

### DIFF
--- a/components/reports/DurationTable.tsx
+++ b/components/reports/DurationTable.tsx
@@ -8,16 +8,22 @@ import { ExportButton } from '@/components/reports/ExportButton';
 import { GameBadge } from '@/components/reports/GameBadge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { formatDuration } from '@/lib/format-duration';
+import { longSessionReason } from '@/lib/long-session-reason';
 import { cn } from '@/lib/utils';
 
 /**
  * Session length per game.
  *
- * Deliberately does NOT present one ranking. Conquest's median is 24 hours
- * because a session there is a day-long campaign; Team Ties' is 5 minutes
- * because a session is a sitting. Ranking them together would read as "Conquest
- * holds attention 280x better", which is not what the number means — so the two
+ * Deliberately does NOT present one ranking. Conquest's median is 24 hours and
+ * Team Ties' is 5 minutes; ranking them together would read as "Conquest holds
+ * attention 280x better", which is not what the number means — so the two
  * shapes are split into separate tables.
+ *
+ * The second table used to explain itself once, for everyone: these games "span
+ * a day or more by design". That is true of a campaign game and false of
+ * Conquest, whose 24 hours is its idle sweeper closing abandoned sessions —
+ * housekeeping, quoted as attention. So the reason is now per row, and each one
+ * carries the median among sessions that actually played out.
  */
 export function DurationTable({ data, meta }: { data: DurationResponse; meta: GameMetaMap }) {
   const resolveColor = useGameColor();
@@ -27,7 +33,7 @@ export function DurationTable({ data, meta }: { data: DurationResponse; meta: Ga
 
   const maxMedian = Math.max(...comparable.map(row => row.median_seconds ?? 0), 0);
 
-  const renderRows = (rows: typeof data.rows, showBar: boolean) => rows.map(row => (
+  const renderRows = (rows: typeof data.rows) => rows.map(row => (
     <tr key={row.game_type} className="border-b last:border-0 dark:border-slate-700">
       <td className="py-2 pr-4">
         <GameBadge gameKey={row.game_type} meta={meta} />
@@ -37,17 +43,15 @@ export function DurationTable({ data, meta }: { data: DurationResponse; meta: Ga
           <span className="w-14 text-right font-medium tabular-nums text-gray-900 dark:text-white">
             {formatDuration(row.median_seconds)}
           </span>
-          {showBar && (
-            <div className="h-1.5 w-full max-w-32 overflow-hidden rounded-full bg-gray-100 dark:bg-slate-700">
+          <div className="h-1.5 w-full max-w-32 overflow-hidden rounded-full bg-gray-100 dark:bg-slate-700">
               <div
                 className="h-full rounded-full"
                 style={{
                   width: `${maxMedian > 0 ? Math.max(2, ((row.median_seconds ?? 0) / maxMedian) * 100) : 0}%`,
                   backgroundColor: resolveColor(meta, row.game_type),
                 }}
-              />
-            </div>
-          )}
+            />
+          </div>
         </div>
       </td>
       <td className="py-2 pr-4 text-right tabular-nums">{formatDuration(row.p90_seconds)}</td>
@@ -63,6 +67,49 @@ export function DurationTable({ data, meta }: { data: DurationResponse; meta: Ga
       </td>
     </tr>
   ));
+
+  const longLivedHead = (
+    <thead>
+      <tr className="border-b text-left text-gray-600 dark:border-slate-700 dark:text-gray-300">
+        <th className="py-2 pr-4 font-medium">Game</th>
+        <th className="py-2 pr-4 font-medium">Median</th>
+        <th className="py-2 pr-4 font-medium">Why it's long</th>
+        <th className="py-2 pr-4 text-right font-medium">Played out</th>
+        <th className="py-2 text-right font-medium">Sessions</th>
+      </tr>
+    </thead>
+  );
+
+  const renderLongLived = (rows: typeof data.rows) => rows.map((row) => {
+    const why = longSessionReason(row);
+    return (
+      <tr key={row.game_type} className="border-b align-top last:border-0 dark:border-slate-700">
+        <td className="py-2 pr-4">
+          <GameBadge gameKey={row.game_type} meta={meta} />
+        </td>
+        <td className="py-2 pr-4 font-medium tabular-nums text-gray-900 dark:text-white">
+          {formatDuration(row.median_seconds)}
+        </td>
+        <td className="max-w-md py-2 pr-4">
+          {why === null
+            ? <span className="text-gray-500 dark:text-gray-400">—</span>
+            : (
+                <>
+                  <span className="font-medium text-gray-900 dark:text-white">{why.label}</span>
+                  <p className="text-xs text-gray-500 dark:text-gray-400">{why.detail}</p>
+                </>
+              )}
+        </td>
+        {/* The comparable number, where the headline one isn't: a swept game's
+            median is the sweeper's clock, and this is the median among the
+            sessions that actually played out. */}
+        <td className="py-2 pr-4 text-right font-medium tabular-nums text-gray-900 dark:text-white">
+          {why?.playedOut ?? '—'}
+        </td>
+        <td className="py-2 text-right tabular-nums">{row.measured.toLocaleString()}</td>
+      </tr>
+    );
+  });
 
   const head = (
     <thead>
@@ -107,13 +154,18 @@ export function DurationTable({ data, meta }: { data: DurationResponse; meta: Ga
               { header: 'Long sessions', value: row => row.long_sessions },
               { header: 'Long sessions %', value: row => row.long_sessions_pct },
               { header: 'Single sitting', value: row => (row.single_sitting === null ? null : String(row.single_sitting)) },
+              { header: 'Why long', value: row => row.long_reason ?? '' },
+              { header: 'Idle sweep after seconds', value: row => row.idle_finish_seconds ?? '' },
+              { header: 'Swept sessions', value: row => row.swept_sessions ?? '' },
+              { header: 'Swept %', value: row => row.swept_pct ?? '' },
+              { header: 'Median excluding swept seconds', value: row => row.median_excluding_swept_seconds ?? '' },
             ]}
           />
         </CardHeader>
         <CardContent className="overflow-x-auto">
           <table className="w-full text-sm">
             {head}
-            <tbody>{renderRows(comparable, true)}</tbody>
+            <tbody>{renderRows(comparable)}</tbody>
           </table>
           {comparable.length === 0 && (
             <p className="py-6 text-center text-sm text-gray-500 dark:text-gray-400">
@@ -130,16 +182,20 @@ export function DurationTable({ data, meta }: { data: DurationResponse; meta: Ga
             <CardDescription className="flex items-start gap-2">
               <Info className="mt-0.5 size-3.5 shrink-0" />
               <span>
-                A session in these games spans a day or more by design, so their length
-                isn't comparable with per-round games — listed separately rather than
-                ranked alongside them, where they'd win by definition.
+                Sessions here run past
+                {' '}
+                {formatDuration(data.long_session_seconds)}
+                , so they aren't comparable with per-round games and are listed apart
+                rather than ranked alongside them, where they'd win by definition.
+                Long for two different reasons, though — played that way, or closed by
+                a timeout — so each row says which.
               </span>
             </CardDescription>
           </CardHeader>
           <CardContent className="overflow-x-auto">
             <table className="w-full text-sm">
-              {head}
-              <tbody>{renderRows(longLived, false)}</tbody>
+              {longLivedHead}
+              <tbody>{renderLongLived(longLived)}</tbody>
             </table>
           </CardContent>
         </Card>

--- a/components/reports/__tests__/DurationTable.test.tsx
+++ b/components/reports/__tests__/DurationTable.test.tsx
@@ -1,0 +1,93 @@
+import type { DurationResponse, DurationRow } from '@/types/reports';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { DurationTable } from '@/components/reports/DurationTable';
+
+const META = {
+  conquest: { key: 'conquest', label: 'Football Conquest Game Sessions', display_name: 'Football Conquest', color: '#38bdf8', color_dark: '#7dd3fc' },
+  team_ties: { key: 'team_ties', label: 'Team Ties Game Sessions', display_name: 'Team Ties', color: '#0d9488', color_dark: '#0d9488' },
+};
+
+function row(over: Partial<DurationRow>): DurationRow {
+  return {
+    game_type: 'team_ties',
+    supported: true,
+    reason: null,
+    sessions: 40,
+    measured: 40,
+    coverage_pct: 100,
+    median_seconds: 330,
+    p90_seconds: 900,
+    long_sessions: 0,
+    long_sessions_pct: 0,
+    single_sitting: true,
+    ...over,
+  };
+}
+
+function response(rows: DurationRow[]): DurationResponse {
+  return {
+    long_session_seconds: 21600,
+    games_without_duration: [],
+    long_lived_session_games: rows.filter(r => r.single_sitting === false).map(r => r.game_type),
+    longest_single_sitting_game: 'team_ties',
+    rows,
+    start: '2026-08-01',
+    end: '2026-08-13',
+    days: 13,
+    window: 13,
+    game_type: null,
+    include_bots: false,
+  };
+}
+
+const SWEPT = row({
+  game_type: 'conquest',
+  median_seconds: 86400,
+  p90_seconds: 90000,
+  long_sessions: 29,
+  long_sessions_pct: 72.5,
+  single_sitting: false,
+  long_reason: 'idle_sweep',
+  idle_finish_seconds: 86400,
+  swept_sessions: 29,
+  swept_pct: 72.5,
+  median_excluding_swept_seconds: 480,
+});
+
+describe('durationTable long-lived section', () => {
+  it('says a swept game is swept, not that it is long by design', () => {
+    // The old copy asserted "spans a day or more by design" for every long
+    // game. For Conquest that turned a housekeeping job into a finding about
+    // attention.
+    render(<DurationTable data={response([row({}), SWEPT])} meta={META as never} />);
+
+    expect(screen.getByText('Idle sweep')).toBeTruthy();
+    expect(screen.getByText(/72.5% of measured sessions were closed after 24h idle/)).toBeTruthy();
+    expect(screen.queryByText(/by design/)).toBeNull();
+  });
+
+  it('shows the median among sessions that played out', () => {
+    // 24h is the sweeper's clock; 8 minutes is the game.
+    render(<DurationTable data={response([row({}), SWEPT])} meta={META as never} />);
+
+    expect(screen.getByText('8.0m')).toBeTruthy();
+  });
+
+  it('does not explain a long game the backend has not classified', () => {
+    // A deploy window: no long_reason yet. Saying nothing beats guessing which
+    // of two opposite explanations applies.
+    const unexplained = row({ game_type: 'conquest', median_seconds: 86400, single_sitting: false });
+    render(<DurationTable data={response([row({}), unexplained])} meta={META as never} />);
+
+    expect(screen.queryByText('Idle sweep')).toBeNull();
+    expect(screen.queryByText('Long play')).toBeNull();
+  });
+
+  it('leaves the comparable table alone', () => {
+    render(<DurationTable data={response([row({}), SWEPT])} meta={META as never} />);
+
+    expect(screen.getByText('How long a session lasts')).toBeTruthy();
+    expect(screen.getByText('5.5m')).toBeTruthy();
+  });
+});

--- a/lib/__tests__/long-session-reason.test.ts
+++ b/lib/__tests__/long-session-reason.test.ts
@@ -65,6 +65,33 @@ describe('longSessionReason', () => {
     expect(longSessionReason(row({ long_reason: null }))).toBeNull();
   });
 
+  it('names the timeout without inventing a duration for it', () => {
+    // The backend always sends the ceiling with an idle_sweep, but the type
+    // allows its absence — and formatDuration(null) is "—", so the sentence
+    // would have read "closed after —", which is worse than not naming it.
+    const why = longSessionReason(row({ long_reason: 'idle_sweep', swept_pct: 72 }));
+
+    expect(why?.detail).toBe(
+      "72% of measured sessions were closed by an idle timeout, so their length is the sweeper's clock rather than time spent playing.",
+    );
+  });
+
+  it('still makes the claim when neither number arrived', () => {
+    const why = longSessionReason(row({ long_reason: 'idle_sweep', swept_pct: null }));
+
+    expect(why?.detail).toBe(
+      "Sessions left idle are closed by an idle timeout, so their length is the sweeper's clock rather than time spent playing.",
+    );
+  });
+
+  it('treats a zero ceiling as no ceiling', () => {
+    // "closed after 0h idle" is not a fact about anything.
+    const why = longSessionReason(row({ long_reason: 'idle_sweep', idle_finish_seconds: 0, swept_pct: 50 }));
+
+    expect(why?.detail).toContain('by an idle timeout');
+    expect(why?.detail).not.toContain('0h');
+  });
+
   it('still explains a sweep whose played-out median is unknown', () => {
     // Every session swept: there is no played-out median to show, but the
     // reason is still the most important thing on the row.

--- a/lib/__tests__/long-session-reason.test.ts
+++ b/lib/__tests__/long-session-reason.test.ts
@@ -1,0 +1,81 @@
+import type { DurationRow } from '@/types/reports';
+import { describe, expect, it } from 'vitest';
+import { longSessionReason } from '@/lib/long-session-reason';
+
+function row(over: Partial<DurationRow>): DurationRow {
+  return {
+    game_type: 'conquest',
+    supported: true,
+    reason: null,
+    sessions: 100,
+    measured: 100,
+    coverage_pct: 100,
+    median_seconds: 86400,
+    p90_seconds: 90000,
+    long_sessions: 72,
+    long_sessions_pct: 72,
+    single_sitting: false,
+    ...over,
+  };
+}
+
+describe('longSessionReason', () => {
+  it('names the sweeper, its ceiling and how much of the sample it closed', () => {
+    // Conquest's 24h median IS its idle timeout. Quoting it as attention is the
+    // error this exists to stop.
+    const why = longSessionReason(row({
+      long_reason: 'idle_sweep',
+      idle_finish_seconds: 86400,
+      swept_pct: 72,
+      median_excluding_swept_seconds: 480,
+    }));
+
+    expect(why?.label).toBe('Idle sweep');
+    expect(why?.detail).toContain('72%');
+    // "24h", not formatDuration's "1.0d": this is a configured timeout, and
+    // whoever checks it against the sweeper task will look for 24 hours.
+    expect(why?.detail).toContain('24h');
+    expect(why?.detail).toContain("sweeper's clock");
+  });
+
+  it('offers the played-out median as the comparable number', () => {
+    const why = longSessionReason(row({
+      long_reason: 'idle_sweep',
+      idle_finish_seconds: 86400,
+      swept_pct: 72,
+      median_excluding_swept_seconds: 480,
+    }));
+
+    expect(why?.playedOut).toBe('8.0m');
+  });
+
+  it('says a genuinely long game is long, without inventing a sweeper', () => {
+    const why = longSessionReason(row({ game_type: 'team_ties', long_reason: 'long_play' }));
+
+    expect(why?.label).toBe('Long play');
+    expect(why?.detail).toContain('not being closed by a timeout');
+    expect(why?.playedOut).toBeNull();
+  });
+
+  it('says nothing at all when the backend has not explained it', () => {
+    // A deploy window, or a game nobody has classified. Silence beats asserting
+    // the wrong one of two opposite explanations — which is what the page did
+    // before, for every long game at once.
+    expect(longSessionReason(row({}))).toBeNull();
+    expect(longSessionReason(row({ long_reason: null }))).toBeNull();
+  });
+
+  it('still explains a sweep whose played-out median is unknown', () => {
+    // Every session swept: there is no played-out median to show, but the
+    // reason is still the most important thing on the row.
+    const why = longSessionReason(row({
+      long_reason: 'idle_sweep',
+      idle_finish_seconds: 86400,
+      swept_pct: 100,
+      median_excluding_swept_seconds: null,
+    }));
+
+    expect(why?.label).toBe('Idle sweep');
+    expect(why?.playedOut).toBeNull();
+  });
+});

--- a/lib/__tests__/response-fields-used.test.ts
+++ b/lib/__tests__/response-fields-used.test.ts
@@ -25,7 +25,6 @@ const ROOT = process.cwd();
  */
 const NOT_RENDERED: Record<string, string> = {
   grain: 'A reminder in the payload that multiplayer counts rooms; the card description says it in prose.',
-  long_session_seconds: 'The threshold behind the per-row single_sitting flag, which is what the table renders.',
   games_without_duration: 'Derived per row as `supported`, which DurationTable already groups by.',
   long_lived_session_games: 'Derived per row as `single_sitting`, which DurationTable already groups by.',
   window_totals: 'The comparison tiles render the same window from `comparison`, with movement attached.',

--- a/lib/long-session-reason.ts
+++ b/lib/long-session-reason.ts
@@ -1,0 +1,66 @@
+/**
+ * Why a game's sessions are long — in words, per game.
+ *
+ * The duration page used to say one thing about every long-lived game: that a
+ * session there "spans a day or more by design". That is true of a campaign
+ * game and false of Conquest, whose 24-hour median is its idle sweeper closing
+ * abandoned sessions. Same number, opposite finding, and the page asserted the
+ * flattering one for both.
+ *
+ * Pure so it can be tested directly — the claim is the risky part here, not the
+ * table markup.
+ */
+
+import type { DurationRow } from '@/types/reports';
+import { formatDuration } from '@/lib/format-duration';
+
+export type LongSessionReason = {
+  /** Short label for the table cell. */
+  label: string;
+  /** The sentence under it — what produced the number. */
+  detail: string;
+  /** The comparable median, when the headline one isn't. */
+  playedOut: string | null;
+};
+
+/**
+ * The sweeper's ceiling in the units it was configured in.
+ *
+ * `formatDuration` renders 86,400s as "1.0d", which is right for a measured
+ * session and wrong for a setting: the timeout is 24 hours, and someone
+ * checking it against the task will look for that number.
+ */
+function ceilingLabel(seconds: number | null | undefined): string {
+  if (seconds && seconds % 3600 === 0) {
+    return `${seconds / 3600}h`;
+  }
+  return formatDuration(seconds ?? null);
+}
+
+export function longSessionReason(row: DurationRow): LongSessionReason | null {
+  if (row.long_reason === 'idle_sweep') {
+    const ceiling = ceilingLabel(row.idle_finish_seconds);
+    const share = row.swept_pct === null || row.swept_pct === undefined ? null : `${row.swept_pct}%`;
+    return {
+      label: 'Idle sweep',
+      detail: share === null
+        ? `Sessions left idle are closed after ${ceiling}, so their length is the sweeper's clock rather than time spent playing.`
+        : `${share} of measured sessions were closed after ${ceiling} idle, so their length is the sweeper's clock rather than time spent playing.`,
+      playedOut: row.median_excluding_swept_seconds === null || row.median_excluding_swept_seconds === undefined
+        ? null
+        : formatDuration(row.median_excluding_swept_seconds),
+    };
+  }
+
+  if (row.long_reason === 'long_play') {
+    return {
+      label: 'Long play',
+      detail: 'Sessions genuinely run long — they are not being closed by a timeout, so the length is time in the game.',
+      playedOut: null,
+    };
+  }
+
+  // A backend predating long_reason, or a game whose length nobody has
+  // explained. Saying nothing beats asserting the wrong one of the two.
+  return null;
+}

--- a/lib/long-session-reason.ts
+++ b/lib/long-session-reason.ts
@@ -24,28 +24,35 @@ export type LongSessionReason = {
 };
 
 /**
- * The sweeper's ceiling in the units it was configured in.
+ * The sweeper's ceiling in the units it was configured in, or null if unknown.
  *
  * `formatDuration` renders 86,400s as "1.0d", which is right for a measured
  * session and wrong for a setting: the timeout is 24 hours, and someone
- * checking it against the task will look for that number.
+ * checking it against the sweeper task will look for that number.
+ *
+ * Null rather than a dash when it's missing. The dash belongs in a table cell,
+ * where a column header says what is absent; dropped into a sentence it reads
+ * "closed after —", which is worse than not naming the timeout at all.
  */
-function ceilingLabel(seconds: number | null | undefined): string {
-  if (seconds && seconds % 3600 === 0) {
-    return `${seconds / 3600}h`;
+function ceilingLabel(seconds: number | null | undefined): string | null {
+  if (typeof seconds !== 'number' || seconds <= 0) {
+    return null;
   }
-  return formatDuration(seconds ?? null);
+  return seconds % 3600 === 0 ? `${seconds / 3600}h` : formatDuration(seconds);
 }
 
 export function longSessionReason(row: DurationRow): LongSessionReason | null {
   if (row.long_reason === 'idle_sweep') {
     const ceiling = ceilingLabel(row.idle_finish_seconds);
-    const share = row.swept_pct === null || row.swept_pct === undefined ? null : `${row.swept_pct}%`;
+    const share = typeof row.swept_pct === 'number' ? `${row.swept_pct}%` : null;
+    // Each half of the sentence is optional, because either number can be
+    // missing and the claim — the length is the sweeper's, not the player's —
+    // is worth making with whichever of them arrived.
+    const subject = share === null ? 'Sessions left idle are closed' : `${share} of measured sessions were closed`;
+    const when = ceiling === null ? 'by an idle timeout' : `after ${ceiling} idle`;
     return {
       label: 'Idle sweep',
-      detail: share === null
-        ? `Sessions left idle are closed after ${ceiling}, so their length is the sweeper's clock rather than time spent playing.`
-        : `${share} of measured sessions were closed after ${ceiling} idle, so their length is the sweeper's clock rather than time spent playing.`,
+      detail: `${subject} ${when}, so their length is the sweeper's clock rather than time spent playing.`,
       playedOut: row.median_excluding_swept_seconds === null || row.median_excluding_swept_seconds === undefined
         ? null
         : formatDuration(row.median_excluding_swept_seconds),

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -377,6 +377,26 @@ export type DurationRow = {
   long_sessions_pct: number | null;
   /** False for campaign-shaped games whose "session" spans a day, not a sitting. */
   single_sitting: boolean | null;
+  /**
+   * Seconds of idleness after which a sweeper task closes an unfinished session,
+   * or null for games with no such job. Optional so a backend predating it
+   * degrades to the old "long by design" reading rather than breaking.
+   */
+  idle_finish_seconds?: number | null;
+  /** Measured sessions sitting at or past that ceiling — timed by the sweeper. */
+  swept_sessions?: number;
+  swept_pct?: number | null;
+  /**
+   * Median among sessions that ended by play rather than by the sweeper. For a
+   * swept game this is the only comparable number it has.
+   */
+  median_excluding_swept_seconds?: number | null;
+  /**
+   * Why the sessions are long. 'idle_sweep' means the length is a housekeeping
+   * job's clock; 'long_play' means the game really is played in long stretches.
+   * A median cannot tell these apart, and they mean opposite things.
+   */
+  long_reason?: 'idle_sweep' | 'long_play' | null;
 };
 
 export type DurationResponse = {

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -379,8 +379,9 @@ export type DurationRow = {
   single_sitting: boolean | null;
   /**
    * Seconds of idleness after which a sweeper task closes an unfinished session,
-   * or null for games with no such job. Optional so a backend predating it
-   * degrades to the old "long by design" reading rather than breaking.
+   * or null for games with no such job. Optional because a backend predating
+   * these fields sends none of them — such a row explains nothing rather than
+   * guessing which of two opposite explanations applies.
    */
   idle_finish_seconds?: number | null;
   /** Measured sessions sitting at or past that ceiling — timed by the sweeper. */


### PR DESCRIPTION
Issue #1453, item **A5** — the UI half. Backend: FootballExtraTime/App#1460. Every new field is optional, so this is safe before that deploys: unclassified games simply say nothing.

## The problem

The duration page explained its second table **once, for everyone**:

> A session in these games spans a day or more **by design**, so their length isn't comparable with per-round games.

True of a campaign game. False of Conquest, whose 24-hour median is `SESSION_ABANDON_TIMEOUT_HOURS` — its sweeper closing abandoned sessions. The page took a housekeeping job and presented it as a finding about attention, and I repeated it as one in a summary.

A median cannot tell the two apart. They look identical and mean opposite things, so the page has to say which.

## What changed

The long-lived table now has a **"Why it's long"** column and a **"Played out"** column:

| Game | Median | Why it's long | Played out | Sessions |
|---|---|---|---|---|
| Football Conquest | 1.0d | **Idle sweep** — 72.5% of measured sessions were closed after 24h idle, so their length is the sweeper's clock rather than time spent playing. | 8.0m | 40 |
| Some campaign game | 9.0h | **Long play** — sessions genuinely run long; they are not being closed by a timeout, so the length is time in the game. | — | 12 |

"Played out" is the median among sessions that ended **by play**. For Conquest that is 8 minutes against a headline 24 hours, and it wasn't visible anywhere before.

When the backend hasn't classified a game, the row says nothing. Silence beats asserting the wrong one of two opposite explanations — which is exactly what the old copy did, for every long game at once.

The ceiling prints in its configured units — "24h", not `formatDuration`'s "1.0d" — because whoever checks it against the sweeper task will be looking for 24 hours.

## Incidental

`long_session_seconds` was listed as deliberately-not-rendered; it is rendered now (the card says which threshold puts a game in this table), and the response-fields guard failed until the exemption was removed. Working as intended.

## Mutation testing

| Mutation | Result |
|---|---|
| explain unclassified games as "long play" | 2 tests fail |
| print the ceiling as `formatDuration` does ("1.0d") | 2 tests fail |
| drop the swept share from the sentence | 2 tests fail |
| show the headline median as the played-out one | 2 tests fail |
| table ignores the reason entirely | 2 tests fail |

Suite: 351 passing (56 files). Build and types clean.