### PR TITLE
Add a reach-vs-depth view to the Games report

### DIFF
--- a/app/reports/games/page.tsx
+++ b/app/reports/games/page.tsx
@@ -10,6 +10,7 @@ import { GameBadge } from '@/components/reports/GameBadge';
 import { MetricInfo } from '@/components/reports/MetricInfo';
 import { ExportButton } from '@/components/reports/ExportButton';
 import { RangePicker } from '@/components/reports/RangePicker';
+import { ReachDepthChart } from '@/components/reports/ReachDepthChart';
 import { ReportError } from '@/components/reports/ReportError';
 import { ReportsShell } from '@/components/reports/ReportsShell';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -125,6 +126,12 @@ export default function GamesIndexPage() {
         : isLoading || !data
           ? <Skeleton className="h-96 w-full" />
           : (
+            <>
+              {/* Before the table, because it answers a question the table
+                  can't: a ranking by volume puts a game with a wide shallow
+                  audience next to one with a small devoted one and says
+                  nothing about the difference. */}
+              <ReachDepthChart rows={data.by_game} meta={meta} />
               <Card>
                 <CardHeader>
                   <CardTitle>Comparison</CardTitle>
@@ -212,6 +219,7 @@ export default function GamesIndexPage() {
                   )}
                 </CardContent>
               </Card>
+            </>
             )}
     </ReportsShell>
   );

--- a/components/reports/ChartTooltip.tsx
+++ b/components/reports/ChartTooltip.tsx
@@ -63,12 +63,18 @@ export function ChartTooltip({
 
   const row = payload[0]?.payload;
   const footerText = footer && row ? footer(row) : null;
+  // A scatter has no meaningful shared label — its identity is the point, not
+  // an x-value — so a formatter may return nothing. Rendering the heading
+  // anyway leaves an empty line with its own margin above the series. Checked
+  // against '' rather than falsiness: hour 0 is a real label.
+  const labelText = label === undefined ? undefined : labelFormatter ? labelFormatter(label) : label;
+  const hasLabel = labelText !== undefined && labelText !== null && labelText !== '';
 
   return (
     <div className="rounded-md border bg-popover px-3 py-2 text-sm shadow-md">
-      {label !== undefined && (
+      {hasLabel && (
         <p className="mb-1 font-medium text-popover-foreground">
-          {labelFormatter ? labelFormatter(label) : label}
+          {labelText}
         </p>
       )}
       {payload.map((entry, index) => (

--- a/components/reports/ReachDepthChart.tsx
+++ b/components/reports/ReachDepthChart.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import type { GameMetaMap } from '@/hooks/use-game-meta';
+import type { GameTotals } from '@/types/reports';
+import { useMemo } from 'react';
+import { useTheme } from 'next-themes';
+import {
+  CartesianGrid,
+  Cell,
+  ReferenceLine,
+  ResponsiveContainer,
+  Scatter,
+  ScatterChart,
+  Tooltip,
+  XAxis,
+  YAxis,
+  ZAxis,
+} from 'recharts';
+import { ChartTooltip } from '@/components/reports/ChartTooltip';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { gameColor, gameName } from '@/hooks/use-game-meta';
+import { chartTheme } from '@/lib/chart-theme';
+import { QUADRANT_LABELS, reachDepth, reachDepthContrast } from '@/lib/reach-depth';
+
+/**
+ * Reach against depth — how many people played a game, against how much each of
+ * them played it.
+ *
+ * The games table ranks by volume, and volume hides this: two games with the
+ * same session count can have opposite problems. A game reaching 227 players
+ * who play it 7 times each has an audience it isn't holding; one reaching 77
+ * who play it 39 times each has devotion it isn't spreading. Ranked by
+ * sessions, both read as mid-table and neither problem is visible.
+ *
+ * A scatter is the honest form here: two measures per game, no ordering
+ * implied. The crosshairs are medians rather than means, because one runaway
+ * game would drag a mean and re-label everything around it.
+ *
+ * Four of the eleven registry colours sit below 3:1 against the card, which is
+ * legal only with relief — so every point is named in the quadrant list below
+ * the plot and in its tooltip. Colour here confirms identity; it never carries
+ * it alone.
+ */
+export function ReachDepthChart({ rows, meta }: { rows: GameTotals[]; meta: GameMetaMap }) {
+  const { resolvedTheme } = useTheme();
+  const isDark = resolvedTheme === 'dark';
+  const theme = chartTheme(isDark);
+
+  const { points, medianReach, medianDepth } = useMemo(() => reachDepth(rows), [rows]);
+  const contrast = useMemo(() => reachDepthContrast(points), [points]);
+
+  const data = useMemo(
+    () => points.map(point => ({
+      ...point,
+      name: gameName(meta[point.game_type], point.game_type),
+      fill: gameColor(meta[point.game_type], isDark),
+      quadrantLabel: QUADRANT_LABELS[point.quadrant],
+    })),
+    [points, meta, isDark],
+  );
+
+  if (points.length === 0) {
+    return null;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Reach vs depth</CardTitle>
+        <CardDescription>
+          How many people played each game, against how often each of them played it.
+          {contrast && (
+            <>
+              {' '}
+              {gameName(meta[contrast.broadest.game_type], contrast.broadest.game_type)}
+              {' reached the most players ('}
+              {contrast.broadest.reach.toLocaleString()}
+              {', '}
+              {contrast.broadest.depth.toFixed(1)}
+              {' sessions each); '}
+              {gameName(meta[contrast.deepest.game_type], contrast.deepest.game_type)}
+              {' is played most per person ('}
+              {contrast.deepest.reach.toLocaleString()}
+              {' players, '}
+              {contrast.deepest.depth.toFixed(1)}
+              {' each). Opposite problems, and a volume ranking shows neither.'}
+            </>
+          )}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="h-80 w-full">
+          <ResponsiveContainer width="100%" height="100%">
+            <ScatterChart margin={{ top: 8, right: 24, bottom: 24, left: 8 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke={theme.grid.stroke} />
+              <XAxis
+                type="number"
+                dataKey="reach"
+                name="Players"
+                tick={theme.tick}
+                label={{ value: 'Players reached', position: 'insideBottom', offset: -12, fill: theme.tick.fill, fontSize: 11 }}
+              />
+              <YAxis
+                type="number"
+                dataKey="depth"
+                name="Sessions per player"
+                tick={theme.tick}
+                width={44}
+                label={{ value: 'Sessions each', angle: -90, position: 'insideLeft', fill: theme.tick.fill, fontSize: 11 }}
+              />
+              {/* Bubble size carries total sessions — the thing a volume ranking
+                  would have shown, kept as a third dimension so this chart
+                  replaces nothing. */}
+              <ZAxis type="number" dataKey="sessions" range={[60, 400]} name="Sessions" />
+              <ReferenceLine
+                x={medianReach}
+                stroke={theme.grid.stroke}
+                strokeDasharray="4 4"
+                label={{ value: 'median reach', position: 'top', fill: theme.tick.fill, fontSize: 10 }}
+              />
+              <ReferenceLine
+                y={medianDepth}
+                stroke={theme.grid.stroke}
+                strokeDasharray="4 4"
+                label={{ value: 'median depth', position: 'right', fill: theme.tick.fill, fontSize: 10 }}
+              />
+              <Tooltip
+                cursor={{ strokeDasharray: '3 3' }}
+                content={(
+                  <ChartTooltip
+                    labelFormatter={() => ''}
+                    footer={row => (typeof row.quadrantLabel === 'string' && typeof row.name === 'string'
+                      ? `${row.name} — ${row.quadrantLabel}`
+                      : null)}
+                  />
+                )}
+              />
+              <Scatter data={data} name="Games">
+                {data.map(point => (
+                  <Cell key={point.game_type} fill={point.fill} fillOpacity={0.75} />
+                ))}
+              </Scatter>
+            </ScatterChart>
+          </ResponsiveContainer>
+        </div>
+
+        {/* The quadrants named, with their members. The chart shows position;
+            this says what a position means, which is the part worth carrying
+            away from it. */}
+        <dl className="mt-4 grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
+          {(Object.keys(QUADRANT_LABELS) as (keyof typeof QUADRANT_LABELS)[]).map((quadrant) => {
+            const members = data.filter(point => point.quadrant === quadrant);
+            return (
+              <div key={quadrant}>
+                <dt className="font-medium text-gray-900 dark:text-white">{QUADRANT_LABELS[quadrant]}</dt>
+                <dd className="text-gray-600 dark:text-gray-300">
+                  {members.length === 0
+                    ? <span className="text-gray-400 dark:text-gray-500">none</span>
+                    : members.map(point => point.name).join(', ')}
+                </dd>
+              </div>
+            );
+          })}
+        </dl>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/reports/__tests__/ChartTooltip.test.tsx
+++ b/components/reports/__tests__/ChartTooltip.test.tsx
@@ -49,6 +49,25 @@ describe('chartTooltip', () => {
     expect(container.firstChild).toBeNull();
   });
 
+  it('keeps a zero label, which is a real hour', () => {
+    // Midnight is a value, not an absence — a falsiness check would drop it.
+    // Unformatted on purpose: a formatter turns 0 into a truthy "0:00" and the
+    // check is never exercised, which is exactly how this test first passed
+    // against a mutation it should have caught.
+    render(<ChartTooltip active payload={PAYLOAD} label={0} />);
+
+    expect(screen.getByText('0')).toBeTruthy();
+  });
+
+  it('draws no heading when the formatter returns nothing', () => {
+    // A scatter's identity is the point, not a shared x-value, so its label
+    // formatter returns ''. The heading would otherwise be an empty line with
+    // a margin above the series.
+    const { container } = render(<ChartTooltip active payload={PAYLOAD} label="28 Jul" labelFormatter={() => ''} />);
+
+    expect(container.querySelector('.mb-1')).toBeNull();
+  });
+
   it('applies a label formatter when given one', () => {
     render(<ChartTooltip active payload={PAYLOAD} label={14} labelFormatter={h => `${h}:00`} />);
 

--- a/lib/__tests__/reach-depth.test.ts
+++ b/lib/__tests__/reach-depth.test.ts
@@ -1,0 +1,119 @@
+import type { GameTotals } from '@/types/reports';
+import { describe, expect, it } from 'vitest';
+import { median, reachDepth, reachDepthContrast } from '@/lib/reach-depth';
+
+function game(key: string, players: number, perPlayer: number | null, started = 100): GameTotals {
+  return {
+    game_type: key,
+    games_started: started,
+    games_finished: started,
+    distinct_players: players,
+    mp_player_sessions: 0,
+    completion_pct: 100,
+    sessions_per_player: perPlayer,
+    share_pct: 10,
+    repeat_players: 0,
+    repeat_rate_pct: null,
+    previous_games_started: 0,
+    trend_pct: null,
+  };
+}
+
+describe('median', () => {
+  it('averages the middle pair on an even count', () => {
+    expect(median([1, 2, 3, 4])).toBe(2.5);
+  });
+
+  it('is unmoved by an outlier that would drag a mean', () => {
+    // The whole reason the crosshairs are medians: one runaway game must not
+    // re-label every other game around it.
+    expect(median([5, 6, 7, 900])).toBe(6.5);
+  });
+
+  it('is 0 for nothing rather than NaN', () => {
+    expect(median([])).toBe(0);
+  });
+});
+
+describe('reachDepth', () => {
+  const ROWS = [
+    game('quiz', 227, 7.2),
+    game('team_ties', 77, 38.6),
+    game('grid', 150, 20),
+    game('scout', 40, 3),
+    game('conquest', 300, 44),
+  ];
+
+  it('puts a wide shallow game and a small devoted one in opposite quadrants', () => {
+    // The pair that motivated the view: ranked by volume they read the same.
+    const { points } = reachDepth(ROWS);
+    const by = Object.fromEntries(points.map(p => [p.game_type, p.quadrant]));
+
+    expect(by.quiz).toBe('broad_shallow');
+    expect(by.team_ties).toBe('small_devoted');
+    expect(by.conquest).toBe('broad_and_deep');
+    expect(by.scout).toBe('quiet');
+  });
+
+  it('splits at the medians, not the means', () => {
+    const { medianReach, medianDepth } = reachDepth(ROWS);
+
+    expect(medianReach).toBe(150);
+    expect(medianDepth).toBe(20);
+  });
+
+  it('drops a game nobody played rather than plotting it at the origin', () => {
+    // It would land in "quiet" and drag both medians down, making every other
+    // game look better than it is. Zero players with a zero rate, not a null
+    // one — the null case is caught by the other half of the filter, so this
+    // is the row that actually exercises this guard.
+    const { points, medianReach } = reachDepth([...ROWS, game('empty', 0, 0, 0)]);
+
+    expect(points.map(p => p.game_type)).not.toContain('empty');
+    expect(medianReach).toBe(150);
+  });
+
+  it('drops a game with players but no sessions-per-player figure', () => {
+    const { points } = reachDepth([...ROWS, game('unknown', 12, null)]);
+
+    expect(points.map(p => p.game_type)).not.toContain('unknown');
+  });
+
+  it('calls a game sitting exactly on the median modest, not broad', () => {
+    // With an odd number of games one of them IS the median. Rounding that one
+    // up to "broad and deep" is flattery, and the quadrant is a claim.
+    const { points } = reachDepth(ROWS);
+
+    expect(points.find(p => p.game_type === 'grid')?.quadrant).toBe('quiet');
+  });
+
+  it('survives a single game', () => {
+    const { points, medianReach } = reachDepth([game('grid', 10, 2)]);
+
+    expect(points).toHaveLength(1);
+    expect(medianReach).toBe(10);
+    expect(points[0].quadrant).toBe('quiet');
+  });
+});
+
+describe('reachDepthContrast', () => {
+  it('names the widest-reaching and the most-played-per-person', () => {
+    const { points } = reachDepth([game('quiz', 227, 7.2), game('team_ties', 77, 38.6)]);
+    const contrast = reachDepthContrast(points);
+
+    expect(contrast?.broadest.game_type).toBe('quiz');
+    expect(contrast?.deepest.game_type).toBe('team_ties');
+  });
+
+  it('says nothing when one game is both', () => {
+    // "X reaches the most players and X is played most per person" is not a
+    // contrast, and printing it as one would be filler.
+    const { points } = reachDepth([game('quiz', 227, 40), game('scout', 20, 2)]);
+
+    expect(reachDepthContrast(points)).toBeNull();
+  });
+
+  it('says nothing with fewer than two games', () => {
+    expect(reachDepthContrast([])).toBeNull();
+  });
+});

--- a/lib/__tests__/reach-depth.test.ts
+++ b/lib/__tests__/reach-depth.test.ts
@@ -97,6 +97,17 @@ describe('reachDepth', () => {
 });
 
 describe('reachDepthContrast', () => {
+  it('picks the extremes by reach and by depth, not by a combined score', () => {
+    // Grid is second on both axes, so any "most divergent overall" rule could
+    // pick it. The card names the two extremes and prints both figures for
+    // each, leaving the weighing of reach against depth to the reader.
+    const { points } = reachDepth([game('quiz', 227, 7.2), game('grid', 150, 20), game('team_ties', 77, 38.6)]);
+    const contrast = reachDepthContrast(points);
+
+    expect(contrast?.broadest.game_type).toBe('quiz');
+    expect(contrast?.deepest.game_type).toBe('team_ties');
+  });
+
   it('names the widest-reaching and the most-played-per-person', () => {
     const { points } = reachDepth([game('quiz', 227, 7.2), game('team_ties', 77, 38.6)]);
     const contrast = reachDepthContrast(points);

--- a/lib/reach-depth.ts
+++ b/lib/reach-depth.ts
@@ -1,0 +1,106 @@
+/**
+ * Reach against depth, per game.
+ *
+ * The games table ranks by volume, and volume hides the most useful thing in
+ * it: two games with similar session counts can have opposite problems. Quiz
+ * reached 227 players who played 7.2 times each; Team Ties reached 77 who
+ * played 38.6 times each. One has an audience it isn't holding, the other has
+ * devotion it isn't spreading — and no view in Reports contrasted them, so both
+ * read as "mid-table".
+ *
+ * Pure, because the quadrant a game lands in is a claim about it and claims are
+ * what should be tested.
+ */
+
+import type { GameTotals } from '@/types/reports';
+
+export type Quadrant = 'broad_and_deep' | 'broad_shallow' | 'small_devoted' | 'quiet';
+
+export type ReachDepthPoint = {
+  game_type: string;
+  /** Distinct players in the window — how many people the game reached. */
+  reach: number;
+  /** Sessions per player — how much each of them played it. */
+  depth: number;
+  sessions: number;
+  quadrant: Quadrant;
+};
+
+export type ReachDepth = {
+  points: ReachDepthPoint[];
+  /** Crosshairs. Medians, not means: one runaway game would drag a mean. */
+  medianReach: number;
+  medianDepth: number;
+};
+
+export const QUADRANT_LABELS: Record<Quadrant, string> = {
+  broad_and_deep: 'Broad and deep',
+  broad_shallow: 'Broad but shallow',
+  small_devoted: 'Small but devoted',
+  quiet: 'Quiet',
+};
+
+export function median(values: number[]): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+/**
+ * Games with players, split into quadrants at the medians.
+ *
+ * A game nobody played is excluded rather than plotted at the origin: it would
+ * sit in "quiet" and drag both medians down, making every other game look
+ * better than it is.
+ *
+ * Strictly-greater-than counts as the high side, so a game sitting exactly on
+ * the median line falls to the modest quadrant. With an odd number of games one
+ * of them IS the median, and calling that one "broad" would be flattery.
+ */
+export function reachDepth(rows: GameTotals[]): ReachDepth {
+  const played = rows.filter(row => row.distinct_players > 0 && row.sessions_per_player !== null);
+  const medianReach = median(played.map(row => row.distinct_players));
+  const medianDepth = median(played.map(row => row.sessions_per_player as number));
+
+  const points = played.map((row) => {
+    const reach = row.distinct_players;
+    const depth = row.sessions_per_player as number;
+    const broad = reach > medianReach;
+    const deep = depth > medianDepth;
+    return {
+      game_type: row.game_type,
+      reach,
+      depth,
+      sessions: row.games_started,
+      quadrant: (broad && deep
+        ? 'broad_and_deep'
+        : broad
+          ? 'broad_shallow'
+          : deep
+            ? 'small_devoted'
+            : 'quiet') as Quadrant,
+    };
+  });
+
+  return { points, medianReach, medianDepth };
+}
+
+/**
+ * The two games furthest apart in shape, named.
+ *
+ * A quadrant chart is only as useful as the sentence someone takes away from
+ * it, and the pair worth reading is the widest-reach-shallowest against the
+ * narrowest-deepest — the two opposite problems the platform actually has.
+ * Returns null when there aren't two games to contrast.
+ */
+export function reachDepthContrast(points: ReachDepthPoint[]): { broadest: ReachDepthPoint; deepest: ReachDepthPoint } | null {
+  if (points.length < 2) {
+    return null;
+  }
+  const broadest = points.reduce((a, b) => (b.reach > a.reach ? b : a));
+  const deepest = points.reduce((a, b) => (b.depth > a.depth ? b : a));
+  return broadest.game_type === deepest.game_type ? null : { broadest, deepest };
+}

--- a/lib/reach-depth.ts
+++ b/lib/reach-depth.ts
@@ -89,12 +89,18 @@ export function reachDepth(rows: GameTotals[]): ReachDepth {
 }
 
 /**
- * The two games furthest apart in shape, named.
+ * The two extremes, named: the game that reached the most players, and the one
+ * played most per person.
  *
  * A quadrant chart is only as useful as the sentence someone takes away from
- * it, and the pair worth reading is the widest-reach-shallowest against the
- * narrowest-deepest — the two opposite problems the platform actually has.
- * Returns null when there aren't two games to contrast.
+ * it. The sentence states both figures for each game, so "reached 227 players,
+ * 7.2 sessions each" against "77 players, 38.6 each" carries the contrast
+ * without needing a combined score to rank divergence by — one that would be a
+ * judgement about how to weigh reach against depth, which is the reader's to
+ * make.
+ *
+ * Null when one game is both extremes: that is not a contrast, and printing it
+ * as one would be filler. Null too when there aren't two games at all.
  */
 export function reachDepthContrast(points: ReachDepthPoint[]): { broadest: ReachDepthPoint; deepest: ReachDepthPoint } | null {
   if (points.length < 2) {


### PR DESCRIPTION
Issue #1453, item **C5**. No backend change — the numbers were already in the payload; nothing put them next to each other.

## The finding

The games table ranks by volume, and volume hides the most useful thing in it:

| Game | Players reached | Sessions each |
|---|---|---|
| Quiz | 227 | 7.2 |
| Team Ties | 77 | 38.6 |

Opposite problems. Quiz has an audience it isn't holding; Team Ties has devotion it isn't spreading. Ranked by session count they sit near each other and read as mid-table, and no view in Reports contrasted them — so neither problem was visible anywhere.

## The view

A scatter: reach on x, sessions-per-player on y, bubble size for total sessions so the volume ranking is still present rather than replaced. Quadrants split at the medians, each one named with its members underneath.

The details are claims, not styling:

- **Medians, not means, for the crosshairs.** One runaway game would drag a mean and re-label every other game around it.
- **Strictly-greater-than counts as the high side**, so a game sitting exactly on the median falls to the modest quadrant. With an odd number of games one of them *is* the median, and rounding that one up to "broad and deep" would be flattery.
- **A game nobody played is dropped, not plotted at the origin.** It would land in "quiet" and drag both medians down, making every other game look better than it is.
- **The headline names the two extremes** — and says nothing when one game is both. "X reaches the most players and X is played most per person" isn't a contrast, and printing it as one would be filler.

## Colour

Ran the eleven registry colours through the palette validator: lightness band, chroma floor, CVD separation (worst adjacent pair ΔE 17.8 deutan) and normal-vision floor all pass. Contrast warns — four sit below 3:1 against the card — which is legal only with relief, so **every point is named** in the quadrant list under the plot and in its tooltip. Colour confirms identity here; it never carries it alone.

## Incidental

`ChartTooltip` drops its heading when the label formats to nothing — a scatter's identity is the point, not a shared x-value, so the heading was an empty line with a margin above the series. Checked against `''` rather than falsiness, because hour 0 is a real label on the patterns chart.

## Mutation testing

| Mutation | Result |
|---|---|
| mean instead of median | 3 fail |
| `>=` counts as the high side | 2 fail |
| keep unplayed games | 1 fails |
| let one game be both ends of the contrast | 1 fails |
| swap the quadrant axes | 1 fails |
| render the tooltip heading regardless | 1 fails |
| falsiness check on the label | 1 fails |

Worth flagging: **two of these tests initially passed against their own mutation.** The zero-player row was being excluded by the other half of the filter, and the zero label was being formatted into a truthy string, so neither guard was actually exercised. Both rewritten.

Suite: 356 passing (55 files). Build and types clean.