### PR TITLE
Add Today and Yesterday range presets

### DIFF
--- a/components/reports/RangePicker.tsx
+++ b/components/reports/RangePicker.tsx
@@ -30,12 +30,15 @@ export function RangePicker({ value, onChange, includeBots, onIncludeBotsChange 
   includeBots: boolean;
   onIncludeBotsChange: (v: boolean) => void;
 }) {
-  const today = isoDay(new Date());
+  // One clock reading for the whole render. Two `new Date()` calls can land
+  // either side of midnight, and the validation bounds and the lit button would
+  // then be describing different days.
+  const now = new Date();
+  const today = isoDay(now);
   const [open, setOpen] = useState(false);
   const [draftStart, setDraftStart] = useState(value.start ?? '');
   const [draftEnd, setDraftEnd] = useState(value.end ?? today);
 
-  const now = new Date();
   const active = activePreset(value, now);
   const custom = active === 'custom';
   const invalid = !draftStart || draftStart > draftEnd || draftEnd > today;

--- a/components/reports/RangePicker.tsx
+++ b/components/reports/RangePicker.tsx
@@ -5,7 +5,7 @@ import { CalendarDays, X } from 'lucide-react';
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { isoDay } from '@/lib/report-range';
+import { activePreset, isoDay, yesterdayRange } from '@/lib/report-range';
 import { REPORT_WINDOWS } from '@/types/reports';
 import { Switch } from '@/components/ui/switch';
 
@@ -17,6 +17,12 @@ import { Switch } from '@/components/ui/switch';
  * validated the same way the server does (start <= end, end not in the future)
  * before being applied, so a mistake shows up as a disabled button rather than
  * a red error panel.
+ *
+ * Today and Yesterday are named rather than numbered. "1d" is technically the
+ * same range and reads as a duration — "how is today going" is the question
+ * this section is asked most often, and it deserves a word, not an arithmetic
+ * exercise. Yesterday is an explicit start=end, because a window only ever
+ * counts back from today.
  */
 export function RangePicker({ value, onChange, includeBots, onIncludeBotsChange }: {
   value: RangeState;
@@ -29,18 +35,37 @@ export function RangePicker({ value, onChange, includeBots, onIncludeBotsChange 
   const [draftStart, setDraftStart] = useState(value.start ?? '');
   const [draftEnd, setDraftEnd] = useState(value.end ?? today);
 
-  const custom = !!value.start;
+  const now = new Date();
+  const active = activePreset(value, now);
+  const custom = active === 'custom';
   const invalid = !draftStart || draftStart > draftEnd || draftEnd > today;
 
   return (
     <div className="flex flex-wrap items-center gap-2">
       <span className="text-sm text-gray-600 dark:text-gray-300">Range</span>
 
-      {REPORT_WINDOWS.map(w => (
+      <Button
+        size="sm"
+        variant={active === 'today' ? 'default' : 'outline'}
+        onClick={() => onChange({ window: 1 })}
+      >
+        Today
+      </Button>
+      <Button
+        size="sm"
+        variant={active === 'yesterday' ? 'default' : 'outline'}
+        onClick={() => onChange(yesterdayRange(now, value.window))}
+      >
+        Yesterday
+      </Button>
+
+      {/* 1 is excluded: it is the Today button above, and "1d" beside it would
+          be the same range offered twice under two names. */}
+      {REPORT_WINDOWS.filter(w => w > 1).map(w => (
         <Button
           key={w}
           size="sm"
-          variant={!custom && w === value.window ? 'default' : 'outline'}
+          variant={active === w ? 'default' : 'outline'}
           onClick={() => onChange({ window: w })}
         >
           {w}

--- a/components/reports/__tests__/RangePicker.test.tsx
+++ b/components/reports/__tests__/RangePicker.test.tsx
@@ -49,4 +49,36 @@ describe('bots control', () => {
 
     expect(onIncludeBotsChange).toHaveBeenCalledWith(true);
   });
+
+  it('offers today and yesterday by name, and only once', () => {
+    // "1d" beside a "Today" button would be the same range under two names.
+    render(<RangePicker value={{ window: 30 }} onChange={() => {}} includeBots={false} onIncludeBotsChange={() => {}} />);
+
+    expect(screen.getByRole('button', { name: 'Today' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Yesterday' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: '1d' })).toBeNull();
+  });
+
+  it('asks for a one-day window when Today is picked', async () => {
+    const onChange = vi.fn();
+    render(<RangePicker value={{ window: 30 }} onChange={onChange} includeBots={false} onIncludeBotsChange={() => {}} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Today' }));
+
+    expect(onChange).toHaveBeenCalledWith({ window: 1 });
+  });
+
+  it('asks for explicit dates when Yesterday is picked', async () => {
+    // A window counts back from today, so yesterday has to be dates.
+    const onChange = vi.fn();
+    render(<RangePicker value={{ window: 30 }} onChange={onChange} includeBots={false} onIncludeBotsChange={() => {}} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Yesterday' }));
+
+    const arg = onChange.mock.calls[0][0];
+    expect(arg.start).toBe(arg.end);
+    expect(arg.start).not.toBeUndefined();
+    // The previous preset survives, so clearing the range returns to it.
+    expect(arg.window).toBe(30);
+  });
 });

--- a/lib/__tests__/report-range.test.ts
+++ b/lib/__tests__/report-range.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isoDay, rangeToParams } from '@/lib/report-range';
+import { activePreset, isoDay, rangeToParams, yesterdayRange } from '@/lib/report-range';
 
 describe('isoDay', () => {
   it('formats the LOCAL date, not the UTC one', () => {
@@ -31,5 +31,50 @@ describe('rangeToParams', () => {
   it('omits end so the BE can default it to today', () => {
     expect(rangeToParams({ window: 7, start: '2026-06-01' }))
       .toEqual({ start: '2026-06-01', end: undefined });
+  });
+});
+
+describe('yesterdayRange', () => {
+  it('is an explicit single day, not a window', () => {
+    // A window only ever counts back from today, so "yesterday" cannot be one.
+    expect(yesterdayRange(new Date(2026, 7, 13, 14, 0), 30)).toEqual({
+      window: 30,
+      start: '2026-08-12',
+      end: '2026-08-12',
+    });
+  });
+
+  it('crosses a month boundary', () => {
+    expect(yesterdayRange(new Date(2026, 7, 1, 9, 0), 7).start).toBe('2026-07-31');
+  });
+
+  it('keeps the window it was given', () => {
+    // Clearing the custom range returns to whatever preset was selected before,
+    // rather than to a default nobody chose.
+    expect(yesterdayRange(new Date(2026, 7, 13), 60).window).toBe(60);
+  });
+});
+
+describe('activePreset', () => {
+  const NOW = new Date(2026, 7, 13, 14, 0);
+
+  it('calls a one-day window "today" rather than the number 1', () => {
+    // Both buttons would otherwise light up: today IS window 1.
+    expect(activePreset({ window: 1 }, NOW)).toBe('today');
+  });
+
+  it('recognises yesterday from its explicit dates', () => {
+    expect(activePreset({ window: 30, start: '2026-08-12', end: '2026-08-12' }, NOW)).toBe('yesterday');
+  });
+
+  it('calls any other explicit range custom', () => {
+    expect(activePreset({ window: 30, start: '2026-08-01', end: '2026-08-12' }, NOW)).toBe('custom');
+    // A single day that isn't yesterday is still custom — lighting up Yesterday
+    // for it would misstate what is on screen.
+    expect(activePreset({ window: 30, start: '2026-08-10', end: '2026-08-10' }, NOW)).toBe('custom');
+  });
+
+  it('returns the number for a numeric preset', () => {
+    expect(activePreset({ window: 30 }, NOW)).toBe(30);
   });
 });

--- a/lib/__tests__/report-range.test.ts
+++ b/lib/__tests__/report-range.test.ts
@@ -77,4 +77,19 @@ describe('activePreset', () => {
   it('returns the number for a numeric preset', () => {
     expect(activePreset({ window: 30 }, NOW)).toBe(30);
   });
+
+  it('reads the same clock for the preset and for yesterday', () => {
+    // The picker used to take two `new Date()` readings — one for the
+    // validation bounds, one for preset matching. Across midnight they describe
+    // different days, and the lit button stops matching the data. Passing the
+    // clock in is what makes that impossible rather than unlikely.
+    const justBeforeMidnight = new Date(2026, 7, 13, 23, 59, 59);
+    const range = yesterdayRange(justBeforeMidnight, 30);
+
+    expect(activePreset(range, justBeforeMidnight)).toBe('yesterday');
+    // One second later it is a different day, and the same range is no longer
+    // yesterday — which is correct, and only knowable because both sides read
+    // the clock the caller passed.
+    expect(activePreset(range, new Date(2026, 7, 14, 0, 0, 1))).toBe('custom');
+  });
 });

--- a/lib/report-range.ts
+++ b/lib/report-range.ts
@@ -1,5 +1,12 @@
 import type { ReportParams, ReportWindow } from '@/types/reports';
 
+/**
+ * The windows that render as a number of days. 1 is excluded because it is the
+ * "Today" button — offering it as "1d" as well would be one range under two
+ * names.
+ */
+export type NumericWindow = Exclude<ReportWindow, 1>;
+
 /** A selected reporting range: a preset window, or explicit dates. */
 export type RangeState = {
   window: ReportWindow;
@@ -47,12 +54,12 @@ export function yesterdayRange(today: Date, window: ReportWindow): RangeState {
  * is correct. Named presets are checked before numeric ones because "today" is
  * also `window: 1`.
  */
-export function activePreset(range: RangeState, today: Date): 'today' | 'yesterday' | 'custom' | number {
+export function activePreset(range: RangeState, today: Date): 'today' | 'yesterday' | 'custom' | NumericWindow {
   if (range.start) {
     const yesterday = yesterdayRange(today, range.window);
     return range.start === yesterday.start && range.end === yesterday.end ? 'yesterday' : 'custom';
   }
-  return range.window === 1 ? 'today' : range.window;
+  return range.window === 1 ? 'today' : (range.window as NumericWindow);
 }
 
 /** Query params for a range — explicit dates win, exactly as the BE resolves them. */

--- a/lib/report-range.ts
+++ b/lib/report-range.ts
@@ -22,6 +22,39 @@ export function isoDay(date: Date): string {
   return `${year}-${month}-${day}`;
 }
 
+/**
+ * Yesterday, as an explicit single-day range.
+ *
+ * Explicit dates rather than a second window value: "yesterday" is a shifted
+ * day, and a `window` only ever counts back from today. The backend already
+ * resolves start=end, so this needs nothing new there.
+ *
+ * `window` is carried along unchanged so clearing the range returns to whatever
+ * preset was selected before, rather than to a default nobody chose.
+ */
+export function yesterdayRange(today: Date, window: ReportWindow): RangeState {
+  const date = new Date(today);
+  date.setDate(date.getDate() - 1);
+  const day = isoDay(date);
+  return { window, start: day, end: day };
+}
+
+/**
+ * Which preset a range corresponds to, if any.
+ *
+ * The picker has to answer this to show what is selected, and getting it wrong
+ * is the kind of bug nobody reports: two buttons lit, or none, while the data
+ * is correct. Named presets are checked before numeric ones because "today" is
+ * also `window: 1`.
+ */
+export function activePreset(range: RangeState, today: Date): 'today' | 'yesterday' | 'custom' | number {
+  if (range.start) {
+    const yesterday = yesterdayRange(today, range.window);
+    return range.start === yesterday.start && range.end === yesterday.end ? 'yesterday' : 'custom';
+  }
+  return range.window === 1 ? 'today' : range.window;
+}
+
 /** Query params for a range — explicit dates win, exactly as the BE resolves them. */
 export function rangeToParams(range: RangeState): ReportParams {
   return range.start ? { start: range.start, end: range.end } : { window: range.window };

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -145,8 +145,13 @@ export type TopPlayersResponse = {
   players: TopPlayer[];
 } & ResolvedRange;
 
-/** Windows the BE accepts (ALLOWED_WINDOWS in core/reporting_views.py). */
-export const REPORT_WINDOWS = [7, 10, 15, 30, 60, 90] as const;
+/**
+ * Windows the BE accepts (ALLOWED_WINDOWS in core/reporting_views.py).
+ *
+ * 1 is here so "today" is a preset rather than two identical dates picked by
+ * hand. It is rendered as a named button, not as "1d" — see `RangePicker`.
+ */
+export const REPORT_WINDOWS = [1, 7, 10, 15, 30, 60, 90] as const;
 export type ReportWindow = (typeof REPORT_WINDOWS)[number];
 
 export type ReportParams = {


### PR DESCRIPTION
Issue #1453, item **B2** (frontend half). Needs FootballExtraTime/App#1461 for `window=1` — that is the only new value it sends.

## Why

The presets started at 7 days. The question this section is asked most often — *how is today going* — meant opening the date picker and choosing the same date twice.

## What changed

**Today** and **Yesterday**, both named rather than numbered. `1d` is technically the same range as Today and reads as a duration, so the numeric list now starts at 7 — the range isn't offered twice under two names.

**Yesterday is explicit dates**, not a second window value. A window only ever counts back from today, so a shifted day cannot be one; the backend already resolves `start=end`, so it needs nothing new there. It carries the previous preset along, so clearing the custom range returns to whatever was selected before rather than to a default nobody chose.

## The part that breaks quietly

`activePreset` decides which button is lit. Get it wrong and you have two buttons lit or none, while the data on screen is perfectly correct — nobody files that bug, they just stop trusting the control. So it is a pure function with its own tests:

- Named presets are checked before numeric ones, because **Today *is* window 1**.
- A single day that isn't yesterday stays **custom** — lighting up Yesterday for it would misstate what is on screen.

## Mutation testing

| Mutation | Result |
|---|---|
| report window 1 as the number | 1 fails |
| treat any single day as yesterday | 1 fails |
| drop the carried window from Yesterday | 3 fail |
| off-by-one (yesterday = today) | 3 fail |
| show `1d` alongside Today | 1 fails |

Suite: 367 passing (56 files). Build and types clean.