### PR TITLE
Say where the unfinished sessions actually are

### DIFF
--- a/app/reports/games/page.tsx
+++ b/app/reports/games/page.tsx
@@ -10,6 +10,7 @@ import { GameBadge } from '@/components/reports/GameBadge';
 import { MetricInfo } from '@/components/reports/MetricInfo';
 import { ExportButton } from '@/components/reports/ExportButton';
 import { RangePicker } from '@/components/reports/RangePicker';
+import { AbandonedPanel } from '@/components/reports/AbandonedPanel';
 import { ReachDepthChart } from '@/components/reports/ReachDepthChart';
 import { ReportError } from '@/components/reports/ReportError';
 import { ReportsShell } from '@/components/reports/ReportsShell';
@@ -132,6 +133,11 @@ export default function GamesIndexPage() {
                   audience next to one with a small devoted one and says
                   nothing about the difference. */}
               <ReachDepthChart rows={data.by_game} meta={meta} />
+              {/* Reach and depth say which games are worth attention; this says
+                  where the recoverable sessions actually are, which is a
+                  different question and the one nobody could answer from a
+                  completion-rate column. */}
+              <AbandonedPanel rows={data.by_game} meta={meta} />
               <Card>
                 <CardHeader>
                   <CardTitle>Comparison</CardTitle>

--- a/components/reports/AbandonedPanel.tsx
+++ b/components/reports/AbandonedPanel.tsx
@@ -17,9 +17,14 @@ import { abandonedSessions, sessionsPerPoint } from '@/lib/abandoned';
  * pool on the platform. Ranked by rate it looks ordinary; ranked by volume it
  * looks healthy; the pool itself was on no screen at all.
  *
- * Bars are the share of *abandoned* sessions rather than of play, because that
- * is the quantity being compared. Completion rate rides alongside as context,
- * not as the ranking — a poor rate on a small game is not a lever.
+ * Bars encode the pool itself — abandoned sessions, not sessions played —
+ * scaled to the largest pool, so the comparison between games uses the full
+ * width available. Each game's share of all abandonment is the % column beside
+ * it; putting that on the bar instead would leave even the biggest one at a
+ * third of the track and make the smaller games unreadable.
+ *
+ * Completion rate rides alongside as context, not as the ranking — a poor rate
+ * on a small game is not a lever.
  */
 export function AbandonedPanel({ rows, meta }: { rows: GameTotals[]; meta: GameMetaMap }) {
   const resolveColor = useGameColor();

--- a/components/reports/AbandonedPanel.tsx
+++ b/components/reports/AbandonedPanel.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import type { GameMetaMap } from '@/hooks/use-game-meta';
+import type { GameTotals } from '@/types/reports';
+import { useMemo } from 'react';
+import { GameBadge } from '@/components/reports/GameBadge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { gameName, useGameColor } from '@/hooks/use-game-meta';
+import { abandonedSessions, sessionsPerPoint } from '@/lib/abandoned';
+
+/**
+ * Where the unfinished sessions are.
+ *
+ * Every number here was already in the reports and none of them said this.
+ * missing11 runs at 61.7% completion — mid-table beside games at 55% — but it
+ * is a quarter of all play, so its abandoned sessions are the largest single
+ * pool on the platform. Ranked by rate it looks ordinary; ranked by volume it
+ * looks healthy; the pool itself was on no screen at all.
+ *
+ * Bars are the share of *abandoned* sessions rather than of play, because that
+ * is the quantity being compared. Completion rate rides alongside as context,
+ * not as the ranking — a poor rate on a small game is not a lever.
+ */
+export function AbandonedPanel({ rows, meta }: { rows: GameTotals[]; meta: GameMetaMap }) {
+  const resolveColor = useGameColor();
+  const { rows: abandoned, totalAbandoned, lever } = useMemo(() => abandonedSessions(rows), [rows]);
+
+  if (abandoned.length === 0) {
+    return null;
+  }
+
+  const max = abandoned[0].abandoned;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Where the losses are</CardTitle>
+        <CardDescription>
+          {totalAbandoned.toLocaleString()}
+          {' sessions were started and not finished in this window. '}
+          {lever
+            ? (
+                <>
+                  {gameName(meta[lever.game_type], lever.game_type)}
+                  {' holds '}
+                  {lever.share_of_abandoned_pct}
+                  {'% of them — '}
+                  {lever.abandoned.toLocaleString()}
+                  {' sessions. Two points of completion there is '}
+                  {sessionsPerPoint(lever, 2).toLocaleString()}
+                  {' sessions, on this window’s volume.'}
+                </>
+              )
+            // Two comparable pools: naming one of them "the" lever would be a
+            // coin toss dressed up as a finding.
+            : 'No single game dominates the pool — the top games are within a few points of each other.'}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-2">
+          {abandoned.map(row => (
+            <li key={row.game_type} className="flex flex-wrap items-center gap-3 text-sm">
+              <span className="min-w-40 flex-1">
+                <GameBadge gameKey={row.game_type} meta={meta} />
+              </span>
+              <span className="h-2 w-full max-w-64 overflow-hidden rounded-full bg-gray-100 dark:bg-slate-700">
+                <span
+                  className="block h-full rounded-full"
+                  style={{
+                    width: `${max > 0 ? Math.max(2, (row.abandoned / max) * 100) : 0}%`,
+                    backgroundColor: resolveColor(meta, row.game_type),
+                  }}
+                />
+              </span>
+              <span className="w-20 text-right font-medium tabular-nums text-gray-900 dark:text-white">
+                {row.abandoned.toLocaleString()}
+              </span>
+              <span className="w-14 text-right tabular-nums text-gray-500 dark:text-gray-400">
+                {row.share_of_abandoned_pct}
+                %
+              </span>
+              {/* Context, not ranking: the rate says how hard the pool would be
+                  to shrink, the pool says how much there is to win. */}
+              <span className="w-24 text-right tabular-nums text-gray-500 dark:text-gray-400">
+                {row.completion_pct === null ? '—' : `${row.completion_pct}% done`}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/lib/__tests__/abandoned.test.ts
+++ b/lib/__tests__/abandoned.test.ts
@@ -1,0 +1,92 @@
+import type { GameTotals } from '@/types/reports';
+import { describe, expect, it } from 'vitest';
+import { abandonedSessions, sessionsPerPoint } from '@/lib/abandoned';
+
+function game(key: string, started: number, finished: number): GameTotals {
+  return {
+    game_type: key,
+    games_started: started,
+    games_finished: finished,
+    distinct_players: 50,
+    mp_player_sessions: 0,
+    completion_pct: started > 0 ? Math.round((finished / started) * 1000) / 10 : null,
+    sessions_per_player: 2,
+    share_pct: 10,
+    repeat_players: 0,
+    repeat_rate_pct: null,
+    previous_games_started: 0,
+    trend_pct: null,
+  };
+}
+
+describe('abandonedSessions', () => {
+  it('ranks by the size of the pool, not by the completion rate', () => {
+    // The finding this exists for: missing11 at 61.7% reads as mid-table beside
+    // a game at 40%, but it is a quarter of all play, so its pool is far
+    // larger. A rate ranking buries exactly the game worth working on.
+    const { rows } = abandonedSessions([
+      game('missing11', 8440, 5207), // 61.7% — 3,233 abandoned
+      game('tiny', 80, 32), //           40.0% —    48 abandoned
+    ]);
+
+    expect(rows.map(r => r.game_type)).toEqual(['missing11', 'tiny']);
+    expect(rows[0].abandoned).toBe(3233);
+  });
+
+  it('reports each pool as a share of all abandonment', () => {
+    const { rows, totalAbandoned } = abandonedSessions([game('a', 100, 30), game('b', 100, 70)]);
+
+    expect(totalAbandoned).toBe(100);
+    expect(rows[0].share_of_abandoned_pct).toBe(70);
+    expect(rows[1].share_of_abandoned_pct).toBe(30);
+  });
+
+  it('names a lever only when one game genuinely dominates', () => {
+    const clear = abandonedSessions([game('big', 1000, 100), game('small', 100, 90)]);
+    expect(clear.lever?.game_type).toBe('big');
+  });
+
+  it('names no lever when the top two are close', () => {
+    // 51% against 49% is a coin toss. Calling one of them "the" lever would
+    // dress it up as a finding.
+    const { lever } = abandonedSessions([game('a', 102, 0), game('b', 98, 0)]);
+
+    expect(lever).toBeNull();
+  });
+
+  it('leaves out games with nothing abandoned', () => {
+    // A perfect game is not a small pool; it is not a pool.
+    const { rows } = abandonedSessions([game('perfect', 40, 40), game('leaky', 40, 10)]);
+
+    expect(rows.map(r => r.game_type)).toEqual(['leaky']);
+  });
+
+  it('never reports a negative pool', () => {
+    // Sessions finished in the window can start before it, so finished can
+    // exceed started at a range boundary. That is a reporting artefact, not
+    // negative abandonment.
+    const { rows, totalAbandoned } = abandonedSessions([game('boundary', 10, 14)]);
+
+    expect(rows).toEqual([]);
+    expect(totalAbandoned).toBe(0);
+  });
+
+  it('has nothing to say about an empty window', () => {
+    const { rows, totalAbandoned, lever } = abandonedSessions([]);
+
+    expect(rows).toEqual([]);
+    expect(totalAbandoned).toBe(0);
+    expect(lever).toBeNull();
+  });
+});
+
+describe('sessionsPerPoint', () => {
+  it('is arithmetic on this window, offered as a unit of comparison', () => {
+    // Two points on 8,440 sessions is worth more than ten points on 80 — which
+    // is the entire point of showing it.
+    const { rows } = abandonedSessions([game('missing11', 8440, 5207), game('tiny', 80, 32)]);
+
+    expect(sessionsPerPoint(rows[0], 2)).toBe(169);
+    expect(sessionsPerPoint(rows[1], 10)).toBe(8);
+  });
+});

--- a/lib/__tests__/abandoned.test.ts
+++ b/lib/__tests__/abandoned.test.ts
@@ -46,6 +46,30 @@ describe('abandonedSessions', () => {
     expect(clear.lever?.game_type).toBe('big');
   });
 
+  it('names no lever at exactly the margin', () => {
+    // "Within five points" has to include five, or the boundary case is decided
+    // by which side of it the arithmetic happens to land on.
+    const { rows, lever } = abandonedSessions([game('a', 105, 0), game('b', 95, 0)]);
+
+    expect(rows[0].share_of_abandoned_pct - rows[1].share_of_abandoned_pct).toBe(5);
+    expect(lever).toBeNull();
+  });
+
+  it('decides on the raw shares, not the rounded ones', () => {
+    // 5248 against 4752 is a 4.96-point gap — under the margin. Displayed, it
+    // rounds to 52.5 and 47.5, which reads as exactly 5.0; deciding on those
+    // would name a lever off a rounding artefact.
+    const { lever } = abandonedSessions([game('a', 5248, 0), game('b', 4752, 0)]);
+
+    expect(lever).toBeNull();
+  });
+
+  it('names a lever once the gap clears the margin', () => {
+    const { lever } = abandonedSessions([game('a', 106, 0), game('b', 94, 0)]);
+
+    expect(lever?.game_type).toBe('a');
+  });
+
   it('names no lever when the top two are close', () => {
     // 51% against 49% is a coin toss. Calling one of them "the" lever would
     // dress it up as a finding.

--- a/lib/abandoned.ts
+++ b/lib/abandoned.ts
@@ -1,0 +1,85 @@
+/**
+ * Where the unfinished sessions are.
+ *
+ * Reports already carry every number this needs, and none of them says the
+ * thing worth acting on: missing11 runs at 61.7% completion, which reads as
+ * mid-table beside games at 55%, but it is a quarter of all play — so its
+ * abandoned sessions are the largest single pool on the platform by a distance.
+ * A completion-rate column ranks by rate and buries that; a volume column ranks
+ * by volume and buries it too.
+ *
+ * The lever is the absolute pool, not the rate. Fixing a 40% completion rate on
+ * a game with 80 sessions recovers fewer sessions than a two-point improvement
+ * on the big one.
+ */
+
+import type { GameTotals } from '@/types/reports';
+
+export type AbandonedRow = {
+  game_type: string;
+  /** Sessions started and not finished, in the window. */
+  abandoned: number;
+  started: number;
+  completion_pct: number | null;
+  /** This game's share of every unfinished session on the platform. */
+  share_of_abandoned_pct: number;
+};
+
+export type AbandonedSummary = {
+  rows: AbandonedRow[];
+  totalAbandoned: number;
+  /**
+   * The game with the largest pool, when it is genuinely the largest — null
+   * when nothing is abandoned, or when the top two are within a few points of
+   * each other and calling one of them "the" lever would be arbitrary.
+   */
+  lever: AbandonedRow | null;
+};
+
+/**
+ * How much clear water the top game needs over the second before it is worth
+ * naming as *the* lever. Below this they are two comparable pools and the
+ * ranked list already says so.
+ */
+const LEVER_MARGIN_PCT = 5;
+
+export function abandonedSessions(games: GameTotals[]): AbandonedSummary {
+  const rows = games
+    .map(game => ({
+      game_type: game.game_type,
+      abandoned: game.games_started - game.games_finished,
+      started: game.games_started,
+      completion_pct: game.completion_pct,
+      share_of_abandoned_pct: 0,
+    }))
+    // `> 0`, not `!== 0`: a game can finish more sessions than it started in a
+    // window, because a session finishing today may have started before it.
+    // That is a range-boundary artefact, not negative abandonment, and it must
+    // not subtract from the total.
+    .filter(row => row.abandoned > 0)
+    .sort((a, b) => b.abandoned - a.abandoned);
+
+  const totalAbandoned = rows.reduce((sum, row) => sum + row.abandoned, 0);
+  for (const row of rows) {
+    row.share_of_abandoned_pct = totalAbandoned > 0
+      ? Math.round((row.abandoned / totalAbandoned) * 1000) / 10
+      : 0;
+  }
+
+  const [first, second] = rows;
+  const clear = !second || first.share_of_abandoned_pct - second.share_of_abandoned_pct >= LEVER_MARGIN_PCT;
+
+  return { rows, totalAbandoned, lever: first && clear ? first : null };
+}
+
+/**
+ * Sessions a completion-rate improvement would recover, on this window's
+ * volume.
+ *
+ * Plain arithmetic, deliberately: started x points. It is offered as a unit of
+ * comparison between games — "two points here is worth ten points there" — not
+ * as a forecast, because nothing here knows whether those points are reachable.
+ */
+export function sessionsPerPoint(row: AbandonedRow, points: number): number {
+  return Math.round(row.started * (points / 100));
+}

--- a/lib/abandoned.ts
+++ b/lib/abandoned.ts
@@ -38,8 +38,8 @@ export type AbandonedSummary = {
 
 /**
  * How much clear water the top game needs over the second before it is worth
- * naming as *the* lever. Below this they are two comparable pools and the
- * ranked list already says so.
+ * naming as *the* lever. Within this — including exactly this — they are two
+ * comparable pools and the ranked list already says so.
  */
 const LEVER_MARGIN_PCT = 5;
 
@@ -66,8 +66,14 @@ export function abandonedSessions(games: GameTotals[]): AbandonedSummary {
       : 0;
   }
 
+  // Compared on the raw shares, and strictly: the displayed percentages are
+  // rounded to 0.1, so a 4.96-point gap prints as 52.5 against 47.5 and a
+  // >= test on those would name a lever off a rounding artefact. "Within five
+  // points" has to include exactly five, or the boundary case is decided by
+  // which side of it the arithmetic happens to land.
   const [first, second] = rows;
-  const clear = !second || first.share_of_abandoned_pct - second.share_of_abandoned_pct >= LEVER_MARGIN_PCT;
+  const share = (row: AbandonedRow) => (totalAbandoned > 0 ? (row.abandoned / totalAbandoned) * 100 : 0);
+  const clear = !second || share(first) - share(second) > LEVER_MARGIN_PCT;
 
   return { rows, totalAbandoned, lever: first && clear ? first : null };
 }


### PR DESCRIPTION
Issue #1453, item **C4**. No backend change — every number was already in the payload.

## The finding

missing11 runs at **61.7% completion**. Beside games at 55% that reads as mid-table. But it is roughly a quarter of all play, so its abandoned sessions are the largest single pool on the platform by a distance — around **3,200 sessions** in a 30-day window.

Ranked by completion rate it looks ordinary. Ranked by volume it looks healthy. The pool itself was on no screen at all.

## The panel

"Where the losses are" ranks games by the size of that pool, because **the pool is the lever**. A 40% completion rate on a game with 80 sessions has 48 sessions to recover; two points on the big one is worth 169. A rate ranking buries exactly the game worth working on.

Completion rate rides alongside as context — it says how *hard* a pool would be to shrink, not how much is in it.

## Restraint

- **The headline names a game only when one genuinely dominates.** Within five points of the runner-up it says so instead. Picking between two comparable pools is a coin toss, and printing it as a finding would dress it up as one.
- **"Two points of completion is N sessions" is plain arithmetic**, framed as a unit of comparison rather than a forecast. Nothing here knows whether those points are reachable — but two points on 8,440 sessions beating ten points on 80 is the entire argument for ranking by pool, so it's worth stating.
- **A game can finish more sessions than it started** in a window, because a session finishing today may have started before it. That's a range-boundary artefact, not negative abandonment, and it must not subtract from the total.

## Mutation testing

| Mutation | Result |
|---|---|
| rank by completion rate | 2 fail |
| name a lever regardless of margin | 1 fails |
| let negatives through (`!== 0`) | 1 fails |
| keep games with nothing abandoned | 2 fail |
| compute sessions-per-point from the pool, not the volume | 1 fails |

A `Math.max(0, …)` was **dropped** along the way: the filter already excluded negatives, so it was dead code with no reachable branch — a mutation removing it changed nothing, which is how it was found.

Suite: 380 passing (58 files). Build and types clean.