### PR TITLE
Put Reports on the dashboard, and stop calling it Coming Soon

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,12 +11,14 @@ import {
   Users,
   Users2,
 } from 'lucide-react';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import React from 'react';
 import { LoadingSpinner } from '@/components/loading-spinner';
 import { LoginForm } from '@/components/login-form';
 
 import { Navigation } from '@/components/navigation';
+import { REPORT_QUICK_LINKS } from '@/components/reports/ReportsNav';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { useAuth } from '@/lib/auth';
@@ -206,7 +208,8 @@ export default function DashboardPage() {
                 User Hub
               </CardTitle>
               <CardDescription>
-                Favourites analytics and user profiles (read-only)
+                Search users and open a profile — favourites, status, activity (read-only).
+                Favourites analytics moved to Reports.
               </CardDescription>
             </CardHeader>
             <CardContent>
@@ -220,25 +223,42 @@ export default function DashboardPage() {
             </CardContent>
           </Card>
 
-          <Card className="opacity-60 transition-shadow duration-200 hover:shadow-lg">
+          {/* Reports has been live for months; this card still said "Coming
+              Soon", which is worse than saying nothing — it tells people the
+              section doesn't exist. It now opens onto the questions someone
+              actually arrives with, rather than one button into a section with
+              ten pages. */}
+          <Card className="transition-shadow duration-200 hover:shadow-lg">
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
                 <FileText className="size-5 text-red-600" />
                 Reports
               </CardTitle>
               <CardDescription>
-                Generate and view various reports and exports
+                How the platform is doing: today against a typical day, per-game health,
+                who is playing and whether they come back.
               </CardDescription>
             </CardHeader>
-            <CardContent>
+            <CardContent className="space-y-3">
               <Button
-                disabled
-                className="w-full"
-                variant="outline"
+                onClick={() => router.push('/reports')}
+                className="w-full border-emerald-500 bg-gradient-to-r from-emerald-500 to-green-600 text-white shadow-lg transition-all duration-200 hover:border-emerald-600 hover:from-emerald-600 hover:to-green-700 hover:shadow-xl"
               >
                 <FileText className="mr-2 size-4" />
-                Coming Soon
+                Open Reports
               </Button>
+              <div className="flex flex-wrap gap-1">
+                {REPORT_QUICK_LINKS.map(({ href, label, icon: Icon }) => (
+                  <Link
+                    key={href}
+                    href={href}
+                    className="flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-slate-700/60"
+                  >
+                    <Icon className="size-3.5 shrink-0" />
+                    {label}
+                  </Link>
+                ))}
+              </div>
             </CardContent>
           </Card>
 

--- a/components/admin/__tests__/SectionNav.test.tsx
+++ b/components/admin/__tests__/SectionNav.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import { BarChart3, BookOpen, Users } from 'lucide-react';
 import { describe, expect, it, vi } from 'vitest';
 import { SectionNav } from '@/components/admin/SectionNav';
-import { REPORT_NAV_GROUPS, REPORT_NAV_TRAILING } from '@/components/reports/ReportsNav';
+import { REPORT_NAV_GROUPS, REPORT_NAV_TRAILING, REPORT_QUICK_LINKS } from '@/components/reports/ReportsNav';
 import { USER_HUB_NAV_GROUPS, USER_HUB_NAV_TRAILING } from '@/components/user-hub/UserHubShell';
 
 vi.mock('next/navigation', () => ({ usePathname: () => '/reports/players' }));
@@ -75,6 +75,22 @@ describe('report nav groups', () => {
     for (const group of REPORT_NAV_GROUPS) {
       expect(items, `group "${group.heading}" repeats a page name`).not.toContain(group.heading);
     }
+  });
+
+  it('offers only dashboard shortcuts that are real destinations', () => {
+    // The dashboard card duplicates a handful of hrefs. A shortcut outliving
+    // the page it points at is a 404 reached from the front door, and nothing
+    // else would catch it.
+    const linked = new Set(REPORT_NAV_GROUPS.flatMap(group => group.items.map(item => item.href)));
+    const orphans = REPORT_QUICK_LINKS.filter(link => !linked.has(link.href));
+
+    expect(orphans.map(o => o.href), 'quick links pointing nowhere').toEqual([]);
+  });
+
+  it('keeps the dashboard shortlist short', () => {
+    // A card reprinting the whole nav is the nav with worse typography. The
+    // dashboard's job is to get someone moving, not to enumerate.
+    expect(REPORT_QUICK_LINKS.length).toBeLessThanOrEqual(4);
   });
 
   it('covers every report page', async () => {

--- a/components/reports/ReportsNav.tsx
+++ b/components/reports/ReportsNav.tsx
@@ -44,3 +44,21 @@ export const REPORT_NAV_TRAILING: NavItem = {
   label: 'What the numbers mean',
   icon: BookOpen,
 };
+
+/**
+ * The handful of reports worth offering from the dashboard.
+ *
+ * Deliberately a shortlist, not the nav: a card that reprints ten destinations
+ * is the nav with worse typography, and the dashboard's job is to get someone
+ * moving, not to enumerate. These four are the questions asked on arrival —
+ * how is today, what needs looking at, how are the games, who is playing.
+ *
+ * Every entry must be a real nav destination; `ReportsNav` tests that, so a
+ * shortcut cannot outlive the page it points at.
+ */
+export const REPORT_QUICK_LINKS: NavItem[] = [
+  { href: '/reports', label: 'Daily Pulse', icon: BarChart3 },
+  { href: '/reports/anomalies', label: 'Needs attention', icon: TriangleAlert },
+  { href: '/reports/games', label: 'Games', icon: LayoutGrid },
+  { href: '/reports/players', label: 'Players', icon: Users },
+];

--- a/components/reports/ReportsNav.tsx
+++ b/components/reports/ReportsNav.tsx
@@ -53,8 +53,9 @@ export const REPORT_NAV_TRAILING: NavItem = {
  * moving, not to enumerate. These four are the questions asked on arrival —
  * how is today, what needs looking at, how are the games, who is playing.
  *
- * Every entry must be a real nav destination; `ReportsNav` tests that, so a
- * shortcut cannot outlive the page it points at.
+ * Every entry must be a real nav destination — enforced in
+ * `components/admin/__tests__/SectionNav.test.tsx`, which owns the guards for
+ * both sections' navs — so a shortcut cannot outlive the page it points at.
  */
 export const REPORT_QUICK_LINKS: NavItem[] = [
   { href: '/reports', label: 'Daily Pulse', icon: BarChart3 },


### PR DESCRIPTION
Issue #1453, item **B1**.

## The problem

The dashboard card for Reports was **disabled**, with a greyed-out "Coming Soon" button — while the section has been live for months with ten pages in it.

That is worse than having no card. A missing card is a gap someone might go looking past; a card that says "Coming Soon" tells people the thing doesn't exist, and they stop looking.

## What it does now

Opens onto the questions someone actually arrives with, rather than one button into a section with ten pages and a menu to work out:

- **Daily Pulse** — how is today
- **Needs attention** — what moved enough to look at
- **Games** — how is each game doing
- **Players** — who is playing

Plus the primary button into the section itself.

## Two properties, both guarded

- **Every shortcut must be a real nav destination.** A shortcut outliving the page it points at is a 404 reached from the front door, and nothing else in the suite would catch it.
- **The shortlist stays short** (≤ 4). A card reprinting the whole nav is the nav with worse typography — the dashboard's job is to get someone moving, not to enumerate.

## Also

The User Hub card advertised "Favourites analytics and user profiles". Favourites moved to Reports in #73, so the card was describing a page that isn't there any more. It now says what User Hub still does, and where favourites went.

## Mutation testing

| Mutation | Result |
|---|---|
| shortcut pointing at a page that doesn't exist | 1 fails |
| let the shortlist become the whole nav | 1 fails |

Suite: 374 passing (57 files). Build and types clean.