### PR TITLE
Show whether a player plays alone or with other people

### DIFF
--- a/app/reports/players/[id]/page.tsx
+++ b/app/reports/players/[id]/page.tsx
@@ -14,6 +14,7 @@ import { ReportsShell } from '@/components/reports/ReportsShell';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useGameColor, useGameMeta } from '@/hooks/use-game-meta';
+import { playStyle } from '@/lib/play-style';
 import { useReport } from '@/hooks/use-report';
 import { useReportFilters } from '@/hooks/use-report-filters';
 import { useAuth } from '@/lib/auth';
@@ -80,6 +81,11 @@ export default function PlayerDetailPage() {
     String(userId),
   );
 
+  // Derived here rather than inside the tile so the tile can be omitted
+  // entirely when the backend hasn't sent a count — a tile reading "—" would
+  // claim we know, and that the answer is none.
+  const style = playStyle(data?.totals.games_played ?? 0, data?.totals.mp_sessions);
+
   return (
     <ReportsShell
       title={data ? data.username : 'Player'}
@@ -137,6 +143,17 @@ export default function PlayerDetailPage() {
                     value={data.totals.games_per_active_day?.toString() ?? '—'}
                     hint="Habit vs one big session"
                   />
+                  {/* Who they play with, which the session count alone cannot
+                      say: the same 41 sessions belong to a solo grinder and to
+                      a lobby regular, and only one of them stops when their
+                      friends do. */}
+                  {style && (
+                    <Tile
+                      label="Play style"
+                      value={style.label ?? '—'}
+                      hint={`${style.mp.toLocaleString()} multiplayer · ${style.solo.toLocaleString()} solo`}
+                    />
+                  )}
                 </div>
 
                 {data.totals.games_played === 0 && (
@@ -197,6 +214,16 @@ export default function PlayerDetailPage() {
                               {' played · '}
                               {row.completion_pct}
                               % finished
+                              {/* Per game, because the split moves: someone can
+                                  be a lobby regular in one game and play the
+                                  rest alone. */}
+                              {row.mp_sessions !== undefined && row.mp_sessions > 0 && (
+                                <>
+                                  {' · '}
+                                  {row.mp_sessions.toLocaleString()}
+                                  {' multiplayer'}
+                                </>
+                              )}
                             </span>
                           </div>
                         ))}

--- a/app/reports/players/[id]/page.tsx
+++ b/app/reports/players/[id]/page.tsx
@@ -216,12 +216,16 @@ export default function PlayerDetailPage() {
                               % finished
                               {/* Per game, because the split moves: someone can
                                   be a lobby regular in one game and play the
-                                  rest alone. */}
-                              {row.mp_sessions !== undefined && row.mp_sessions > 0 && (
+                                  rest alone. A known zero says "all solo" rather
+                                  than nothing — hiding it would make it
+                                  indistinguishable from a field the backend
+                                  never sent. */}
+                              {row.mp_sessions !== undefined && (
                                 <>
                                   {' · '}
-                                  {row.mp_sessions.toLocaleString()}
-                                  {' multiplayer'}
+                                  {row.mp_sessions === 0
+                                    ? 'all solo'
+                                    : `${row.mp_sessions.toLocaleString()} multiplayer`}
                                 </>
                               )}
                             </span>

--- a/app/reports/players/page.tsx
+++ b/app/reports/players/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import type { RangeState } from '@/lib/report-range';
 import { useEffect, useMemo, useState } from 'react';
 import { GameBadge } from '@/components/reports/GameBadge';
+import { PlayStyleBadge } from '@/components/reports/PlayStyleBadge';
 import { ExportButton } from '@/components/reports/ExportButton';
 import { RangePicker } from '@/components/reports/RangePicker';
 import { ReportError } from '@/components/reports/ReportError';
@@ -148,6 +149,8 @@ export default function PlayersReportPage() {
                     { header: 'Username', value: row => row.username },
                     { header: 'Played', value: row => row.games_played },
                     { header: 'Finished', value: row => row.games_finished },
+                    { header: 'Multiplayer sessions', value: row => row.mp_sessions ?? '' },
+                    { header: 'Solo sessions', value: row => (row.mp_sessions === undefined ? '' : row.games_played - row.mp_sessions) },
                     { header: 'Distinct games', value: row => row.distinct_games },
                     { header: 'Games', value: row => row.games.join(' | ') },
                   ]}
@@ -170,6 +173,9 @@ export default function PlayersReportPage() {
                   </CardTitle>
                   <CardDescription>
                     Games played counts sessions started, matching the Daily Pulse.
+                    Multiplayer sessions are included in that total — the Style column
+                    says how much of it they are, which is the difference between a solo
+                    grinder and a lobby regular.
                   </CardDescription>
                 </CardHeader>
                 <CardContent className="overflow-x-auto">
@@ -180,6 +186,7 @@ export default function PlayersReportPage() {
                         <th className="py-2 pr-4 font-medium">Player</th>
                         <th className="py-2 pr-4 text-right font-medium">Played</th>
                         <th className="py-2 pr-4 text-right font-medium">Finished</th>
+                        <th className="py-2 pr-4 font-medium">Style</th>
                         <th className="py-2 font-medium">Games</th>
                       </tr>
                     </thead>
@@ -199,6 +206,9 @@ export default function PlayersReportPage() {
                           </td>
                           <td className="py-2 pr-4 text-right">{player.games_played.toLocaleString()}</td>
                           <td className="py-2 pr-4 text-right">{player.games_finished.toLocaleString()}</td>
+                          <td className="py-2 pr-4">
+                            <PlayStyleBadge played={player.games_played} mp={player.mp_sessions} />
+                          </td>
                           <td className="py-2">
                             <div className="flex flex-wrap gap-1">
                               {player.games.map(playedGame => (

--- a/app/reports/players/page.tsx
+++ b/app/reports/players/page.tsx
@@ -5,6 +5,7 @@ import type { RangeState } from '@/lib/report-range';
 import { useEffect, useMemo, useState } from 'react';
 import { GameBadge } from '@/components/reports/GameBadge';
 import { PlayStyleBadge } from '@/components/reports/PlayStyleBadge';
+import { playStyle } from '@/lib/play-style';
 import { ExportButton } from '@/components/reports/ExportButton';
 import { RangePicker } from '@/components/reports/RangePicker';
 import { ReportError } from '@/components/reports/ReportError';
@@ -149,8 +150,11 @@ export default function PlayersReportPage() {
                     { header: 'Username', value: row => row.username },
                     { header: 'Played', value: row => row.games_played },
                     { header: 'Finished', value: row => row.games_finished },
-                    { header: 'Multiplayer sessions', value: row => row.mp_sessions ?? '' },
-                    { header: 'Solo sessions', value: row => (row.mp_sessions === undefined ? '' : row.games_played - row.mp_sessions) },
+                    // Through the same helper the table uses, so the CSV cannot
+                    // contradict the screen: subtracting the raw count would
+                    // export a negative solo figure the UI clamps away.
+                    { header: 'Multiplayer sessions', value: row => playStyle(row.games_played, row.mp_sessions)?.mp ?? '' },
+                    { header: 'Solo sessions', value: row => playStyle(row.games_played, row.mp_sessions)?.solo ?? '' },
                     { header: 'Distinct games', value: row => row.distinct_games },
                     { header: 'Games', value: row => row.games.join(' | ') },
                   ]}

--- a/components/reports/PlayStyleBadge.tsx
+++ b/components/reports/PlayStyleBadge.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { playStyle } from '@/lib/play-style';
+import { cn } from '@/lib/utils';
+
+/**
+ * Whether a player's sessions were solo or against other people.
+ *
+ * A word rather than a percentage: "63% multiplayer" is a number still waiting
+ * to be interpreted, and a column of them is a column of arithmetic. The exact
+ * figure is in the tooltip and the CSV for anyone who wants it.
+ *
+ * Renders nothing when the backend hasn't sent the count — a dash would read as
+ * "we know, and it's none", which is a different claim from "we don't know".
+ */
+export function PlayStyleBadge({ played, mp }: { played: number; mp?: number }) {
+  const style = playStyle(played, mp);
+  if (!style) {
+    return null;
+  }
+
+  // Multiplayer earns the accent; solo is the ordinary case and stays quiet.
+  // A palette per band would make five colours out of one fact.
+  const emphasised = style.label === 'Multiplayer' || style.label === 'Mostly multiplayer';
+
+  return (
+    <span
+      title={`${style.mp.toLocaleString()} multiplayer · ${style.solo.toLocaleString()} solo (${style.mpPct}%)`}
+      className={cn(
+        'inline-block whitespace-nowrap rounded-full px-2 py-0.5 text-xs font-medium',
+        emphasised
+          ? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200'
+          : 'bg-gray-100 text-gray-600 dark:bg-slate-700/60 dark:text-gray-300',
+      )}
+    >
+      {style.label}
+    </span>
+  );
+}

--- a/components/reports/PlayStyleBadge.tsx
+++ b/components/reports/PlayStyleBadge.tsx
@@ -23,9 +23,15 @@ export function PlayStyleBadge({ played, mp }: { played: number; mp?: number }) 
   // A palette per band would make five colours out of one fact.
   const emphasised = style.label === 'Multiplayer' || style.label === 'Mostly multiplayer';
 
+  // `title` is a hover affordance: unreliable for screen readers and absent on
+  // touch. The same sentence goes in aria-label so the numbers behind the word
+  // are available rather than merely discoverable with a mouse.
+  const breakdown = `${style.label}: ${style.mp.toLocaleString()} multiplayer, ${style.solo.toLocaleString()} solo (${style.mpPct}%)`;
+
   return (
     <span
-      title={`${style.mp.toLocaleString()} multiplayer · ${style.solo.toLocaleString()} solo (${style.mpPct}%)`}
+      title={breakdown}
+      aria-label={breakdown}
       className={cn(
         'inline-block whitespace-nowrap rounded-full px-2 py-0.5 text-xs font-medium',
         emphasised

--- a/components/reports/__tests__/PlayStyleBadge.test.tsx
+++ b/components/reports/__tests__/PlayStyleBadge.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { PlayStyleBadge } from '@/components/reports/PlayStyleBadge';
+
+describe('playStyleBadge', () => {
+  it('exposes the breakdown to assistive tech, not only on hover', () => {
+    // `title` is a hover affordance: unreliable for screen readers, absent on
+    // touch. The numbers behind the word have to be available, not merely
+    // discoverable with a mouse.
+    render(<PlayStyleBadge played={41} mp={35} />);
+    const badge = screen.getByText('Mostly multiplayer');
+
+    expect(badge.getAttribute('aria-label')).toBe('Mostly multiplayer: 35 multiplayer, 6 solo (85.4%)');
+    expect(badge.getAttribute('title')).toBe(badge.getAttribute('aria-label'));
+  });
+
+  it('renders nothing when the backend has not sent a count', () => {
+    // Absent is not zero: a badge reading "Solo" would claim we know.
+    const { container } = render(<PlayStyleBadge played={41} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/lib/__tests__/play-style.test.ts
+++ b/lib/__tests__/play-style.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { playStyle } from '@/lib/play-style';
+
+describe('playStyle', () => {
+  it('derives solo from the total rather than counting it', () => {
+    // The two must sum to what was played; deriving one is the only way that
+    // stays true if the multiplayer count changes.
+    const style = playStyle(41, 35);
+
+    expect(style?.mp).toBe(35);
+    expect(style?.solo).toBe(6);
+    expect(style!.mp + style!.solo).toBe(41);
+  });
+
+  it('calls no multiplayer at all Solo, exactly', () => {
+    // Not "hardly any": a player with one multiplayer session is a different
+    // fact from a player with none, and rounding that away is how a report
+    // starts lying quietly.
+    expect(playStyle(40, 0)?.label).toBe('Solo');
+    expect(playStyle(40, 1)?.label).toBe('Mostly solo');
+  });
+
+  it('calls all multiplayer Multiplayer, exactly', () => {
+    expect(playStyle(40, 40)?.label).toBe('Multiplayer');
+    expect(playStyle(40, 39)?.label).toBe('Mostly multiplayer');
+  });
+
+  it('bands the middle rather than reporting a bare percentage', () => {
+    expect(playStyle(100, 85)?.label).toBe('Mostly multiplayer');
+    expect(playStyle(100, 50)?.label).toBe('Mixed');
+    expect(playStyle(100, 20)?.label).toBe('Mostly solo');
+  });
+
+  it('puts the band edges on the stated side', () => {
+    // 70 and 30 are inclusive on the outer bands, so the boundaries are a
+    // decision rather than an accident of which comparison was typed.
+    expect(playStyle(100, 70)?.label).toBe('Mostly multiplayer');
+    expect(playStyle(100, 69)?.label).toBe('Mixed');
+    expect(playStyle(100, 30)?.label).toBe('Mostly solo');
+    expect(playStyle(100, 31)?.label).toBe('Mixed');
+  });
+
+  it('says nothing when the backend has not sent a count', () => {
+    // Absent is not zero: a backend predating the field would otherwise have
+    // every player labelled Solo.
+    expect(playStyle(40, undefined)).toBeNull();
+  });
+
+  it('says nothing about a player who played nothing', () => {
+    expect(playStyle(0, 0)).toBeNull();
+  });
+
+  it('never reports more multiplayer than was played', () => {
+    // Defensive: the two counts come from separate queries, and a split that
+    // exceeds its total would render a negative solo count.
+    const style = playStyle(10, 12);
+
+    expect(style?.mp).toBe(10);
+    expect(style?.solo).toBe(0);
+  });
+});

--- a/lib/__tests__/play-style.test.ts
+++ b/lib/__tests__/play-style.test.ts
@@ -50,6 +50,16 @@ describe('playStyle', () => {
     expect(playStyle(0, 0)).toBeNull();
   });
 
+  it('clamps the derived pair, which is what the CSV exports too', () => {
+    // The export subtracts through this helper rather than doing its own
+    // arithmetic on the raw field: a negative "Solo sessions" column would
+    // contradict the screen, where the clamp already applies.
+    const style = playStyle(10, 12);
+
+    expect(style!.mp + style!.solo).toBe(10);
+    expect(style!.solo).toBeGreaterThanOrEqual(0);
+  });
+
   it('never reports more multiplayer than was played', () => {
     // Defensive: the two counts come from separate queries, and a split that
     // exceeds its total would render a negative solo count.

--- a/lib/play-style.ts
+++ b/lib/play-style.ts
@@ -1,0 +1,48 @@
+/**
+ * Solo or multiplayer, per player.
+ *
+ * The Players report has always counted multiplayer sessions — a room attaches
+ * each player's session to the game's own table — but it could not show them.
+ * Forty sessions read identically whether they belong to a solo grinder or a
+ * lobby regular, and those are different players: one of them stops when their
+ * friends do.
+ *
+ * Solo is derived from the total rather than counted separately, so the two can
+ * never sum to something other than what was played.
+ */
+
+export type PlayStyle = {
+  mp: number;
+  solo: number;
+  /** Share of sessions played against other people, 0..100. */
+  mpPct: number;
+  /** A word for the split, or null when there is nothing to characterise. */
+  label: 'Multiplayer' | 'Mostly multiplayer' | 'Mixed' | 'Mostly solo' | 'Solo' | null;
+};
+
+/**
+ * Bands, not a gradient: "63% multiplayer" is a number to interpret, and the
+ * point of the label is that it has already been interpreted. The ends are
+ * exact — "Solo" means no multiplayer sessions at all, not "hardly any" —
+ * because a player with one MP session is a different fact from a player with
+ * none, and rounding that away is how a report starts lying quietly.
+ */
+export function playStyle(played: number, mp: number | undefined): PlayStyle | null {
+  if (mp === undefined || played <= 0) {
+    return null;
+  }
+  const bounded = Math.min(Math.max(mp, 0), played);
+  const mpPct = (bounded / played) * 100;
+
+  const label = bounded === 0
+    ? 'Solo'
+    : bounded === played
+      ? 'Multiplayer'
+      : mpPct >= 70
+        ? 'Mostly multiplayer'
+        : mpPct <= 30
+          ? 'Mostly solo'
+          : 'Mixed';
+
+  return { mp: bounded, solo: played - bounded, mpPct: Math.round(mpPct * 10) / 10, label };
+}

--- a/lib/play-style.ts
+++ b/lib/play-style.ts
@@ -16,8 +16,13 @@ export type PlayStyle = {
   solo: number;
   /** Share of sessions played against other people, 0..100. */
   mpPct: number;
-  /** A word for the split, or null when there is nothing to characterise. */
-  label: 'Multiplayer' | 'Mostly multiplayer' | 'Mixed' | 'Mostly solo' | 'Solo' | null;
+  /**
+   * A word for the split. Never null: `playStyle` returns null in its entirety
+   * when there is nothing to characterise, so a style that exists always has a
+   * label, and keeping null in the type would force call sites to handle a case
+   * this cannot produce.
+   */
+  label: 'Multiplayer' | 'Mostly multiplayer' | 'Mixed' | 'Mostly solo' | 'Solo';
 };
 
 /**

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -134,6 +134,12 @@ export type TopPlayer = {
   username: string;
   games_played: number;
   games_finished: number;
+  /**
+   * How many of those sessions were played against other people. Solo is the
+   * difference — derived, never sent, so the two can't disagree with the total.
+   * Optional so a backend predating it shows no split rather than claiming 0.
+   */
+  mp_sessions?: number;
   distinct_games: number;
   games: string[];
 };
@@ -250,6 +256,8 @@ export type PlayerGameRow = {
   games_played: number;
   games_finished: number;
   completion_pct: number;
+  /** Multiplayer sessions in this game. Solo is games_played minus this. */
+  mp_sessions?: number;
 };
 
 export type PlayerDetailResponse = {
@@ -262,6 +270,12 @@ export type PlayerDetailResponse = {
     games_finished: number;
     completion_pct: number | null;
     distinct_games: number;
+    mp_sessions?: number;
+    /**
+     * Share of this player's sessions played against other people. Null when
+     * they played nothing — 0% would claim they played solo.
+     */
+    mp_share_pct?: number | null;
     active_days: number;
     active_days_pct: number | null;
     games_per_active_day: number | null;


### PR DESCRIPTION
Issue #1453, item **B4** (frontend half). Backend: FootballExtraTime/App#1462, already deployed.

## What this shows

The Players report has always *counted* multiplayer sessions — the backend PR established that with measurements against real data — but it could not *show* them. Forty sessions read identically whether they belong to a solo grinder or a lobby regular, and only one of those stops playing when their friends do.

- **Style column** on the ranking
- **Play style tile** on the player detail page
- **Multiplayer count per game**, because the split moves — someone can be a lobby regular in one game and play the rest alone

## A word, not a percentage

"63% multiplayer" is a number still waiting to be interpreted, and a column of them is a column of arithmetic. The bands do the interpreting; the exact figures are in the tooltip and the CSV.

**The ends are exact.** `Solo` means no multiplayer sessions at all, not "hardly any" — one multiplayer session is a different fact from none, and rounding that away is how a report starts lying quietly. Same at the other end.

| Multiplayer share | Label |
|---|---|
| exactly 0 | Solo |
| ≤ 30% | Mostly solo |
| 30–70% | Mixed |
| ≥ 70% | Mostly multiplayer |
| exactly 100% | Multiplayer |

## Absent is not zero

Nothing renders when the backend hasn't sent a count. A dash would claim we know, and that the answer is none — during a deploy window every player would have been labelled Solo.

Solo is **derived** from the total rather than read from a second field, so the two can't sum to something other than what was played. The multiplayer count is clamped to the total as well: the two numbers come from separate queries, and a split exceeding its total would render a negative solo count.

## Mutation testing

| Mutation | Result |
|---|---|
| treat `undefined` as zero | 1 fails |
| let one multiplayer session round to Solo | 1 fails |
| flip the band edges to exclusive | 1 fails |
| drop the clamp on an over-count | 1 fails |

Suite: 404 passing (59 files). Build and types clean.