### PR TITLE
Let the reader choose what the comparison compares against

### DIFF
--- a/app/reports/games/[key]/page.tsx
+++ b/app/reports/games/[key]/page.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { useMemo, useState } from 'react';
 import { ActivityChart } from '@/components/reports/ActivityChart';
+import { ComparePicker } from '@/components/reports/ComparePicker';
 import { ComparisonTiles } from '@/components/reports/ComparisonTiles';
 import { DurationTable } from '@/components/reports/DurationTable';
 import { RangePicker } from '@/components/reports/RangePicker';
@@ -18,7 +19,7 @@ import { useGameMeta, useGameColor } from '@/hooks/use-game-meta';
 import { useReport } from '@/hooks/use-report';
 import { useReportFilters } from '@/hooks/use-report-filters';
 import { useAuth } from '@/lib/auth';
-import { rangeToParams } from '@/lib/report-range';
+import { compareToParams, rangeToParams } from '@/lib/report-range';
 import { ReportsAPI } from '@/lib/reports-api';
 
 function Stat({ label, value, hint }: { label: string; value: string; hint?: string }) {
@@ -52,12 +53,18 @@ export default function GameDetailPage() {
     game: null,
     metric: 'games_started',
   });
-  const { range, includeBots } = filters;
+  const { range, includeBots, compareOffset, compareStart, compareEnd } = filters;
   const setRange = (next: RangeState) => update({ range: next });
   const setIncludeBots = (next: boolean) => update({ includeBots: next });
   const params = useMemo(
-    () => ({ ...rangeToParams(range), include_bots: includeBots, game_type: gameKey , granularity }),
-    [range, includeBots, gameKey, granularity],
+    () => ({
+      ...rangeToParams(range),
+      include_bots: includeBots,
+      game_type: gameKey,
+      granularity,
+      ...compareToParams(compareOffset, compareStart, compareEnd),
+    }),
+    [range, includeBots, gameKey, granularity, compareOffset, compareStart, compareEnd],
   );
 
   const { meta } = useGameMeta(enabled);
@@ -102,6 +109,15 @@ export default function GameDetailPage() {
           ? <Skeleton className="h-32 w-full" />
           : (
               <>
+                {/* The picker sits with the tiles it changes, not up with the
+                    range: it answers "compared with what", which is a question
+                    about these four numbers and nothing else on the page. */}
+                <ComparePicker
+                  offset={compareOffset}
+                  start={compareStart}
+                  end={compareEnd}
+                  onChange={update}
+                />
                 <ComparisonTiles comparison={summary.data.comparison} />
                 {row && (
                   <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">

--- a/components/reports/ComparePicker.tsx
+++ b/components/reports/ComparePicker.tsx
@@ -51,7 +51,11 @@ export function ComparePicker({ offset, start, end, onChange }: {
           key={value}
           size="sm"
           variant={!named && value === offset ? 'default' : 'outline'}
-          onClick={() => onChange({ compareOffset: value })}
+          // The named period must be cleared explicitly. `update` merges
+          // patches, and an explicit period outranks the offset everywhere
+          // downstream — so leaving it set would make this button do nothing
+          // while looking selected.
+          onClick={() => onChange({ compareOffset: value, compareStart: undefined, compareEnd: undefined })}
         >
           {label}
         </Button>
@@ -65,17 +69,24 @@ export function ComparePicker({ offset, start, end, onChange }: {
       >
         <CalendarDays className="mr-1 size-3.5" />
         {named ? `${start} → ${end ?? start}` : 'Specific period'}
-        {named && (
-          <X
-            className="ml-1 size-3"
-            onClick={(event) => {
-              event.stopPropagation();
-              onChange({ compareOffset: offset });
-              setOpen(false);
-            }}
-          />
-        )}
       </Button>
+
+      {/* A real button, not an icon inside one. Nesting it made clearing
+          mouse-only — no tab stop, no name for a screen reader — and a
+          <button> inside a <button> is invalid markup besides. */}
+      {named && (
+        <Button
+          size="sm"
+          variant="ghost"
+          aria-label="Clear the comparison period"
+          onClick={() => {
+            onChange({ compareOffset: offset, compareStart: undefined, compareEnd: undefined });
+            setOpen(false);
+          }}
+        >
+          <X className="size-3.5" />
+        </Button>
+      )}
 
       {open && (
         <div className="flex w-full flex-wrap items-end gap-2 rounded-md border bg-white p-3 dark:border-slate-700 dark:bg-slate-800">

--- a/components/reports/ComparePicker.tsx
+++ b/components/reports/ComparePicker.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useState } from 'react';
+import { CalendarDays, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { isoDay } from '@/lib/report-range';
+
+/** What the offsets are called. Beyond three, the dates say it better. */
+const OFFSETS: { value: number; label: string }[] = [
+  { value: 1, label: 'Previous period' },
+  { value: 2, label: '2 periods back' },
+  { value: 3, label: '3 periods back' },
+];
+
+/**
+ * What the selected range is compared against.
+ *
+ * Against the immediately preceding period alone, a steady decline reads as
+ * flat: every period is a few points down on the one before, and only the one
+ * before that shows the slope. "One bad week" and "a trend" are the same
+ * picture until you can look further back.
+ *
+ * Named periods are the other half — "this month against launch month" is a
+ * question no offset expresses.
+ */
+export function ComparePicker({ offset, start, end, onChange }: {
+  offset: number;
+  start?: string;
+  end?: string;
+  onChange: (next: { compareOffset: number; compareStart?: string; compareEnd?: string }) => void;
+}) {
+  const today = isoDay(new Date());
+  const [open, setOpen] = useState(false);
+  const [draftStart, setDraftStart] = useState(start ?? '');
+  const [draftEnd, setDraftEnd] = useState(end ?? '');
+
+  const named = !!start;
+  // Same rules the API enforces, so a mistake is a disabled button rather than
+  // an error panel. An empty end is allowed: it means a single day.
+  const invalid = !draftStart
+    || draftStart > today
+    || (!!draftEnd && (draftStart > draftEnd || draftEnd > today));
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <span className="text-sm text-gray-600 dark:text-gray-300">Compared with</span>
+
+      {OFFSETS.map(({ value, label }) => (
+        <Button
+          key={value}
+          size="sm"
+          variant={!named && value === offset ? 'default' : 'outline'}
+          onClick={() => onChange({ compareOffset: value })}
+        >
+          {label}
+        </Button>
+      ))}
+
+      <Button
+        size="sm"
+        variant={named ? 'default' : 'outline'}
+        onClick={() => setOpen(!open)}
+        title="Compare against a specific period"
+      >
+        <CalendarDays className="mr-1 size-3.5" />
+        {named ? `${start} → ${end ?? start}` : 'Specific period'}
+        {named && (
+          <X
+            className="ml-1 size-3"
+            onClick={(event) => {
+              event.stopPropagation();
+              onChange({ compareOffset: offset });
+              setOpen(false);
+            }}
+          />
+        )}
+      </Button>
+
+      {open && (
+        <div className="flex w-full flex-wrap items-end gap-2 rounded-md border bg-white p-3 dark:border-slate-700 dark:bg-slate-800">
+          <label htmlFor="compare-start" className="flex flex-col gap-1 text-xs text-gray-600 dark:text-gray-300">
+            From
+            <Input
+              id="compare-start"
+              type="date"
+              value={draftStart}
+              max={draftEnd || today}
+              onChange={event => setDraftStart(event.target.value)}
+              className="h-8 w-40"
+            />
+          </label>
+          <label htmlFor="compare-end" className="flex flex-col gap-1 text-xs text-gray-600 dark:text-gray-300">
+            To
+            <Input
+              id="compare-end"
+              type="date"
+              value={draftEnd}
+              min={draftStart}
+              max={today}
+              onChange={event => setDraftEnd(event.target.value)}
+              className="h-8 w-40"
+            />
+          </label>
+          <Button
+            size="sm"
+            disabled={invalid}
+            onClick={() => {
+              onChange({
+                compareOffset: offset,
+                compareStart: draftStart,
+                compareEnd: draftEnd || undefined,
+              });
+              setOpen(false);
+            }}
+          >
+            Apply
+          </Button>
+          <span className="text-xs text-gray-500 dark:text-gray-400">
+            {invalid
+              ? 'Pick a start date on or before the end date, and not in the future.'
+              : 'A period of a different length shows totals without a percentage — a rate across unequal spans describes the calendar, not the platform.'}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/reports/ComparisonTiles.tsx
+++ b/components/reports/ComparisonTiles.tsx
@@ -25,11 +25,18 @@ const TILES: { key: keyof ActivityMetrics; label: string }[] = [
  * with it would be a caption describing a different chart.
  */
 export function ComparisonTiles({ comparison }: { comparison: PeriodComparison }) {
-  const offset = comparison.compare_offset;
+  // null and undefined mean different things here. `null` is a period the
+  // reader named, which no offset describes. `undefined` is a backend that
+  // predates the field — and that backend always compared with the period
+  // immediately before, so it reads as offset 1 rather than as something
+  // unknown. Conflating them would caption a legacy response "a period you
+  // named", which nobody did.
+  const offset = comparison.compare_offset === undefined ? 1 : comparison.compare_offset;
+  const named = offset === null;
   // "vs previous" was accurate while the comparison was always the preceding
   // period. Now it isn't, and a tile reading "-50% vs previous" against a
   // period three back is the kind of wrong that looks right.
-  const offsetLabel = offset === null || offset === undefined
+  const offsetLabel = named
     ? 'the period shown'
     : offset === 1 ? 'previous' : `${offset} periods back`;
 
@@ -90,7 +97,7 @@ export function ComparisonTiles({ comparison }: { comparison: PeriodComparison }
         {' ('}
         {comparison.previous.days}
         {comparison.previous.days === 1 ? ' day' : ' days'}
-        {offset === null || offset === undefined
+        {named
           ? ', a period you named'
           : offset === 1 ? ', immediately before' : `, ${offset} periods back`}
         {').'}

--- a/components/reports/ComparisonTiles.tsx
+++ b/components/reports/ComparisonTiles.tsx
@@ -13,13 +13,26 @@ const TILES: { key: keyof ActivityMetrics; label: string }[] = [
 ];
 
 /**
- * The selected period against the one before it.
+ * The selected period against an earlier one.
  *
  * Replaces the daily pulse whenever the range doesn't end today: "how is today
  * going" is not an answer to "how did 1–15 June do", and showing it anyway made
  * the date picker look broken.
+ *
+ * The footer states which period was compared, always. The comparison used to
+ * be fixed at "the days immediately before" and said so in fixed text; now that
+ * it can reach further back or name a period outright, text that didn't move
+ * with it would be a caption describing a different chart.
  */
 export function ComparisonTiles({ comparison }: { comparison: PeriodComparison }) {
+  const offset = comparison.compare_offset;
+  // "vs previous" was accurate while the comparison was always the preceding
+  // period. Now it isn't, and a tile reading "-50% vs previous" against a
+  // period three back is the kind of wrong that looks right.
+  const offsetLabel = offset === null || offset === undefined
+    ? 'the period shown'
+    : offset === 1 ? 'previous' : `${offset} periods back`;
+
   return (
     <div className="space-y-2">
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
@@ -49,8 +62,10 @@ export function ComparisonTiles({ comparison }: { comparison: PeriodComparison }
                 >
                   <Icon className="size-3" />
                   {pct === null
-                    ? (metric.previous === 0 ? 'no earlier activity' : 'incomplete data')
-                    : `${pct > 0 ? '+' : ''}${pct}% vs previous`}
+                    ? (comparison.same_length === false
+                        ? 'periods differ in length'
+                        : metric.previous === 0 ? 'no earlier activity' : 'incomplete data')
+                    : `${pct > 0 ? '+' : ''}${pct}% vs ${offsetLabel}`}
                 </span>
                 <p className="pt-1 text-xs text-gray-500 dark:text-gray-400">
                   {metric.previous.toLocaleString()}
@@ -72,9 +87,15 @@ export function ComparisonTiles({ comparison }: { comparison: PeriodComparison }
         {comparison.previous.start}
         {' → '}
         {comparison.previous.end}
-        {' (the '}
+        {' ('}
         {comparison.previous.days}
-        {' days immediately before).'}
+        {comparison.previous.days === 1 ? ' day' : ' days'}
+        {offset === null || offset === undefined
+          ? ', a period you named'
+          : offset === 1 ? ', immediately before' : `, ${offset} periods back`}
+        {').'}
+        {comparison.same_length === false
+          && ' The periods differ in length, so totals are shown without percentages — a rate across unequal spans describes the calendar, not the platform.'}
         {!comparison.coverage.complete
           && ' Percentages are hidden because some days in these periods were never computed — run the reporting backfill to fill them.'}
       </p>

--- a/components/reports/__tests__/ComparePicker.test.tsx
+++ b/components/reports/__tests__/ComparePicker.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { ComparePicker } from '@/components/reports/ComparePicker';
+
+describe('comparePicker', () => {
+  it('clears a named period when an offset is chosen', () => {
+    // The filter patch is merged, and an explicit period outranks the offset
+    // everywhere downstream — so leaving it set makes this button do nothing
+    // while looking selected. Silent, and only visible as "the picker is
+    // broken".
+    const onChange = vi.fn();
+    render(
+      <ComparePicker offset={1} start="2026-01-01" end="2026-01-31" onChange={onChange} />,
+    );
+
+    return userEvent.click(screen.getByRole('button', { name: '2 periods back' })).then(() => {
+      // toStrictEqual, not toHaveBeenCalledWith: the latter treats a missing
+      // key and an explicit `undefined` as equal, so it would pass against a
+      // patch that never cleared anything — which is exactly the bug.
+      expect(onChange.mock.calls[0][0]).toStrictEqual({
+        compareOffset: 2,
+        compareStart: undefined,
+        compareEnd: undefined,
+      });
+    });
+  });
+
+  it('clears the named period from the clear button too', async () => {
+    const onChange = vi.fn();
+    render(
+      <ComparePicker offset={3} start="2026-01-01" end="2026-01-31" onChange={onChange} />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Clear the comparison period' }));
+
+    expect(onChange.mock.calls[0][0]).toStrictEqual({
+      compareOffset: 3,
+      compareStart: undefined,
+      compareEnd: undefined,
+    });
+  });
+
+  it('gives the clear control a name and a tab stop', async () => {
+    // It was an icon nested inside another button: no tab stop, no accessible
+    // name, and invalid markup besides.
+    render(<ComparePicker offset={1} start="2026-01-01" onChange={() => {}} />);
+    const clear = screen.getByRole('button', { name: 'Clear the comparison period' });
+
+    expect(clear.tagName).toBe('BUTTON');
+    await userEvent.tab();
+    expect(document.activeElement).not.toBeNull();
+  });
+
+  it('marks the chosen offset as selected, and not while a period is named', () => {
+    const { rerender } = render(<ComparePicker offset={2} onChange={() => {}} />);
+    expect(screen.getByRole('button', { name: '2 periods back' }).className).toContain('bg-');
+
+    // With a named period, no offset button should read as active — the
+    // comparison isn't using any of them.
+    rerender(<ComparePicker offset={2} start="2026-01-01" onChange={() => {}} />);
+    expect(screen.getByRole('button', { name: /2026-01-01/ })).toBeTruthy();
+  });
+});

--- a/components/reports/__tests__/ComparisonTiles.test.tsx
+++ b/components/reports/__tests__/ComparisonTiles.test.tsx
@@ -1,0 +1,102 @@
+import type { PeriodComparison } from '@/types/reports';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ComparisonTiles } from '@/components/reports/ComparisonTiles';
+
+function metric(current: number, previous: number, pct: number | null) {
+  return { current, previous, change: current - previous, change_pct: pct };
+}
+
+function comparison(over: Partial<PeriodComparison> = {}): PeriodComparison {
+  return {
+    current: { start: '2026-08-08', end: '2026-08-14', days: 7 },
+    previous: { start: '2026-08-01', end: '2026-08-07', days: 7 },
+    compare_offset: 1,
+    same_length: true,
+    coverage: { complete: true, missing_current_days: [], missing_previous_days: [] },
+    metrics: {
+      games_started: metric(200, 400, -50),
+      games_finished: metric(120, 240, -50),
+      distinct_players: metric(30, 40, -25),
+      mp_player_sessions: metric(10, 20, -50),
+    },
+    ...over,
+  };
+}
+
+describe('comparisonTiles', () => {
+  it('says which period it compared against, not just "previous"', () => {
+    // "-50% vs previous" against a period three back is the kind of wrong that
+    // looks right, because the label was written when the comparison could
+    // only ever be the preceding period.
+    render(<ComparisonTiles comparison={comparison({
+      compare_offset: 3,
+      previous: { start: '2026-07-18', end: '2026-07-24', days: 7 },
+    })} />);
+
+    expect(screen.getAllByText(/vs 3 periods back/).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/vs previous$/)).toBeNull();
+  });
+
+  it('still says "previous" for the immediately preceding period', () => {
+    render(<ComparisonTiles comparison={comparison()} />);
+
+    expect(screen.getAllByText(/vs previous/).length).toBeGreaterThan(0);
+  });
+
+  it('describes a named period as one the reader chose', () => {
+    // No offset describes it, and printing "1 period back" would be a lie.
+    render(<ComparisonTiles comparison={comparison({
+      compare_offset: null,
+      previous: { start: '2026-01-01', end: '2026-01-07', days: 7 },
+    })} />);
+
+    expect(screen.getByText(/a period you named/)).toBeTruthy();
+  });
+
+  it('explains a withheld percentage when the periods differ in length', () => {
+    // Without this the tiles read as broken: four numbers and no movement,
+    // with nothing saying why.
+    render(<ComparisonTiles comparison={comparison({
+      same_length: false,
+      previous: { start: '2026-05-01', end: '2026-05-30', days: 30 },
+      metrics: {
+        games_started: metric(200, 900, null),
+        games_finished: metric(120, 540, null),
+        distinct_players: metric(30, 90, null),
+        mp_player_sessions: metric(10, 45, null),
+      },
+    })} />);
+
+    // The TILES must say it, not only the footer: a chip reading "incomplete
+    // data" would send someone to run a backfill that changes nothing. Matched
+    // exactly so the footer sentence can't satisfy this on its own.
+    expect(screen.getAllByText('periods differ in length').length).toBe(4);
+    expect(screen.queryByText('incomplete data')).toBeNull();
+    expect(screen.getByText(/describes the calendar, not the platform/)).toBeTruthy();
+  });
+
+  it('keeps saying "incomplete data" when that is the actual reason', () => {
+    // Two different reasons for a missing percentage; conflating them would
+    // send someone to run a backfill that changes nothing.
+    render(<ComparisonTiles comparison={comparison({
+      coverage: { complete: false, missing_current_days: ['2026-08-10'], missing_previous_days: [] },
+      metrics: {
+        games_started: metric(200, 400, null),
+        games_finished: metric(120, 240, null),
+        distinct_players: metric(30, 40, null),
+        mp_player_sessions: metric(10, 20, null),
+      },
+    })} />);
+
+    expect(screen.getAllByText(/incomplete data/).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/periods differ in length/)).toBeNull();
+  });
+
+  it('falls back to a neutral label when the backend predates the field', () => {
+    const { compare_offset: _dropped, ...legacy } = comparison();
+    render(<ComparisonTiles comparison={legacy as PeriodComparison} />);
+
+    expect(screen.getAllByText(/vs the period shown/).length).toBeGreaterThan(0);
+  });
+});

--- a/components/reports/__tests__/ComparisonTiles.test.tsx
+++ b/components/reports/__tests__/ComparisonTiles.test.tsx
@@ -93,10 +93,15 @@ describe('comparisonTiles', () => {
     expect(screen.queryByText(/periods differ in length/)).toBeNull();
   });
 
-  it('falls back to a neutral label when the backend predates the field', () => {
+  it('reads a backend predating the field as the immediately preceding period', () => {
+    // null and undefined mean different things: null is a period the reader
+    // named, undefined is a backend that only ever compared with the period
+    // before. Conflating them captions a legacy response "a period you named",
+    // which nobody did.
     const { compare_offset: _dropped, ...legacy } = comparison();
     render(<ComparisonTiles comparison={legacy as PeriodComparison} />);
 
-    expect(screen.getAllByText(/vs the period shown/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/vs previous/).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/a period you named/)).toBeNull();
   });
 });

--- a/hooks/use-report-filters.ts
+++ b/hooks/use-report-filters.ts
@@ -26,12 +26,23 @@ export type ReportFilters = {
   limit: number;
   /** Username fragment on the players view. Empty means no filter, not "match nothing". */
   search: string;
+  /**
+   * Which earlier period the summary compares against: 1 is the one immediately
+   * before, 2 the one before that. Ignored when `compare` names explicit dates.
+   */
+  compareOffset: number;
+  /** An explicitly named comparison period, for "this month vs launch month". */
+  compareStart?: string;
+  compareEnd?: string;
 };
 
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
 
 /** MAX_LIMIT in core/reporting_views.py — a larger value is rejected with a 400. */
 const MAX_LIMIT = 100;
+
+/** MAX_COMPARE_OFFSET in core/reporting_queries.py; beyond it the API 400s. */
+const MAX_COMPARE_OFFSET = 12;
 
 /** Only the leaderboard views paginate, so the rest never mention a limit. */
 const DEFAULT_LIMIT = 25;
@@ -63,6 +74,18 @@ function parse(search: string, fallback: ReportFilters): ReportFilters {
     ? rawLimit
     : fallback.limit;
 
+  const rawOffset = Number(params.get('compare_offset'));
+  const compareOffset = Number.isInteger(rawOffset) && rawOffset >= 1 && rawOffset <= MAX_COMPARE_OFFSET
+    ? rawOffset
+    : fallback.compareOffset;
+
+  // Both halves must be shaped like dates before either is used: half a valid
+  // comparison range would send the API a request it rejects, turning a typo in
+  // a shared link into an error panel.
+  const compareStart = params.get('compare_start');
+  const compareEnd = params.get('compare_end');
+  const hasCompare = !!compareStart && ISO_DATE.test(compareStart) && (!compareEnd || ISO_DATE.test(compareEnd));
+
   return {
     range: hasRange ? { window, start, end: end ?? undefined } : { window },
     includeBots: params.get('bots') === '1',
@@ -70,6 +93,9 @@ function parse(search: string, fallback: ReportFilters): ReportFilters {
     metric: (params.get('metric') as MetricKey) || fallback.metric,
     limit,
     search: searchTerm,
+    compareOffset,
+    compareStart: hasCompare ? compareStart : undefined,
+    compareEnd: hasCompare ? (compareEnd ?? undefined) : undefined,
   };
 }
 
@@ -101,6 +127,16 @@ function serialise(filters: ReportFilters, defaults: ReportFilters): string {
   if (filters.search) {
     params.set('search', filters.search);
   }
+  // An explicit comparison period wins, so the offset isn't also written — the
+  // API ignores it there, and a link carrying both would suggest otherwise.
+  if (filters.compareStart) {
+    params.set('compare_start', filters.compareStart);
+    if (filters.compareEnd) {
+      params.set('compare_end', filters.compareEnd);
+    }
+  } else if (filters.compareOffset !== defaults.compareOffset) {
+    params.set('compare_offset', String(filters.compareOffset));
+  }
   const query = params.toString();
   return query ? `?${query}` : '';
 }
@@ -109,9 +145,19 @@ export function useReportFilters(
   // `limit` is optional: only the leaderboard views paginate, and requiring it
   // on the other seven pages would put a number in front of readers that means
   // nothing there.
-  suppliedDefaults: Omit<ReportFilters, 'limit' | 'search'> & { limit?: number; search?: string },
+  suppliedDefaults: Omit<ReportFilters, 'limit' | 'search' | 'compareOffset'> & {
+    limit?: number;
+    search?: string;
+    compareOffset?: number;
+  },
 ) {
-  const defaults: ReportFilters = { limit: DEFAULT_LIMIT, search: '', ...suppliedDefaults };
+  const defaults: ReportFilters = {
+    limit: DEFAULT_LIMIT,
+    search: '',
+    // Only the summary compares periods; the other pages never mention it.
+    compareOffset: 1,
+    ...suppliedDefaults,
+  };
   const [filters, setFilters] = useState<ReportFilters>(defaults);
   const [hydrated, setHydrated] = useState(false);
 

--- a/lib/__tests__/report-filters.test.ts
+++ b/lib/__tests__/report-filters.test.ts
@@ -11,6 +11,7 @@ const defaults = {
   metric: 'games_started' as const,
   limit: 25,
   search: '',
+  compareOffset: 1,
 };
 
 describe('report filter URL state', () => {
@@ -66,6 +67,38 @@ describe('report filter URL state', () => {
 
     expect(parsed.game).toBe('grid');
     expect(parsed.includeBots).toBe(true);
+  });
+
+  it('carries a chosen comparison offset, and drops it when it is the default', () => {
+    // Only the summary compares periods, so the other pages never mention it.
+    expect(__test.serialise({ ...defaults, compareOffset: 3 }, defaults)).toBe('?compare_offset=3');
+    expect(__test.serialise({ ...defaults, compareOffset: 1 }, defaults)).toBe('');
+    expect(__test.parse('?compare_offset=3', defaults).compareOffset).toBe(3);
+  });
+
+  it('falls back to the default for an offset the API would reject', () => {
+    // A shared link with a typo should degrade to the default view rather than
+    // to an error panel.
+    for (const bad of ['0', '-2', '13', 'lots', '1.5']) {
+      expect(__test.parse(`?compare_offset=${bad}`, defaults).compareOffset).toBe(1);
+    }
+  });
+
+  it('carries an explicitly named comparison period instead of the offset', () => {
+    // The API ignores the offset when explicit dates are given, so a link
+    // carrying both would suggest otherwise.
+    const named = { ...defaults, compareOffset: 4, compareStart: '2026-01-01', compareEnd: '2026-01-31' };
+
+    expect(__test.serialise(named, defaults)).toBe('?compare_start=2026-01-01&compare_end=2026-01-31');
+    expect(__test.parse('?compare_start=2026-01-01&compare_end=2026-01-31', defaults)).toMatchObject({
+      compareStart: '2026-01-01',
+      compareEnd: '2026-01-31',
+    });
+  });
+
+  it('ignores half a comparison range rather than sending a request the API rejects', () => {
+    expect(__test.parse('?compare_start=nonsense&compare_end=2026-01-31', defaults).compareStart).toBeUndefined();
+    expect(__test.parse('?compare_start=2026-01-01&compare_end=nonsense', defaults).compareStart).toBeUndefined();
   });
 });
 

--- a/lib/__tests__/report-range.test.ts
+++ b/lib/__tests__/report-range.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { activePreset, isoDay, rangeToParams, yesterdayRange } from '@/lib/report-range';
+import { activePreset, compareToParams, isoDay, rangeToParams, yesterdayRange } from '@/lib/report-range';
 
 describe('isoDay', () => {
   it('formats the LOCAL date, not the UTC one', () => {
@@ -91,5 +91,28 @@ describe('activePreset', () => {
     // yesterday — which is correct, and only knowable because both sides read
     // the clock the caller passed.
     expect(activePreset(range, new Date(2026, 7, 14, 0, 0, 1))).toBe('custom');
+  });
+});
+
+describe('compareToParams', () => {
+  it('omits the default offset rather than sending it', () => {
+    // An unchanged default has no business in a request or in a shared URL.
+    expect(compareToParams(1)).toEqual({});
+  });
+
+  it('sends an offset that was actually chosen', () => {
+    expect(compareToParams(3)).toEqual({ compare_offset: 3 });
+  });
+
+  it('drops the offset when explicit dates are given', () => {
+    // The API ignores it there, so sending both would imply it still applied.
+    expect(compareToParams(4, '2026-01-01', '2026-01-31')).toEqual({
+      compare_start: '2026-01-01',
+      compare_end: '2026-01-31',
+    });
+  });
+
+  it('treats a start with no end as a single day', () => {
+    expect(compareToParams(1, '2026-01-01')).toEqual({ compare_start: '2026-01-01' });
   });
 });

--- a/lib/report-range.ts
+++ b/lib/report-range.ts
@@ -66,3 +66,22 @@ export function activePreset(range: RangeState, today: Date): 'today' | 'yesterd
 export function rangeToParams(range: RangeState): ReportParams {
   return range.start ? { start: range.start, end: range.end } : { window: range.window };
 }
+
+/**
+ * Query params for the comparison the summary should make.
+ *
+ * Explicit dates win, exactly as the BE resolves them — sending both would
+ * imply the offset still applied, and it doesn't. The default offset is
+ * omitted rather than sent as 1: an unchanged default has no business in a
+ * request or in a shared URL.
+ */
+export function compareToParams(
+  compareOffset: number,
+  compareStart?: string,
+  compareEnd?: string,
+): { compare_offset?: number; compare_start?: string; compare_end?: string } {
+  if (compareStart) {
+    return { compare_start: compareStart, ...(compareEnd ? { compare_end: compareEnd } : {}) };
+  }
+  return compareOffset === 1 ? {} : { compare_offset: compareOffset };
+}

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -86,6 +86,18 @@ export type MetricComparison = {
 export type PeriodComparison = {
   current: { start: string; end: string; days: number };
   previous: { start: string; end: string; days: number };
+  /**
+   * How many periods back the comparison reached: 1 is the one immediately
+   * before. Null when a period was named outright, which no offset describes.
+   * Optional so a backend predating it reads as the old always-1 behaviour.
+   */
+  compare_offset?: number | null;
+  /**
+   * False when the two periods differ in length. Their totals still compare;
+   * their percentages don't — a rate across unequal spans describes the
+   * calendar rather than the platform, so `change_pct` is withheld.
+   */
+  same_length?: boolean;
   coverage: {
     complete: boolean;
     missing_current_days: string[];


### PR DESCRIPTION
Issue #1453, item **B3** (frontend half). Backend: FootballExtraTime/App#1463. Every field is optional, so this is safe to ship before that deploys — the tiles simply read as they did before.

## Why

The tiles could only ever show the selected range against the period **immediately before it**. Against that alone, a steady decline reads as flat: every period is a few points down on the one before, and only the one before *that* shows the slope.

## The picker

Previous period · 2 back · 3 back · or a period named outright. It sits **with the tiles**, not up with the range picker, because it answers "compared with what" — a question about those four numbers and nothing else on the page.

## The tiles now say what they used

`-50% vs previous` against a period three back is the kind of wrong that looks right. The label was written when the comparison could only ever be the preceding period, so it now reads `vs 3 periods back`, or *"a period you named"* when dates were given — no offset describes that, and printing "1 period back" would be a lie.

**Two different reasons for a missing percentage, kept apart:**

| Reason | Chip |
|---|---|
| periods differ in length | `periods differ in length` |
| days never computed | `incomplete data` |

Conflating them would send someone to run a backfill that changes nothing.

## URL state

Selection lives in the URL like every other filter, and **degrades rather than errors**: an offset outside 1–12, or half a date range, falls back to the default instead of sending the API a request it rejects — a typo in a shared link should land on the default view, not an error panel.

The default offset is never sent (an unchanged default has no business in a request or a shared URL), and explicit dates *replace* it rather than accompany it, since the API ignores the offset there.

## Mutation testing

| Mutation | Result |
|---|---|
| hardcode the label to "previous" | 1 fails |
| report a named period as an offset | 1 fails |
| show a length mismatch as "incomplete data" | 1 fails |
| send the default offset | 1 fails |
| send explicit dates *and* the offset | 2 fail |

**Three of those initially survived.** The length-mismatch test was matching the footer sentence rather than the tile chips — so the chips could have said anything — and `compareToParams` had no tests at all. Both fixed before this went up.

Suite: 410 passing (59 files). Build and types clean.