### PR TITLE
Show which games keep people, not just whether the platform does

### DIFF
--- a/app/reports/retention/page.tsx
+++ b/app/reports/retention/page.tsx
@@ -8,6 +8,7 @@ import { GameFilter } from '@/components/reports/GameFilter';
 import { RangePicker } from '@/components/reports/RangePicker';
 import { ReportError } from '@/components/reports/ReportError';
 import { ReportsShell } from '@/components/reports/ReportsShell';
+import { RetentionByGame } from '@/components/reports/RetentionByGame';
 import { RetentionTable } from '@/components/reports/RetentionTable';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useGameMeta } from '@/hooks/use-game-meta';
@@ -90,7 +91,15 @@ export default function RetentionPage() {
         ? <ReportError error={error} notDeployed={notDeployed} onRetry={refetch} />
         : isLoading || !data
           ? <Skeleton className="h-96 w-full" />
-          : <RetentionTable data={data} />}
+          : (
+              <>
+                {/* Before the cohort grid: "which games keep people" is the
+                    question someone arrives with, and the grid answers "which
+                    days did". */}
+                <RetentionByGame data={data} meta={meta} />
+                <RetentionTable data={data} />
+              </>
+            )}
     </ReportsShell>
   );
 }

--- a/components/reports/RetentionByGame.tsx
+++ b/components/reports/RetentionByGame.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import type { GameMetaMap } from '@/hooks/use-game-meta';
+import type { RetentionResponse, RetentionSummaryCell } from '@/types/reports';
+import { GameBadge } from '@/components/reports/GameBadge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+function cell(row: Record<string, unknown>, key: string): RetentionSummaryCell | null {
+  const value = row[key];
+  return value && typeof value === 'object' ? (value as RetentionSummaryCell) : null;
+}
+
+/**
+ * Which games keep people.
+ *
+ * The platform figure says whether the site keeps players; it cannot say what
+ * they came back to. A game with a strong first day and nothing after it is a
+ * different problem from a game nobody starts, and one average across eleven
+ * games hides both.
+ *
+ * Each game is measured on its OWN cohorts — players whose first day in that
+ * game was X, returning to that game — so this is not a decomposition of the
+ * platform number and does not sum to it.
+ */
+export function RetentionByGame({ data, meta }: { data: RetentionResponse; meta: GameMetaMap }) {
+  const rows = data.by_game ?? [];
+  if (rows.length === 0) {
+    return null;
+  }
+
+  const offsets = data.offsets.map(offset => `d${offset}`);
+  const median = data.game_median ?? {};
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Which games keep people</CardTitle>
+        <CardDescription>
+          Each game measured on its own players: of those whose first day in it was X, how
+          many came back to
+          {' '}
+          <em>it</em>
+          . Best keeper first. These don't sum to the platform figure above — that one counts
+          a return to any game, from a different set of cohorts, so a game can sit either
+          side of it.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b text-left text-gray-600 dark:border-slate-700 dark:text-gray-300">
+              <th className="py-2 pr-4 font-medium">Game</th>
+              {offsets.map(key => (
+                <th key={key} className="py-2 pr-4 text-right font-medium uppercase">{key}</th>
+              ))}
+              <th className="py-2 text-right font-medium">Players</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => {
+              const players = cell(row, offsets[0])?.players ?? 0;
+              return (
+                <tr key={row.game_type} className="border-b last:border-0 dark:border-slate-700">
+                  <td className="py-2 pr-4">
+                    <GameBadge gameKey={row.game_type} meta={meta} />
+                  </td>
+                  {offsets.map((key) => {
+                    const value = cell(row, key);
+                    const pct = value?.pct ?? null;
+                    const peer = median[key];
+                    // Above or below its peers, which is the only reference
+                    // this data can defend. No colour where there is no peer
+                    // median to compare with.
+                    const above = pct !== null && peer !== null && peer !== undefined && pct > peer;
+                    const below = pct !== null && peer !== null && peer !== undefined && pct < peer;
+                    return (
+                      <td key={key} className="py-2 pr-4 text-right tabular-nums">
+                        {pct === null
+                          ? (
+                              <span
+                                className="text-gray-400 dark:text-gray-500"
+                                title={value?.below_threshold
+                                  ? `Only ${value.players} players — too few to state a rate`
+                                  : 'No cohort has reached this offset yet'}
+                              >
+                                —
+                              </span>
+                            )
+                          : (
+                              <span className={cn(
+                                above ? 'text-emerald-700 dark:text-emerald-400' : '',
+                                below ? 'text-amber-700 dark:text-amber-400' : '',
+                              )}
+                              >
+                                {pct}
+                                %
+                              </span>
+                            )}
+                      </td>
+                    );
+                  })}
+                  <td className="py-2 text-right tabular-nums text-gray-500 dark:text-gray-400">
+                    {players.toLocaleString()}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+          <tfoot>
+            <tr className="text-gray-500 dark:text-gray-400">
+              <td className="py-2 pr-4 text-xs">Median across games</td>
+              {offsets.map(key => (
+                <td key={key} className="py-2 pr-4 text-right text-xs tabular-nums">
+                  {median[key] === null || median[key] === undefined ? '—' : `${median[key]}%`}
+                </td>
+              ))}
+              <td />
+            </tr>
+          </tfoot>
+        </table>
+        <p className="mt-3 text-xs text-gray-500 dark:text-gray-400">
+          {`A dash means no rate could be stated: either no cohort has reached that offset yet, or the game had fewer than ${data.min_players ?? 20} measurable players — one of three returning is 33%, which beside a game with hundreds reads as a finding rather than as noise.`}
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/reports/RetentionByGame.tsx
+++ b/components/reports/RetentionByGame.tsx
@@ -1,14 +1,21 @@
 'use client';
 
 import type { GameMetaMap } from '@/hooks/use-game-meta';
-import type { RetentionResponse, RetentionSummaryCell } from '@/types/reports';
+import type { RetentionGameRow, RetentionResponse, RetentionSummaryCell } from '@/types/reports';
 import { GameBadge } from '@/components/reports/GameBadge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
 
-function cell(row: Record<string, unknown>, key: string): RetentionSummaryCell | null {
-  const value = row[key];
-  return value && typeof value === 'object' ? (value as RetentionSummaryCell) : null;
+/**
+ * One offset's cell, or null when the backend didn't send that offset.
+ *
+ * The lookup is by a string built from `offsets`, so it has to be widened to
+ * the row's key type — and the null branch is real: a response can list an
+ * offset the rows don't carry, and reading `undefined.pct` would blank the
+ * whole table rather than one cell.
+ */
+function cell(row: RetentionGameRow, key: string): RetentionSummaryCell | null {
+  return row[key as `d${number}`] ?? null;
 }
 
 /**
@@ -59,7 +66,14 @@ export function RetentionByGame({ data, meta }: { data: RetentionResponse; meta:
           </thead>
           <tbody>
             {rows.map((row) => {
-              const players = cell(row, offsets[0])?.players ?? 0;
+              // The first offset the row actually carries, not the first one
+              // listed: they are the same set today, and a row missing the
+              // leading offset would otherwise report a cohort of zero for a
+              // game that has players.
+              const players = offsets.reduce<number>(
+                (found, key) => found || (cell(row, key)?.players ?? 0),
+                0,
+              );
               return (
                 <tr key={row.game_type} className="border-b last:border-0 dark:border-slate-700">
                   <td className="py-2 pr-4">

--- a/components/reports/__tests__/RetentionByGame.test.tsx
+++ b/components/reports/__tests__/RetentionByGame.test.tsx
@@ -1,0 +1,84 @@
+import type { RetentionResponse } from '@/types/reports';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { RetentionByGame } from '@/components/reports/RetentionByGame';
+
+const META = {
+  scout: { key: 'scout', label: 'Scout Game Sessions', display_name: 'Scout', color: '#4338ca' },
+  career_path: { key: 'career_path', label: 'CareerPath Game Sessions', display_name: 'Career Path', color: '#6d28d9' },
+  quiz: { key: 'quiz', label: 'Quizzes Played', display_name: 'Quiz', color: '#3b82f6' },
+};
+
+function summaryCell(pct: number | null, players: number, below = false) {
+  return { cohorts_measured: 4, players, returned: 0, pct, ...(below ? { below_threshold: true } : {}) };
+}
+
+function data(over: Partial<RetentionResponse> = {}): RetentionResponse {
+  return {
+    basis: 'first session within the selected range (not first ever)',
+    first_cohort_inflated: false,
+    offsets: [1, 7, 30],
+    summary: { d1: summaryCell(14.2, 226), d7: summaryCell(5.3, 226), d30: summaryCell(0, 226) },
+    cohorts: [],
+    by_game: [
+      { game_type: 'scout', d1: summaryCell(6.1, 33), d7: summaryCell(12.1, 33), d30: summaryCell(0, 33) },
+      { game_type: 'career_path', d1: summaryCell(15.9, 88), d7: summaryCell(1.1, 88), d30: summaryCell(0, 88) },
+      { game_type: 'quiz', d1: summaryCell(null, 3, true), d7: summaryCell(null, 3, true), d30: summaryCell(null, 3, true) },
+    ],
+    min_players: 20,
+    game_median: { d1: 11, d7: 6.6, d30: 0 },
+    start: '2026-06-15',
+    end: '2026-08-13',
+    days: 60,
+    window: 60,
+    game_type: null,
+    include_bots: false,
+    ...over,
+  } as RetentionResponse;
+}
+
+describe('retentionByGame', () => {
+  it('shows each game measured on its own players', () => {
+    // The finding the platform average hides: Career Path has a strong first
+    // day and nothing after it, which is a different problem from a game
+    // nobody starts.
+    render(<RetentionByGame data={data()} meta={META as never} />);
+
+    expect(screen.getByText('12.1%')).toBeTruthy();
+    expect(screen.getByText('15.9%')).toBeTruthy();
+    expect(screen.getByText('1.1%')).toBeTruthy();
+  });
+
+  it('says these do not decompose the platform figure', () => {
+    // Scout's 12.1% sits ABOVE a platform 5.3%: the cohorts are different
+    // people, so treating one as a share of the other is arithmetic between
+    // two questions.
+    render(<RetentionByGame data={data()} meta={META as never} />);
+
+    expect(screen.getByText(/don't sum to the platform figure/)).toBeTruthy();
+  });
+
+  it('withholds a rate for too small a sample and explains the dash', () => {
+    render(<RetentionByGame data={data()} meta={META as never} />);
+
+    const dashes = screen.getAllByText('—');
+    expect(dashes.length).toBeGreaterThan(0);
+    expect(dashes[0].getAttribute('title')).toBe('Only 3 players — too few to state a rate');
+    expect(screen.getByText(/fewer than 20 measurable players/)).toBeTruthy();
+  });
+
+  it('carries the peer median as the reference, not the platform number', () => {
+    render(<RetentionByGame data={data()} meta={META as never} />);
+
+    expect(screen.getByText('Median across games')).toBeTruthy();
+    expect(screen.getByText('6.6%')).toBeTruthy();
+  });
+
+  it('renders nothing when the backend predates the per-game view', () => {
+    // The platform table still stands on its own; a blank card would read as
+    // a failure.
+    const { container } = render(<RetentionByGame data={data({ by_game: undefined })} meta={META as never} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/components/reports/__tests__/RetentionByGame.test.tsx
+++ b/components/reports/__tests__/RetentionByGame.test.tsx
@@ -74,6 +74,28 @@ describe('retentionByGame', () => {
     expect(screen.getByText('6.6%')).toBeTruthy();
   });
 
+  it('renders a dash for an offset the rows do not carry', () => {
+    // The response lists which offsets exist; a row can still be missing one.
+    // Reading through it must blank that cell, not the whole table.
+    render(<RetentionByGame data={data({
+      offsets: [1, 7, 30, 90],
+      game_median: { d1: 11, d7: 6.6, d30: 0, d90: null },
+    })} meta={META as never} />);
+
+    expect(screen.getByText('12.1%')).toBeTruthy();
+    expect(screen.getAllByText('—').length).toBeGreaterThan(3);
+  });
+
+  it('reads the cohort size from whichever offset the row carries', () => {
+    // Taking it from the first offset LISTED would report a cohort of zero for
+    // a game that plainly has players, because the row need not carry that one.
+    render(<RetentionByGame data={data({
+      by_game: [{ game_type: 'scout', d7: summaryCell(12.1, 33), d30: summaryCell(0, 33) }],
+    })} meta={META as never} />);
+
+    expect(screen.getByText('33')).toBeTruthy();
+  });
+
   it('renders nothing when the backend predates the per-game view', () => {
     // The platform table still stands on its own; a blank card would read as
     // a failure.

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -390,10 +390,17 @@ export type RetentionSummaryCell = {
   below_threshold?: boolean;
 };
 
-/** One game's own retention: its cohorts, its returns. */
+/**
+ * One game's own retention: its cohorts, its returns.
+ *
+ * Keyed by offset (`d1`, `d7`, `d30`) and optional, because which offsets are
+ * present follows `offsets` in the response. A plain `Record<string, …>` would
+ * claim every string key exists and admit any field at all, so a typo'd offset
+ * would type-check and read as missing data at runtime.
+ */
 export type RetentionGameRow = {
   game_type: string;
-} & Record<string, RetentionSummaryCell | string>;
+} & Partial<Record<`d${number}`, RetentionSummaryCell>>;
 
 export type RetentionResponse = {
   /** States what "new" means here — a window return rate, not lifetime retention. */

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -382,7 +382,18 @@ export type RetentionSummaryCell = {
   players: number;
   returned: number;
   pct: number | null;
+  /**
+   * True when the sample is too small to state a rate. The counts are still
+   * reported — only the percentage is withheld, because "1 of 3 came back" is
+   * 33% and reads as a finding beside a game with 400 players.
+   */
+  below_threshold?: boolean;
 };
+
+/** One game's own retention: its cohorts, its returns. */
+export type RetentionGameRow = {
+  game_type: string;
+} & Record<string, RetentionSummaryCell | string>;
 
 export type RetentionResponse = {
   /** States what "new" means here — a window return rate, not lifetime retention. */
@@ -391,6 +402,21 @@ export type RetentionResponse = {
   offsets: number[];
   summary: Record<string, RetentionSummaryCell>;
   cohorts: RetentionCohort[];
+  /**
+   * Per-game retention, best keeper first. A game's cohort is players whose
+   * first day in THAT game was X, returning to THAT game — a different question
+   * from the platform summary, which counts a return to anything.
+   * Optional so a backend predating it renders the platform view alone.
+   */
+  by_game?: RetentionGameRow[];
+  /** Players a game needs before its rate is stated rather than withheld. */
+  min_players?: number;
+  /**
+   * The median across games, per offset — the reference a game should be read
+   * against. Not the platform figure: that counts different cohorts and
+   * different returns, so a game can sit either side of it.
+   */
+  game_median?: Record<string, number | null>;
 } & ResolvedRange;
 
 export type DurationRow = {


### PR DESCRIPTION
Issue #1453, item **C1** (frontend half). Backend: FootballExtraTime/App#1464.

## The finding this makes visible

Retention answered *"does the site keep players"*. It could not say **what they came back to**.

On dev data (illustrative, not production):

| | D1 | D7 |
|---|---|---|
| Platform | 14.2% | 5.3% |
| Scout | 6.1% | **12.1%** |
| Career Path | **15.9%** | **1.1%** |

**Career Path is a hook that leads nowhere** — a strong first day and almost nothing after it. That is a completely different problem from a game nobody starts, and both were invisible inside a single platform average.

## These do not decompose the platform number

The card says so, in the description. Each game is measured on its **own** cohorts — players whose first day in *that* game was X, returning to *that* game. So a game can sit either side of the platform figure, and Scout does: 12.1% D7 against a platform 5.3%, because a player's first Scout day usually isn't their first day on the site.

Treating one as a share of the other would be arithmetic between two questions.

## Reference and dashes

- **Colour marks a game against the median of its peers**, not against the platform figure — the only reference this data can defend. No colour where there's no peer median.
- **A withheld rate is a dash with the reason on hover**: too small a sample (fewer than 20 measurable players), or no cohort old enough to have reached that offset. Those are different facts, and rendering either as `0%` would be a number nobody measured.

## Degradation

Needs App#1464. Without it the card renders **nothing at all** rather than an empty shell, and the platform cohort table still stands on its own.

## Mutation testing

| Mutation | Result |
|---|---|
| render a withheld rate as `0%` | 1 fails |
| drop the explanation behind the dash | 1 fails |
| render the card with no per-game data | 1 fails |

Suite: 430 passing (63 files). Build and types clean.