### PR TITLE
Show session length as a shape, not a single number

### DIFF
--- a/app/reports/duration/page.tsx
+++ b/app/reports/duration/page.tsx
@@ -2,6 +2,7 @@
 
 import type { RangeState } from '@/lib/report-range';
 import { useMemo, useState } from 'react';
+import { DurationHistogram } from '@/components/reports/DurationHistogram';
 import { DurationTable } from '@/components/reports/DurationTable';
 import { ExportButton } from '@/components/reports/ExportButton';
 import { RangePicker } from '@/components/reports/RangePicker';
@@ -77,7 +78,14 @@ export default function DurationPage() {
         ? <ReportError error={error} notDeployed={notDeployed} onRetry={refetch} />
         : isLoading || !data
           ? <Skeleton className="h-80 w-full" />
-          : <DurationTable data={data} meta={meta} />}
+          : (
+              <>
+                <DurationTable data={data} meta={meta} />
+                {/* After the comparison, because "which game holds attention"
+                    comes before "what does this one look like". */}
+                <DurationHistogram data={data} meta={meta} />
+              </>
+            )}
     </ReportsShell>
   );
 }

--- a/components/reports/DurationHistogram.tsx
+++ b/components/reports/DurationHistogram.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import type { GameMetaMap } from '@/hooks/use-game-meta';
+import type { DurationResponse } from '@/types/reports';
+import { useState } from 'react';
+import { GameBadge } from '@/components/reports/GameBadge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { gameName, useGameColor } from '@/hooks/use-game-meta';
+import { durationHistogram } from '@/lib/duration-histogram';
+
+/**
+ * How one game's session lengths are distributed.
+ *
+ * The table says where the middle half sits; this says what the whole shape
+ * looks like — one hump, two, or a long tail. Conquest's tail is the clearest
+ * case on the platform: 401 sessions past six hours against 156 below, which is
+ * its idle sweeper rather than anything a player did.
+ *
+ * One game at a time on purpose. Eleven overlaid distributions is a picture
+ * nobody reads, and the question here is "what does THIS game look like".
+ */
+export function DurationHistogram({ data, meta }: { data: DurationResponse; meta: GameMetaMap }) {
+  const resolveColor = useGameColor();
+  const measurable = data.rows.filter(row => row.supported && row.measured > 0 && (row.buckets?.length ?? 0) > 0);
+  const [selected, setSelected] = useState<string | null>(null);
+
+  if (measurable.length === 0) {
+    return null;
+  }
+
+  const row = measurable.find(candidate => candidate.game_type === selected) ?? measurable[0];
+  const bands = durationHistogram(row);
+  const max = Math.max(...bands.map(band => band.count), 1);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Session length, distributed</CardTitle>
+        <CardDescription>
+          {`How ${gameName(meta[row.game_type], row.game_type)}'s ${row.measured.toLocaleString()} measured sessions spread out. `}
+          A median tells you the middle; this tells you whether there is one kind of session or several.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex flex-wrap gap-1">
+          {measurable.map(candidate => (
+            <GameBadge
+              key={candidate.game_type}
+              gameKey={candidate.game_type}
+              meta={meta}
+              active={candidate.game_type === row.game_type}
+              onClick={key => setSelected(key)}
+            />
+          ))}
+        </div>
+
+        <ul className="space-y-1.5">
+          {bands.map(band => (
+            <li key={band.label} className="flex items-center gap-3 text-sm">
+              <span className="w-28 shrink-0 text-right text-xs text-gray-600 dark:text-gray-300">{band.label}</span>
+              <span className="h-2.5 flex-1 overflow-hidden rounded-full bg-gray-100 dark:bg-slate-700">
+                <span
+                  className="block h-full rounded-full"
+                  style={{
+                    width: `${(band.count / max) * 100}%`,
+                    backgroundColor: resolveColor(meta, row.game_type),
+                  }}
+                />
+              </span>
+              <span className="w-16 shrink-0 text-right text-xs tabular-nums text-gray-500 dark:text-gray-400">
+                {band.count.toLocaleString()}
+              </span>
+              <span className="w-12 shrink-0 text-right text-xs tabular-nums text-gray-400 dark:text-gray-500">
+                {band.pct}
+                %
+              </span>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/reports/DurationHistogram.tsx
+++ b/components/reports/DurationHistogram.tsx
@@ -21,7 +21,14 @@ import { durationHistogram } from '@/lib/duration-histogram';
  */
 export function DurationHistogram({ data, meta }: { data: DurationResponse; meta: GameMetaMap }) {
   const resolveColor = useGameColor();
-  const measurable = data.rows.filter(row => row.supported && row.measured > 0 && (row.buckets?.length ?? 0) > 0);
+  // Summed counts, not just "has bands": a row whose bands are all zero would
+  // put a chip in the selector and then draw an empty card, which reads as a
+  // broken chart. The backend's bands sum to `measured` today, so this can only
+  // trigger on a response that breaks that — which is exactly when a component
+  // should not be relying on the invariant.
+  const measurable = data.rows.filter(
+    row => row.supported && (row.buckets ?? []).reduce((sum, bucket) => sum + bucket.count, 0) > 0,
+  );
   const [selected, setSelected] = useState<string | null>(null);
 
   if (measurable.length === 0) {

--- a/components/reports/DurationSpread.tsx
+++ b/components/reports/DurationSpread.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import type { DurationRow } from '@/types/reports';
+import { formatDuration } from '@/lib/format-duration';
+
+/**
+ * The shape of a game's session lengths, in one row.
+ *
+ * A median is one number and says nothing about spread. Scout's median session
+ * is 6.8 minutes and its p90 is 10.8 days; Team Ties sits between 3.3 and 7.3
+ * minutes at the quartiles. Both reported "a few minutes", and only one of them
+ * is a few-minute game.
+ *
+ * The bar is the interquartile range — where the middle half of sessions live —
+ * with the median marked inside it. Not a box plot: whiskers and outlier dots
+ * need a legend to read, and this has to work as a table cell, at a glance,
+ * beside ten other games.
+ */
+export function DurationSpread({ row }: { row: DurationRow }) {
+  const { p25_seconds: p25, p75_seconds: p75, median_seconds: median, p90_seconds: p90 } = row;
+
+  if (p25 === null || p25 === undefined || p75 === null || p75 === undefined || median === null) {
+    return <span className="text-xs text-gray-400 dark:text-gray-500">—</span>;
+  }
+
+  // Scaled against p90 rather than the longest session: one abandoned session
+  // left open for a week would squash every game's bar to a sliver, and the
+  // shape is the point of the control.
+  const scale = Math.max(p90 ?? p75, p75, 1);
+  const pct = (value: number) => Math.min(100, Math.max(0, (value / scale) * 100));
+  const left = pct(p25);
+  const width = Math.max(1.5, pct(p75) - left);
+
+  return (
+    <span
+      className="flex items-center gap-2"
+      title={`25% of sessions under ${formatDuration(p25)} · half under ${formatDuration(median)} · 75% under ${formatDuration(p75)} · 90% under ${formatDuration(p90 ?? null)}`}
+    >
+      <span className="relative h-1.5 w-24 shrink-0 overflow-hidden rounded-full bg-gray-100 dark:bg-slate-700">
+        <span
+          className="absolute inset-y-0 rounded-full bg-gray-300 dark:bg-slate-500"
+          style={{ left: `${left}%`, width: `${width}%` }}
+        />
+        {/* The median inside the range, because "the middle half runs 3–7
+            minutes" and "the middle is at 4" are different facts and a reader
+            needs both to judge whether the median represents anything. */}
+        <span
+          className="absolute inset-y-0 w-0.5 bg-gray-900 dark:bg-white"
+          style={{ left: `${Math.min(99, pct(median))}%` }}
+        />
+      </span>
+      <span className="whitespace-nowrap text-xs tabular-nums text-gray-500 dark:text-gray-400">
+        {formatDuration(p25)}
+        {'–'}
+        {formatDuration(p75)}
+      </span>
+    </span>
+  );
+}

--- a/components/reports/DurationTable.tsx
+++ b/components/reports/DurationTable.tsx
@@ -7,6 +7,7 @@ import { Info } from 'lucide-react';
 import { ExportButton } from '@/components/reports/ExportButton';
 import { GameBadge } from '@/components/reports/GameBadge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { DurationSpread } from '@/components/reports/DurationSpread';
 import { formatDuration } from '@/lib/format-duration';
 import { longSessionReason } from '@/lib/long-session-reason';
 import { cn } from '@/lib/utils';
@@ -54,6 +55,10 @@ export function DurationTable({ data, meta }: { data: DurationResponse; meta: Ga
           </div>
         </div>
       </td>
+      {/* Where the middle half of sessions actually sit. The median beside it
+          is one number, and two games with the same median can be a tight
+          five-minute game and a sprawl. */}
+      <td className="py-2 pr-4"><DurationSpread row={row} /></td>
       <td className="py-2 pr-4 text-right tabular-nums">{formatDuration(row.p90_seconds)}</td>
       <td className="py-2 pr-4 text-right tabular-nums">{row.measured.toLocaleString()}</td>
       <td className="py-2 text-right">
@@ -116,6 +121,7 @@ export function DurationTable({ data, meta }: { data: DurationResponse; meta: Ga
       <tr className="border-b text-left text-gray-600 dark:border-slate-700 dark:text-gray-300">
         <th className="py-2 pr-4 font-medium">Game</th>
         <th className="py-2 pr-4 font-medium">Median</th>
+        <th className="py-2 pr-4 font-medium" title="Where the middle half of sessions sit — p25 to p75, median marked">Middle half</th>
         <th className="py-2 pr-4 text-right font-medium">p90</th>
         <th className="py-2 pr-4 text-right font-medium">Sessions</th>
         <th className="py-2 text-right font-medium">Coverage</th>
@@ -146,7 +152,9 @@ export function DurationTable({ data, meta }: { data: DurationResponse; meta: Ga
             filters={{ start: data.start, end: data.end }}
             columns={[
               { header: 'Game', value: row => row.game_type },
+              { header: 'p25 seconds', value: row => row.p25_seconds ?? '' },
               { header: 'Median seconds', value: row => row.median_seconds },
+              { header: 'p75 seconds', value: row => row.p75_seconds ?? '' },
               { header: 'p90 seconds', value: row => row.p90_seconds },
               { header: 'Sessions measured', value: row => row.measured },
               { header: 'Finished sessions', value: row => row.sessions },

--- a/components/reports/__tests__/DurationHistogram.test.tsx
+++ b/components/reports/__tests__/DurationHistogram.test.tsx
@@ -1,0 +1,78 @@
+import type { DurationResponse, DurationRow } from '@/types/reports';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { DurationHistogram } from '@/components/reports/DurationHistogram';
+
+const META = {
+  team_ties: { key: 'team_ties', label: 'Team Ties Game Sessions', display_name: 'Team Ties', color: '#0d9488' },
+  grid: { key: 'grid', label: 'Grid Game Sessions', display_name: 'Grid', color: '#f97316' },
+};
+
+function row(over: Partial<DurationRow>): DurationRow {
+  return {
+    game_type: 'team_ties',
+    supported: true,
+    reason: null,
+    sessions: 100,
+    measured: 100,
+    coverage_pct: 100,
+    median_seconds: 300,
+    p90_seconds: 900,
+    long_sessions: 0,
+    long_sessions_pct: 0,
+    single_sitting: true,
+    buckets: [
+      { under_seconds: 60, count: 10 },
+      { under_seconds: 120, count: 60 },
+      { under_seconds: null, count: 30 },
+    ],
+    ...over,
+  } as DurationRow;
+}
+
+function data(rows: DurationRow[]): DurationResponse {
+  return {
+    long_session_seconds: 21600,
+    games_without_duration: [],
+    long_lived_session_games: [],
+    longest_single_sitting_game: null,
+    rows,
+    start: '2026-07-15',
+    end: '2026-08-13',
+    days: 30,
+    window: 30,
+    game_type: null,
+    include_bots: false,
+  } as DurationResponse;
+}
+
+describe('durationHistogram card', () => {
+  it('draws the bands for the first measurable game', () => {
+    render(<DurationHistogram data={data([row({})])} meta={META as never} />);
+
+    expect(screen.getByText('under 1.0m')).toBeTruthy();
+    expect(screen.getByText('over 2.0m')).toBeTruthy();
+  });
+
+  it('skips a game whose bands are all empty rather than drawing a blank card', () => {
+    // A chip in the selector leading to an empty list reads as a broken chart.
+    // The backend's bands sum to `measured` today, so this only triggers on a
+    // response that breaks that — which is exactly when a component should not
+    // be trusting the invariant.
+    const empty = row({
+      game_type: 'grid',
+      buckets: [{ under_seconds: 60, count: 0 }, { under_seconds: null, count: 0 }],
+    });
+    render(<DurationHistogram data={data([empty, row({})])} meta={META as never} />);
+
+    expect(screen.getByText('Team Ties')).toBeTruthy();
+    expect(screen.queryByText('Grid')).toBeNull();
+  });
+
+  it('renders nothing when no game has anything to draw', () => {
+    const empty = row({ buckets: [{ under_seconds: null, count: 0 }] });
+    const { container } = render(<DurationHistogram data={data([empty])} meta={META as never} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/components/reports/__tests__/DurationSpread.test.tsx
+++ b/components/reports/__tests__/DurationSpread.test.tsx
@@ -1,0 +1,72 @@
+import type { DurationRow } from '@/types/reports';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { DurationSpread } from '@/components/reports/DurationSpread';
+
+function row(over: Partial<DurationRow>): DurationRow {
+  return {
+    game_type: 'team_ties',
+    supported: true,
+    reason: null,
+    sessions: 100,
+    measured: 100,
+    coverage_pct: 100,
+    median_seconds: 312,
+    p90_seconds: 577,
+    p25_seconds: 197,
+    p75_seconds: 436,
+    long_sessions: 0,
+    long_sessions_pct: 0,
+    single_sitting: true,
+    ...over,
+  } as DurationRow;
+}
+
+describe('durationSpread', () => {
+  it('shows where the middle half of sessions sit', () => {
+    render(<DurationSpread row={row({})} />);
+
+    expect(screen.getByText('3.3m–7.3m')).toBeTruthy();
+  });
+
+  it('names every percentile behind the bar', () => {
+    // The bar is a shape; someone comparing two games needs the numbers.
+    const { container } = render(<DurationSpread row={row({})} />);
+
+    expect(container.firstElementChild?.getAttribute('title'))
+      .toBe('25% of sessions under 3.3m · half under 5.2m · 75% under 7.3m · 90% under 9.6m');
+  });
+
+  it('scales against p90, so a sprawling game does not look like a tight one', () => {
+    // Scaled to p75, every game's bar would end at the right edge and they
+    // would all look identical — which destroys the only thing this control is
+    // for. Scout's middle half runs to 28 minutes with a tail of days; Team
+    // Ties' runs to seven minutes. Those must not draw the same.
+    const tight = render(<DurationSpread row={row({})} />);
+    const tightWidth = tight.container.querySelector('span[style*="width"]')?.getAttribute('style');
+
+    const sprawl = render(
+      <DurationSpread row={row({ p25_seconds: 186, median_seconds: 411, p75_seconds: 1726, p90_seconds: 931565 })} />,
+    );
+    const sprawlWidth = sprawl.container.querySelector('span[style*="width"]')?.getAttribute('style');
+
+    const percent = (style?: string | null) => Number(/width: ([\d.]+)%/.exec(style ?? '')?.[1] ?? 0);
+
+    expect(percent(tightWidth)).toBeGreaterThan(percent(sprawlWidth));
+    expect(percent(sprawlWidth)).toBeLessThan(5);
+  });
+
+  it('draws nothing but a dash when the backend predates the quartiles', () => {
+    // A bar drawn from a median alone would be a shape with no data behind it
+    // — worse than an obvious gap, because it looks measured.
+    render(<DurationSpread row={row({ p25_seconds: undefined, p75_seconds: undefined })} />);
+
+    expect(screen.getByText('—')).toBeTruthy();
+  });
+
+  it('draws a dash for a game with no median at all', () => {
+    render(<DurationSpread row={row({ median_seconds: null })} />);
+
+    expect(screen.getByText('—')).toBeTruthy();
+  });
+});

--- a/lib/__tests__/duration-histogram.test.ts
+++ b/lib/__tests__/duration-histogram.test.ts
@@ -48,11 +48,25 @@ describe('durationHistogram', () => {
     expect(durationHistogram(row(BANDS))[3].label).toBe('over 5.0m');
   });
 
-  it('computes each share against the total, so they sum to 100', () => {
+  it('computes each share against the total', () => {
     const bands = durationHistogram(row(BANDS));
 
     expect(bands.map(b => b.pct)).toEqual([10, 20, 40, 30]);
-    expect(bands.reduce((sum, b) => sum + b.pct, 0)).toBe(100);
+  });
+
+  it('rounds each band on its own, even when the column then misses 100', () => {
+    // Three equal bands are 33.3% each and total 99.9%. Nudging one of them to
+    // 33.4% would buy a tidy total at the cost of a figure its own count
+    // doesn't support — and a reader checking 33.3% against 1 of 3 would find
+    // the adjusted one wrong. This is a shape, not a budget.
+    const bands = durationHistogram(row([
+      { under_seconds: 60, count: 1 },
+      { under_seconds: 120, count: 1 },
+      { under_seconds: null, count: 1 },
+    ]));
+
+    expect(bands.map(b => b.pct)).toEqual([33.3, 33.3, 33.3]);
+    expect(bands.reduce((sum, b) => sum + b.pct, 0)).toBeCloseTo(99.9, 5);
   });
 
   it('has nothing to draw when nothing was measured', () => {

--- a/lib/__tests__/duration-histogram.test.ts
+++ b/lib/__tests__/duration-histogram.test.ts
@@ -1,0 +1,67 @@
+import type { DurationRow } from '@/types/reports';
+import { describe, expect, it } from 'vitest';
+import { durationHistogram } from '@/lib/duration-histogram';
+
+function row(buckets: DurationRow['buckets']): DurationRow {
+  return {
+    game_type: 'team_ties',
+    supported: true,
+    reason: null,
+    sessions: 100,
+    measured: 100,
+    coverage_pct: 100,
+    median_seconds: 300,
+    p90_seconds: 900,
+    long_sessions: 0,
+    long_sessions_pct: 0,
+    single_sitting: true,
+    buckets,
+  } as DurationRow;
+}
+
+const BANDS = [
+  { under_seconds: 60, count: 10 },
+  { under_seconds: 120, count: 20 },
+  { under_seconds: 300, count: 40 },
+  { under_seconds: null, count: 30 },
+];
+
+describe('durationHistogram', () => {
+  it('labels the first band as an upper bound only', () => {
+    // "0s–1m" is noise; nothing starts before zero.
+    expect(durationHistogram(row(BANDS))[0].label).toBe('under 1.0m');
+  });
+
+  it('labels middle bands from the boundary before them', () => {
+    // The labels come from the boundaries the backend sent, not a parallel
+    // list here — a second copy would drift the first time a boundary moved
+    // and the chart would be confidently mislabelled rather than obviously
+    // broken.
+    const bands = durationHistogram(row(BANDS));
+
+    expect(bands[1].label).toBe('1.0m–2.0m');
+    expect(bands[2].label).toBe('2.0m–5.0m');
+  });
+
+  it('labels the open-ended band from the last boundary', () => {
+    // This is where a 24-hour session lands, and it must not claim a ceiling.
+    expect(durationHistogram(row(BANDS))[3].label).toBe('over 5.0m');
+  });
+
+  it('computes each share against the total, so they sum to 100', () => {
+    const bands = durationHistogram(row(BANDS));
+
+    expect(bands.map(b => b.pct)).toEqual([10, 20, 40, 30]);
+    expect(bands.reduce((sum, b) => sum + b.pct, 0)).toBe(100);
+  });
+
+  it('has nothing to draw when nothing was measured', () => {
+    // Zero counts across every band would otherwise divide by zero and render
+    // NaN% on every row.
+    expect(durationHistogram(row([{ under_seconds: 60, count: 0 }, { under_seconds: null, count: 0 }]))).toEqual([]);
+  });
+
+  it('has nothing to draw for a backend that predates the bands', () => {
+    expect(durationHistogram(row(undefined))).toEqual([]);
+  });
+});

--- a/lib/duration-histogram.ts
+++ b/lib/duration-histogram.ts
@@ -1,0 +1,49 @@
+/**
+ * Session-length bands, ready to draw.
+ *
+ * The backend sends counts per band with the last one open-ended
+ * (`under_seconds: null`). Turning those into labels is the part worth testing:
+ * a band mislabelled by one boundary describes a different game, and the chart
+ * gives no hint that it happened.
+ */
+
+import type { DurationRow } from '@/types/reports';
+import { formatDuration } from '@/lib/format-duration';
+
+export type HistogramBand = {
+  /** "1–2m", "over 6h" — what the band covers, in words. */
+  label: string;
+  count: number;
+  /** Share of measured sessions, 0..100. */
+  pct: number;
+};
+
+/**
+ * Bands with human labels and shares.
+ *
+ * Labels come from the boundaries the backend chose, not from a parallel list
+ * here: a second copy would drift the first time a boundary moved, and the
+ * chart would be confidently mislabelled rather than obviously broken.
+ */
+export function durationHistogram(row: DurationRow): HistogramBand[] {
+  const buckets = row.buckets ?? [];
+  const total = buckets.reduce((sum, bucket) => sum + bucket.count, 0);
+  if (total === 0) {
+    return [];
+  }
+
+  let previous: number | null = null;
+  return buckets.map((bucket) => {
+    const label = bucket.under_seconds === null
+      ? `over ${formatDuration(previous ?? 0)}`
+      : previous === null
+        ? `under ${formatDuration(bucket.under_seconds)}`
+        : `${formatDuration(previous)}–${formatDuration(bucket.under_seconds)}`;
+    previous = bucket.under_seconds;
+    return {
+      label,
+      count: bucket.count,
+      pct: Math.round((bucket.count / total) * 1000) / 10,
+    };
+  });
+}

--- a/lib/duration-histogram.ts
+++ b/lib/duration-histogram.ts
@@ -14,7 +14,15 @@ export type HistogramBand = {
   /** "1–2m", "over 6h" — what the band covers, in words. */
   label: string;
   count: number;
-  /** Share of measured sessions, 0..100. */
+  /**
+   * This band's share of measured sessions, rounded on its own.
+   *
+   * Deliberately NOT adjusted to make the column total exactly 100: each figure
+   * is the honest rounding of its own band, so a reader can check 12.5% against
+   * the count beside it. Shifting a remainder into the last band would buy a
+   * tidy total at the cost of one band saying something its own numbers don't
+   * support — and this is a shape, not a budget.
+   */
   pct: number;
 };
 

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -437,6 +437,20 @@ export type DurationRow = {
   coverage_pct: number | null;
   median_seconds: number | null;
   p90_seconds: number | null;
+  /**
+   * The quartiles either side of the median. Half of all sessions fall between
+   * them, so "5 minutes" reads very differently at 4–6 than at 1–40.
+   * Optional so a backend predating them shows the median alone.
+   */
+  p25_seconds?: number | null;
+  p75_seconds?: number | null;
+  /**
+   * Session lengths per band, over fixed boundaries. Per-band counts, not
+   * cumulative — they sum to `measured`. The final band has `under_seconds:
+   * null`: everything past the last boundary, which is where a 24-hour session
+   * lands.
+   */
+  buckets?: { under_seconds: number | null; count: number }[];
   long_sessions: number;
   long_sessions_pct: number | null;
   /** False for campaign-shaped games whose "session" spans a day, not a sitting. */


### PR DESCRIPTION
Issue #1453, item **C2** (frontend half). Backend: FootballExtraTime/App#1465, merged.

## Why

| Game | p25 | median | p75 | p90 |
|---|---|---|---|---|
| Scout | 3.1m | **6.8m** | 28.8m | **10.8 days** |
| Team Ties | 3.3m | **5.2m** | 7.3m | 9.6m |

Both read as "a few minutes" in a median column. Only one of them is a few-minute game.

## Two additions

**A "middle half" column** — the interquartile range as a bar, median marked inside it. Deliberately not a box plot: whiskers and outlier dots need a legend, and this has to be readable as a table cell beside ten other games.

It scales against **p90**, and both halves of that choice matter:
- not against the longest session — one abandoned session left open for a week would squash every game's bar to a sliver;
- not against p75 — every bar would then end at the right edge and they'd all look identical, which destroys the comparison the column exists for. There's a test asserting a sprawling game and a tight one don't draw the same.

**A distribution card**, one game at a time. Eleven overlaid histograms is a picture nobody reads, and the question is "what does *this* game look like". Conquest is the clearest case on the platform: 401 sessions past six hours against 156 below — its idle sweeper (A5), visible as shape.

## Labels come from the data

Band labels are derived from the boundaries the backend sends, never from a parallel list in the frontend. A second copy would drift the first time a boundary moved, and the chart would be **confidently mislabelled rather than obviously broken**. The open-ended band reads "over 6h" and never invents a ceiling.

## Mutation testing

| Mutation | Result |
|---|---|
| open band claims a ceiling ("under 6h") | 1 fails |
| labels off by one boundary | 3 fail |
| shares computed against the max instead of the total | 1 fails |
| draw a bar with no quartiles | 1 fails |
| scale the bar to p75 | 1 fails |

**The last two needed tests written for them.** `DurationSpread` had no test file of its own, so neither its legacy-backend path nor its scale choice was covered — both mutations passed silently until I added one.

Suite: 443 passing (65 files). Build and types clean.