### PR TITLE
Make a game's own page answer more than "how much"

### DIFF
--- a/app/reports/games/[key]/page.tsx
+++ b/app/reports/games/[key]/page.tsx
@@ -9,7 +9,10 @@ import { useMemo, useState } from 'react';
 import { ActivityChart } from '@/components/reports/ActivityChart';
 import { ComparePicker } from '@/components/reports/ComparePicker';
 import { ComparisonTiles } from '@/components/reports/ComparisonTiles';
+import { DurationHistogram } from '@/components/reports/DurationHistogram';
 import { DurationTable } from '@/components/reports/DurationTable';
+import { GameHourProfile } from '@/components/reports/GameHourProfile';
+import { GameRetentionCard } from '@/components/reports/GameRetentionCard';
 import { RangePicker } from '@/components/reports/RangePicker';
 import { ReportError } from '@/components/reports/ReportError';
 import { ReportsShell } from '@/components/reports/ReportsShell';
@@ -72,6 +75,17 @@ export default function GameDetailPage() {
   const summary = useReport(ReportsAPI.getSummary, params, ready, 'The reporting summary endpoint');
   const activity = useReport(ReportsAPI.getActivity, params, ready, 'The reporting activity endpoint');
   const duration = useReport(ReportsAPI.getDuration, params, ready, 'The duration reporting endpoint');
+  // Deliberately UNFILTERED: one call carries both this game's row and the
+  // median across the others, and the peer median is the only reference this
+  // number can be read against. A game-filtered call would return a median of
+  // one game — itself.
+  const retention = useReport(
+    ReportsAPI.getRetention,
+    useMemo(() => ({ ...rangeToParams(range), include_bots: includeBots }), [range, includeBots]),
+    ready,
+    'The retention reporting endpoint',
+  );
+  const patterns = useReport(ReportsAPI.getPatterns, params, ready, 'The patterns reporting endpoint');
   const players = useReport(
     ReportsAPI.getTopPlayers,
     useMemo(() => ({ ...params, limit: 10 }), [params]),
@@ -157,7 +171,19 @@ export default function GameDetailPage() {
         />
       )}
 
+      {retention.data && (
+        <GameRetentionCard data={retention.data} gameKey={gameKey} gameLabel={label} />
+      )}
+
+      {patterns.data && <GameHourProfile data={patterns.data} gameLabel={label} />}
+
       {duration.data && <DurationTable data={duration.data} meta={meta} />}
+
+      {/* Same data as the table above, drawn as a shape: the table says where
+          the middle half sits, this says whether there is one kind of session
+          here or several. No extra request — the response is already filtered
+          to this game. */}
+      {duration.data && <DurationHistogram data={duration.data} meta={meta} />}
 
       {players.data && (
         <Card>

--- a/components/reports/GameHourProfile.tsx
+++ b/components/reports/GameHourProfile.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import type { PatternsResponse } from '@/types/reports';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+/**
+ * When this game is played, across the day.
+ *
+ * Shown as each hour's share of the game's own play, not as raw counts: a
+ * popular game and a quiet one have the same shape question, and counts would
+ * make every small game look flat. The point is the skew — a lunchtime game and
+ * an evening game want different things from a release schedule.
+ */
+export function GameHourProfile({ data, gameLabel }: { data: PatternsResponse; gameLabel: string }) {
+  const hours = data.by_hour ?? [];
+  const total = hours.reduce((sum, hour) => sum + hour.games_started, 0);
+  if (total === 0) {
+    return null;
+  }
+
+  const max = Math.max(...hours.map(hour => hour.games_started), 1);
+  const peak = hours.reduce((best, hour) => (hour.games_started > best.games_started ? hour : best), hours[0]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">When it's played</CardTitle>
+        <CardDescription>
+          {`${gameLabel}'s own play across the day, in ${data.timezone}. Busiest hour: `}
+          <strong>
+            {`${String(peak.hour).padStart(2, '0')}:00`}
+          </strong>
+          {`, ${Math.round((peak.games_started / total) * 100)}% of its sessions start in that hour.`}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="flex h-24 items-end gap-0.5">
+          {hours.map(hour => (
+            <div
+              key={hour.hour}
+              className="flex-1"
+              title={`${String(hour.hour).padStart(2, '0')}:00 — ${hour.games_started.toLocaleString()} sessions (${Math.round((hour.games_started / total) * 100)}%)`}
+            >
+              <div
+                className="w-full rounded-sm bg-emerald-500/80 dark:bg-emerald-500/70"
+                style={{ height: `${Math.max(2, (hour.games_started / max) * 96)}px` }}
+              />
+            </div>
+          ))}
+        </div>
+        <div className="mt-1 flex justify-between text-[10px] text-gray-400 dark:text-gray-500">
+          <span>00:00</span>
+          <span>06:00</span>
+          <span>12:00</span>
+          <span>18:00</span>
+          <span>23:00</span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/reports/GameHourProfile.tsx
+++ b/components/reports/GameHourProfile.tsx
@@ -34,20 +34,27 @@ export function GameHourProfile({ data, gameLabel }: { data: PatternsResponse; g
         </CardDescription>
       </CardHeader>
       <CardContent>
-        <div className="flex h-24 items-end gap-0.5">
-          {hours.map(hour => (
-            <div
-              key={hour.hour}
-              className="flex-1"
-              title={`${String(hour.hour).padStart(2, '0')}:00 — ${hour.games_started.toLocaleString()} sessions (${Math.round((hour.games_started / total) * 100)}%)`}
-            >
-              <div
-                className="w-full rounded-sm bg-emerald-500/80 dark:bg-emerald-500/70"
-                style={{ height: `${Math.max(2, (hour.games_started / max) * 96)}px` }}
-              />
-            </div>
-          ))}
-        </div>
+        {/* Labelled per bar, the way the heatmap and the multiplayer funnel
+            already are. `title` is a hover affordance: unreliable for screen
+            readers and absent on touch, so the numbers behind each bar have to
+            be in the accessibility tree rather than only under a mouse. */}
+        <ul
+          className="flex h-24 items-end gap-0.5"
+          aria-label={`${gameLabel} sessions by hour, ${data.timezone}`}
+        >
+          {hours.map((hour) => {
+            const label = `${String(hour.hour).padStart(2, '0')}:00 — ${hour.games_started.toLocaleString()} sessions (${Math.round((hour.games_started / total) * 100)}%)`;
+            return (
+              <li key={hour.hour} className="flex-1" title={label} aria-label={label}>
+                <div
+                  className="w-full rounded-sm bg-emerald-500/80 dark:bg-emerald-500/70"
+                  style={{ height: `${Math.max(2, (hour.games_started / max) * 96)}px` }}
+                  aria-hidden
+                />
+              </li>
+            );
+          })}
+        </ul>
         <div className="mt-1 flex justify-between text-[10px] text-gray-400 dark:text-gray-500">
           <span>00:00</span>
           <span>06:00</span>

--- a/components/reports/GameRetentionCard.tsx
+++ b/components/reports/GameRetentionCard.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import type { RetentionGameRow, RetentionResponse, RetentionSummaryCell } from '@/types/reports';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+function cell(row: RetentionGameRow, key: string): RetentionSummaryCell | null {
+  return row[key as `d${number}`] ?? null;
+}
+
+/**
+ * Does this game keep the people who try it?
+ *
+ * Read against the median of the other games rather than against the platform
+ * figure. The platform number counts a return to anything, from cohorts defined
+ * by a player's first day anywhere, so a game can sit either side of it —
+ * comparing to it would be arithmetic between two questions.
+ */
+export function GameRetentionCard({ data, gameKey, gameLabel }: {
+  data: RetentionResponse;
+  gameKey: string;
+  gameLabel: string;
+}) {
+  const row = data.by_game?.find(candidate => candidate.game_type === gameKey);
+  if (!row) {
+    return null;
+  }
+
+  const median = data.game_median ?? {};
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Does it keep people?</CardTitle>
+        <CardDescription>
+          {`Of the players whose first ${gameLabel} day was X, how many came back to it. `}
+          Compared with the median across games — not the platform figure, which counts a
+          return to any game and answers a different question.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          {data.offsets.map((offset) => {
+            const key = `d${offset}`;
+            const value = cell(row, key);
+            const pct = value?.pct ?? null;
+            const peer = median[key];
+            const hasPeer = peer !== null && peer !== undefined;
+            const delta = pct !== null && hasPeer ? Math.round((pct - peer) * 10) / 10 : null;
+
+            return (
+              <div key={key}>
+                <p className="text-sm font-medium text-gray-600 dark:text-gray-300">
+                  {`Day ${offset}`}
+                </p>
+                <p className="text-3xl font-bold text-gray-900 dark:text-white">
+                  {pct === null ? '—' : `${pct}%`}
+                </p>
+                <p className="text-xs text-gray-500 dark:text-gray-400">
+                  {pct === null
+                    ? (value?.below_threshold
+                        ? `only ${value.players} players — too few to state a rate`
+                        : 'no cohort has reached this day yet')
+                    : (
+                        <>
+                          {value?.players.toLocaleString()}
+                          {' players · '}
+                          {hasPeer
+                            ? (
+                                <span className={cn(
+                                  delta! > 0 ? 'text-emerald-700 dark:text-emerald-400' : '',
+                                  delta! < 0 ? 'text-amber-700 dark:text-amber-400' : '',
+                                )}
+                                >
+                                  {delta! > 0 ? '+' : ''}
+                                  {delta}
+                                  {' vs median '}
+                                  {peer}
+                                  %
+                                </span>
+                              )
+                            : 'no peer median to compare with'}
+                        </>
+                      )}
+                </p>
+              </div>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/reports/__tests__/GameHourProfile.test.tsx
+++ b/components/reports/__tests__/GameHourProfile.test.tsx
@@ -1,0 +1,55 @@
+import type { PatternsResponse } from '@/types/reports';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { GameHourProfile } from '@/components/reports/GameHourProfile';
+
+function hours(counts: Partial<Record<number, number>>) {
+  return Array.from({ length: 24 }, (_, hour) => ({ hour, games_started: counts[hour] ?? 0 }));
+}
+
+function data(over: Partial<PatternsResponse> = {}): PatternsResponse {
+  return {
+    timezone: 'Europe/Sofia',
+    by_hour: hours({ 12: 10, 20: 40, 21: 30, 22: 20 }),
+    by_weekday: [],
+    by_hour_weekday: [],
+    peak_cell: null,
+    busiest_cell_games: 0,
+    peak_hour: 20,
+    peak_weekday: null,
+    new_vs_returning: [],
+    start: '2026-07-15',
+    end: '2026-08-13',
+    days: 30,
+    window: 30,
+    game_type: 'grid',
+    include_bots: false,
+    ...over,
+  } as PatternsResponse;
+}
+
+describe('gameHourProfile', () => {
+  it('names the busiest hour and its share of the game\'s own play', () => {
+    // Share, not raw count: a popular game and a quiet one have the same shape
+    // question, and counts would make every small game look flat.
+    render(<GameHourProfile data={data()} gameLabel="Grid" />);
+
+    expect(screen.getByText('20:00')).toBeTruthy();
+    expect(screen.getByText(/40% of its sessions start in that hour/)).toBeTruthy();
+  });
+
+  it('states the timezone the hours are in', () => {
+    // "8pm" means nothing without it, and the platform buckets in Sofia time.
+    render(<GameHourProfile data={data()} gameLabel="Grid" />);
+
+    expect(screen.getByText(/Europe\/Sofia/)).toBeTruthy();
+  });
+
+  it('renders nothing for a game with no play in the window', () => {
+    // An all-zero chart is 24 empty bars and a peak hour of midnight — a
+    // confident-looking answer to a question with no data behind it.
+    const { container } = render(<GameHourProfile data={data({ by_hour: hours({}) })} gameLabel="Grid" />);
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/components/reports/__tests__/GameHourProfile.test.tsx
+++ b/components/reports/__tests__/GameHourProfile.test.tsx
@@ -45,6 +45,16 @@ describe('gameHourProfile', () => {
     expect(screen.getByText(/Europe\/Sofia/)).toBeTruthy();
   });
 
+  it('puts each hour\'s numbers in the accessibility tree, not only in a tooltip', () => {
+    // `title` is a hover affordance: unreliable for screen readers, absent on
+    // touch. The heatmap and the multiplayer funnel already label their marks;
+    // this matches them.
+    render(<GameHourProfile data={data()} gameLabel="Grid" />);
+
+    expect(screen.getByLabelText('20:00 — 40 sessions (40%)')).toBeTruthy();
+    expect(screen.getByLabelText('Grid sessions by hour, Europe/Sofia')).toBeTruthy();
+  });
+
   it('renders nothing for a game with no play in the window', () => {
     // An all-zero chart is 24 empty bars and a peak hour of midnight — a
     // confident-looking answer to a question with no data behind it.

--- a/components/reports/__tests__/GameRetentionCard.test.tsx
+++ b/components/reports/__tests__/GameRetentionCard.test.tsx
@@ -1,0 +1,72 @@
+import type { RetentionResponse } from '@/types/reports';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { GameRetentionCard } from '@/components/reports/GameRetentionCard';
+
+function summaryCell(pct: number | null, players: number, below = false) {
+  return { cohorts_measured: 4, players, returned: 0, pct, ...(below ? { below_threshold: true } : {}) };
+}
+
+function data(over: Partial<RetentionResponse> = {}): RetentionResponse {
+  return {
+    basis: 'first session within the selected range (not first ever)',
+    first_cohort_inflated: false,
+    offsets: [1, 7, 30],
+    summary: { d1: summaryCell(14.2, 226), d7: summaryCell(5.3, 226), d30: summaryCell(0, 226) },
+    cohorts: [],
+    by_game: [
+      { game_type: 'scout', d1: summaryCell(6.1, 33), d7: summaryCell(12.1, 33), d30: summaryCell(null, 33) },
+      { game_type: 'quiz', d1: summaryCell(null, 4, true), d7: summaryCell(null, 4, true), d30: summaryCell(null, 4, true) },
+    ],
+    min_players: 20,
+    game_median: { d1: 11, d7: 6.6, d30: null },
+    start: '2026-06-15',
+    end: '2026-08-13',
+    days: 60,
+    window: 60,
+    game_type: null,
+    include_bots: false,
+    ...over,
+  } as RetentionResponse;
+}
+
+describe('gameRetentionCard', () => {
+  it('compares against the peer median, not the platform figure', () => {
+    // The platform number counts a return to ANY game from different cohorts,
+    // so a game can sit either side of it — Scout's 12.1% is above the
+    // platform's 5.3%. Comparing to it would be arithmetic between two
+    // questions.
+    render(<GameRetentionCard data={data()} gameKey="scout" gameLabel="Scout" />);
+
+    expect(screen.getByText('12.1%')).toBeTruthy();
+    expect(screen.getByText(/\+5\.5 vs median 6\.6%/)).toBeTruthy();
+  });
+
+  it('says why a rate is missing rather than showing a bare dash', () => {
+    render(<GameRetentionCard data={data()} gameKey="quiz" gameLabel="Quiz" />);
+
+    // All three offsets are below the threshold for this game, so the reason
+    // appears once per offset.
+    expect(screen.getAllByText(/only 4 players — too few to state a rate/)).toHaveLength(3);
+  });
+
+  it('distinguishes "not yet" from "too few"', () => {
+    // Two different facts. Conflating them would have someone chasing a
+    // sample-size problem that is really just time.
+    render(<GameRetentionCard data={data()} gameKey="scout" gameLabel="Scout" />);
+
+    expect(screen.getByText(/no cohort has reached this day yet/)).toBeTruthy();
+  });
+
+  it('says so when there is no peer median to compare with', () => {
+    render(<GameRetentionCard data={data({ game_median: { d1: null, d7: null, d30: null } })} gameKey="scout" gameLabel="Scout" />);
+
+    expect(screen.getAllByText(/no peer median to compare with/).length).toBeGreaterThan(0);
+  });
+
+  it('renders nothing for a game the response does not carry', () => {
+    const { container } = render(<GameRetentionCard data={data()} gameKey="conquest" gameLabel="Conquest" />);
+
+    expect(container.firstChild).toBeNull();
+  });
+});


### PR DESCRIPTION
Issue #1453, item **C3** — *"Games page needs richer info: per-game funnel, retention, time-of-day skew, trend sparkline."*

## Why

The per-game page had volume, a comparison, four rates and a top-players list. Everything built this week — retention per game, the duration distribution — was reachable from the section index and **nowhere from the page about one game**.

## Three additions

**"Does it keep people?"** — this game's retention, read against the **median across games**. Not against the platform figure: that counts a return to *any* game, from cohorts defined by a player's first day anywhere, so a game can sit either side of it (Scout's 12.1% D7 against a platform 5.3%).

The retention call here is deliberately **unfiltered**. One unfiltered response carries both this game's row *and* the peer median; a game-filtered call would return a median of a single game — itself.

**"When it's played"** — the game's own hours as a share of *its own* play, not raw counts, so a quiet game has the same readable shape as a busy one. The timezone is named, because "8pm" means nothing without it.

**The duration histogram** — no extra request: the duration response on this page is already filtered to this game.

## Both new cards refuse to draw on empty data

An all-zero hour chart is 24 flat bars and a peak hour of midnight — a confident-looking answer to a question with no data behind it.

## Mutation testing

| Mutation | Result |
|---|---|
| compare retention against the platform figure | 2 fail |
| conflate "too few players" with "no cohort yet" | 1 fails |
| drop the "no peer median" message | 1 fails |
| render an all-zero hour chart | 1 fails |
| compute the peak share against the max instead of the total | 1 fails |

## Not included

The per-game multiplayer funnel. It needs a seventh request on this page and the page already makes six; it's worth doing as its own change rather than bolted on here. Left on #1453.

Suite: 455 passing (68 files). Build and types clean.