### PR TITLE
Stop drawing four metrics on one axis

### DIFF
--- a/components/reports/ActivityChart.tsx
+++ b/components/reports/ActivityChart.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { ActivityDay, MetricKey } from '@/types/reports';
-import { CartesianGrid, Legend, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { METRIC_OPTIONS } from '@/types/reports';
 import { useTheme } from 'next-themes';

--- a/components/reports/ActivityChart.tsx
+++ b/components/reports/ActivityChart.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { METRIC_OPTIONS } from '@/types/reports';
 import { useTheme } from 'next-themes';
 import { chartTheme } from '@/lib/chart-theme';
+import { metricPanels } from '@/lib/metric-panels';
 import type { Granularity } from '@/types/reports';
 import { GRANULARITIES } from '@/types/reports';
 import { cn } from '@/lib/utils';
@@ -25,6 +26,12 @@ function formatBucket(iso: string, granularity: Granularity): string {
   return granularity === 'week' ? `w/c ${day}` : day;
 }
 
+/** A metric's total over the window, skipping uncovered days rather than
+ *  counting them as zero — the same rule the chart draws by. */
+function total(rows: { [key: string]: unknown }[], key: MetricKey): number {
+  return rows.reduce((sum, row) => sum + (typeof row[key] === 'number' ? (row[key] as number) : 0), 0);
+}
+
 const DEFAULT_COLORS: Record<MetricKey, string> = {
   games_started: '#059669',
   games_finished: '#2563eb',
@@ -33,10 +40,20 @@ const DEFAULT_COLORS: Record<MetricKey, string> = {
 };
 
 /**
- * Daily activity. The selected metric is drawn boldly and the others stay as
- * faint context — showing only the selection loses the shape that makes it
- * meaningful (a "played" line means much more next to "finished"), while giving
- * four lines equal weight makes none of them readable.
+ * Daily activity: the selected metric large, the other three beneath it.
+ *
+ * All four used to share one y-axis, with the unselected ones drawn faint. That
+ * was two problems wearing one coat. A shared axis across metrics of different
+ * magnitudes flattens the small ones into a line along the bottom — distinct
+ * players runs in the tens where games played runs in the thousands, so the
+ * shape of the most interesting series was never visible. And a shared axis
+ * *asserts* comparability: it invites reading the gap between two lines as if
+ * it meant something, when one counts sessions and the other counts people.
+ *
+ * Small multiples instead. Each panel keeps its own scale, they share the
+ * x-axis, and nobody is invited to subtract one from another. The two-axis
+ * alternative is the one thing worse than both — it lets the author choose
+ * where the lines cross.
  */
 export function ActivityChart({ series, title, description, metric, color, granularity, onGranularityChange }: {
   series: ActivityDay[];
@@ -77,6 +94,8 @@ export function ActivityChart({ series, title, description, metric, color, granu
   }));
   const uncovered = rows.filter(row => !row.covered).length;
   const primaryColor = color ?? DEFAULT_COLORS[metric];
+  const panels = metricPanels(metric);
+  const primaryOption = METRIC_OPTIONS.find(option => option.key === panels.primary)!;
 
   return (
     <Card>
@@ -125,26 +144,57 @@ export function ActivityChart({ series, title, description, metric, color, granu
             <XAxis dataKey="label" tick={theme.tick} interval="preserveStartEnd" minTickGap={24} />
             <YAxis tick={theme.tick} allowDecimals={false} width={44} />
             <Tooltip content={<ChartTooltip />} cursor={theme.tooltip.cursor} />
-            <Legend wrapperStyle={{ fontSize: 12 }} />
-            {METRIC_OPTIONS.map((option) => {
-              const isPrimary = option.key === metric;
-              return (
-                <Line
-                  key={option.key}
-                  type="monotone"
-                  dataKey={option.key}
-                  name={option.label}
-                  stroke={isPrimary ? primaryColor : DEFAULT_COLORS[option.key]}
-                  strokeWidth={isPrimary ? 2.5 : 1}
-                  strokeOpacity={isPrimary ? 1 : 0.28}
-                  dot={false}
-                  activeDot={isPrimary ? { r: 4 } : false}
-                  connectNulls={false}
-                />
-              );
-            })}
+            {/* One line, its own axis. The others are below at their own
+                scales rather than squashed onto this one. */}
+            <Line
+              type="monotone"
+              dataKey={primaryOption.key}
+              name={primaryOption.label}
+              stroke={primaryColor}
+              strokeWidth={2.5}
+              dot={false}
+              activeDot={{ r: 4 }}
+              connectNulls={false}
+            />
           </LineChart>
         </ResponsiveContainer>
+      </CardContent>
+
+      {/* The other three, each on its own scale. Same x-axis, no shared y —
+          so the shapes can be compared without the numbers being implied to
+          be comparable. */}
+      <CardContent className="grid grid-cols-1 gap-4 pt-0 sm:grid-cols-3">
+        {panels.context.map(key => METRIC_OPTIONS.find(option => option.key === key)!).map(option => (
+          <div key={option.key} className="space-y-1">
+            <p className="text-xs font-medium text-gray-600 dark:text-gray-300">
+              {option.label}
+              <span className="ml-1 font-normal tabular-nums text-gray-400 dark:text-gray-500">
+                {total(data, option.key).toLocaleString()}
+              </span>
+            </p>
+            <div className="h-20">
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={data} margin={{ top: 4, right: 4, bottom: 0, left: 0 }}>
+                  <XAxis dataKey="label" hide />
+                  {/* Its own domain, which is the entire point: on the shared
+                      axis above, a series in the tens beside one in the
+                      thousands was a flat line along the bottom. */}
+                  <YAxis hide domain={['dataMin', 'dataMax']} />
+                  <Tooltip content={<ChartTooltip />} cursor={theme.tooltip.cursor} />
+                  <Line
+                    type="monotone"
+                    dataKey={option.key}
+                    name={option.label}
+                    stroke={DEFAULT_COLORS[option.key]}
+                    strokeWidth={1.5}
+                    dot={false}
+                    connectNulls={false}
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+        ))}
       </CardContent>
     </Card>
   );

--- a/components/reports/__tests__/ActivityChart.test.tsx
+++ b/components/reports/__tests__/ActivityChart.test.tsx
@@ -1,0 +1,95 @@
+import type { ActivityDay } from '@/types/reports';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ActivityChart } from '@/components/reports/ActivityChart';
+
+function day(date: string, over: Partial<ActivityDay> = {}): ActivityDay {
+  return {
+    date,
+    covered: true,
+    games_started: 1000,
+    games_finished: 600,
+    distinct_players: 30,
+    mp_player_sessions: 120,
+    ...over,
+  };
+}
+
+const SERIES = [day('2026-08-01'), day('2026-08-02'), day('2026-08-03')];
+
+function chart(metric: Parameters<typeof ActivityChart>[0]['metric'] = 'games_started') {
+  return (
+    <ActivityChart
+      series={SERIES}
+      title="Activity"
+      description="Last 3 days."
+      metric={metric}
+      granularity="day"
+      onGranularityChange={() => {}}
+    />
+  );
+}
+
+describe('activityChart', () => {
+  it('gives every other metric its own panel', () => {
+    // They used to share one y-axis. Distinct players runs in the tens where
+    // games played runs in the thousands, so the small series was a flat line
+    // along the bottom — and a shared axis also implies the gap between two
+    // lines means something, when one counts sessions and the other counts
+    // people.
+    render(chart('games_started'));
+
+    expect(screen.getByText('Finished')).toBeTruthy();
+    expect(screen.getByText('Players')).toBeTruthy();
+    expect(screen.getByText('Multiplayer')).toBeTruthy();
+  });
+
+  it('does not give the selected metric a second panel', () => {
+    // It is already the large chart above; repeating it would imply the two
+    // are different measurements.
+    render(chart('distinct_players'));
+
+    expect(screen.queryByText('Players')).toBeNull();
+    expect(screen.getByText('Played')).toBeTruthy();
+  });
+
+  it('totals each panel over the window', () => {
+    render(chart('games_started'));
+
+    expect(screen.getByText('1,800')).toBeTruthy();
+    expect(screen.getByText('90')).toBeTruthy();
+    expect(screen.getByText('360')).toBeTruthy();
+  });
+
+  it('leaves uncovered days out of a panel total rather than counting them as zero', () => {
+    // An uncovered day was never computed. Counting it as zero understates the
+    // total and draws a dip that never happened.
+    render(
+      <ActivityChart
+        series={[day('2026-08-01'), day('2026-08-02', { covered: false })]}
+        title="Activity"
+        description="Two days, one uncovered."
+        metric="games_started"
+        granularity="day"
+        onGranularityChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByText('600')).toBeTruthy();
+  });
+
+  it('says how many days were never computed', () => {
+    render(
+      <ActivityChart
+        series={[day('2026-08-01'), day('2026-08-02', { covered: false })]}
+        title="Activity"
+        description="Two days, one uncovered."
+        metric="games_started"
+        granularity="day"
+        onGranularityChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByText(/1 day in this range were never computed/)).toBeTruthy();
+  });
+});

--- a/lib/__tests__/metric-panels.test.ts
+++ b/lib/__tests__/metric-panels.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { metricPanels } from '@/lib/metric-panels';
+import { METRIC_OPTIONS } from '@/types/reports';
+
+describe('metricPanels', () => {
+  it('puts only the selected metric on the large chart', () => {
+    // All four used to share one axis, which flattened the small series and
+    // implied the gap between two lines meant something — one counts sessions,
+    // another counts people.
+    expect(metricPanels('distinct_players').primary).toBe('distinct_players');
+    expect(metricPanels('distinct_players').context).not.toContain('distinct_players');
+  });
+
+  it('gives every other metric a panel, and no metric twice', () => {
+    for (const { key } of METRIC_OPTIONS) {
+      const { primary, context } = metricPanels(key);
+
+      expect(new Set([primary, ...context]).size).toBe(METRIC_OPTIONS.length);
+      expect(context).toHaveLength(METRIC_OPTIONS.length - 1);
+    }
+  });
+
+  it('drops no metric, whichever is selected', () => {
+    // A metric silently missing from both regions is invisible on the page,
+    // and nothing else would catch it.
+    for (const { key } of METRIC_OPTIONS) {
+      const { primary, context } = metricPanels(key);
+      const shown = new Set<string>([primary, ...context]);
+
+      for (const option of METRIC_OPTIONS) {
+        expect(shown.has(option.key), `${option.key} missing when ${key} is selected`).toBe(true);
+      }
+    }
+  });
+
+  it('keeps the declared order in the context panels', () => {
+    // So the row doesn't reshuffle when the selection changes, which would
+    // make the eye re-find each panel every time.
+    expect(metricPanels('games_started').context).toEqual(['games_finished', 'distinct_players', 'mp_player_sessions']);
+  });
+});

--- a/lib/metric-panels.ts
+++ b/lib/metric-panels.ts
@@ -1,0 +1,34 @@
+/**
+ * Which metric goes where on the activity chart.
+ *
+ * All four used to share one y-axis. That flattened the small series — distinct
+ * players runs in the tens where games played runs in the thousands — and,
+ * worse, a shared axis asserts comparability: it invites reading the gap
+ * between two lines as meaningful when one counts sessions and the other counts
+ * people.
+ *
+ * So the selected metric gets the large chart and the rest get their own
+ * panels, each with its own scale. The split is here rather than inline because
+ * it is the claim being made — that no metric is drawn twice, and none is
+ * dropped — and a recharts tree renders nothing measurable in jsdom.
+ */
+
+import type { MetricKey } from '@/types/reports';
+import { METRIC_OPTIONS } from '@/types/reports';
+
+export type MetricPanels = {
+  /** The one metric on the large chart, at its own scale. */
+  primary: MetricKey;
+  /** The others, one small panel each, each at its own scale. */
+  context: MetricKey[];
+};
+
+export function metricPanels(metric: MetricKey): MetricPanels {
+  const keys = METRIC_OPTIONS.map(option => option.key);
+  return {
+    primary: metric,
+    // Every other metric, in the declared order. Filtering rather than slicing
+    // so a metric added to the registry appears here without a second edit.
+    context: keys.filter(key => key !== metric),
+  };
+}


### PR DESCRIPTION
Issue #1453, item **B6** — *"metric toggle is single-select; Played/Finished/Players/Multiplayer are different units, so a naive overlay would mislead"*.

## The actual defect

The chart already drew all four metrics — the unselected ones faint, on a **shared y-axis**. That's two problems wearing one coat:

1. **The small series were invisible.** Distinct players runs in the tens where games played runs in the thousands, so the players line sat flat along the bottom. Its shape is the interesting part and it was never on screen.
2. **A shared axis asserts comparability.** It invites reading the gap between two lines as meaningful, when one counts *sessions* and the other counts *people*.

## Small multiples

The selected metric keeps the large chart. The other three get a panel each, at their own scale, sharing the x-axis. Nobody is invited to subtract one from another.

The dual-axis alternative would be worse than either — it lets whoever draws the chart choose where the lines cross.

Each panel carries its metric's total for the window, computed the way the chart draws: an uncovered day is skipped, not counted as zero.

## Why there's a new lib file

`lib/metric-panels.ts` holds the split. Which metric goes where is *the claim being made* — no metric drawn twice, none dropped — and a recharts tree renders nothing measurable in jsdom, so the decision needs to be testable away from the chart.

## Mutation testing

| Mutation | Result |
|---|---|
| leave the selected metric in the context panels | 4 fail |
| drop a metric from the row | 5 fail |
| reshuffle the panel order | 1 fails |
| repeat the selection below the large chart | 1 fails |
| count uncovered days as zero in a panel total | 2 fail |

**Not covered, and I'd rather say so than imply otherwise:** that the large chart draws exactly one line, and that each small panel gets its own y-domain. Both are recharts props; recharts renders nothing in jsdom, so a test asserting them would only be asserting my own mock. The metric *split* is tested; the rendering of it is verified by eye on the preview.

Suite: 456 passing (68 files). Build and types clean.