### PR TITLE
Catch unused imports where reporting lives

### DIFF
--- a/app/reports/duration/page.tsx
+++ b/app/reports/duration/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { RangeState } from '@/lib/report-range';
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { DurationHistogram } from '@/components/reports/DurationHistogram';
 import { DurationTable } from '@/components/reports/DurationTable';
 import { ExportButton } from '@/components/reports/ExportButton';

--- a/app/reports/games/page.tsx
+++ b/app/reports/games/page.tsx
@@ -2,7 +2,6 @@
 
 import type { RangeState } from '@/lib/report-range';
 import type { GameRowWithDuration, GameSortKey } from '@/lib/report-sort';
-import type { GameTotals } from '@/types/reports';
 import { ArrowDown, ArrowUp } from 'lucide-react';
 import Link from 'next/link';
 import { useMemo, useState } from 'react';

--- a/app/reports/multiplayer/page.tsx
+++ b/app/reports/multiplayer/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { RangeState } from '@/lib/report-range';
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { GameBadge } from '@/components/reports/GameBadge';
 import { ModeBreakdown } from '@/components/reports/ModeBreakdown';
 import { MultiplayerFunnel } from '@/components/reports/MultiplayerFunnel';

--- a/app/reports/patterns/page.tsx
+++ b/app/reports/patterns/page.tsx
@@ -2,7 +2,7 @@
 
 import type { RangeState } from '@/lib/report-range';
 import type { HourWeekdayRow } from '@/types/reports';
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { Area, AreaChart, Bar, BarChart, CartesianGrid, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import { ActivityHeatmap } from '@/components/reports/ActivityHeatmap';
 import { MetricInfo } from '@/components/reports/MetricInfo';

--- a/app/reports/players/[id]/page.tsx
+++ b/app/reports/players/[id]/page.tsx
@@ -5,7 +5,7 @@ import type { ReportParams } from '@/types/reports';
 import { ArrowLeft } from 'lucide-react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 import { Area, AreaChart, CartesianGrid, Cell, Pie, PieChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import { GameBadge } from '@/components/reports/GameBadge';
 import { RangePicker } from '@/components/reports/RangePicker';

--- a/app/reports/retention/page.tsx
+++ b/app/reports/retention/page.tsx
@@ -2,7 +2,7 @@
 
 import type { RangeState } from '@/lib/report-range';
 import type { RetentionCohort } from '@/types/reports';
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { ExportButton } from '@/components/reports/ExportButton';
 import { GameFilter } from '@/components/reports/GameFilter';
 import { RangePicker } from '@/components/reports/RangePicker';

--- a/components/reports/GameBadge.tsx
+++ b/components/reports/GameBadge.tsx
@@ -3,7 +3,6 @@
 import type { GameMetaMap } from '@/hooks/use-game-meta';
 import { X } from 'lucide-react';
 import { gameName, useGameColor } from '@/hooks/use-game-meta';
-import { prettySlug } from '@/lib/user-hub-format';
 import { cn } from '@/lib/utils';
 
 /**

--- a/lib/__tests__/report-sort.test.ts
+++ b/lib/__tests__/report-sort.test.ts
@@ -1,4 +1,3 @@
-import type { GameTotals } from '@/types/reports';
 import { describe, expect, it } from 'vitest';
 import type { GameRowWithDuration } from '@/lib/report-sort';
 import { sortGameTotals } from '@/lib/report-sort';

--- a/scripts/__tests__/check-types-scope.test.ts
+++ b/scripts/__tests__/check-types-scope.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { inScope } from '../check-types.mjs';
+
+describe('inScope', () => {
+  it('matches a scoped path', () => {
+    expect(inScope('components/reports/GameBadge.tsx(6,1): error TS6133: unused')).toBe(true);
+  });
+
+  it('matches the same path with Windows separators', () => {
+    // tsc prints backslashes on Windows. A prefix match against forward slashes
+    // would match nothing there — the gate would report success on every file
+    // it exists to guard, which is worse than no gate because it is trusted.
+    expect(inScope('components\\reports\\GameBadge.tsx(6,1): error TS6133: unused')).toBe(true);
+  });
+
+  it('leaves paths outside the scope alone', () => {
+    // The rest of the app has ~40 of these and some are bug evidence rather
+    // than dead code. Widening this filter by accident would invite deleting
+    // them.
+    expect(inScope('app/career-lookup/page.tsx(3,1): error TS6133: unused')).toBe(false);
+    expect(inScope('app\\career-lookup\\page.tsx(3,1): error TS6133: unused')).toBe(false);
+  });
+});

--- a/scripts/check-types.mjs
+++ b/scripts/check-types.mjs
@@ -25,6 +25,8 @@
  * of those bugs. They want reading, not a codemod.
  */
 import { spawnSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 /** Must stay empty. Anything listed here is a file nobody typechecks. */
 const IGNORED_PREFIXES = [];
@@ -35,6 +37,21 @@ const IGNORED_PREFIXES = [];
  */
 const UNUSED_SCOPE = ['app/reports/', 'components/reports/', 'components/admin/', 'hooks/', 'lib/'];
 
+/**
+ * True when a tsc error line belongs to a scoped path.
+ *
+ * Separators are normalised because tsc prints backslashes on Windows, and a
+ * prefix match against forward slashes would then match nothing — the check
+ * would report success on every file it was meant to guard. A gate that
+ * silently covers nothing is worse than no gate, because it is trusted.
+ *
+ * Exported for the test; nothing else imports this file.
+ */
+export function inScope(line, prefixes = UNUSED_SCOPE) {
+  const normalised = line.replaceAll('\\', '/');
+  return prefixes.some(prefix => normalised.startsWith(prefix));
+}
+
 function tsc(extraArgs = []) {
   return spawnSync('npx', ['tsc', '--noEmit', '--pretty', 'false', ...extraArgs], {
     encoding: 'utf8',
@@ -42,63 +59,86 @@ function tsc(extraArgs = []) {
   });
 }
 
-const result = tsc();
+/**
+ * Run both passes. Wrapped in a function and called only when this file is the
+ * entry point: importing it (the scope filter has a test) used to execute both
+ * tsc runs — nine seconds, and a `process.exit(1)` that would kill the test
+ * process the first time the repo had a type error.
+ */
+function main() {
+  const result = tsc();
 
-const stdout = result.stdout || '';
+  const stdout = result.stdout || '';
 
-const errors = (stdout || '').split('\n').filter(line => / error TS\d+:/.test(line));
-const ours = errors.filter(line => !IGNORED_PREFIXES.some(prefix => line.startsWith(prefix)));
-const ignored = errors.length - ours.length;
+  const errors = (stdout || '').split('\n').filter(line => / error TS\d+:/.test(line));
+  const ours = errors.filter(line => !IGNORED_PREFIXES.some(prefix => line.startsWith(prefix)));
+  const ignored = errors.length - ours.length;
 
-if (ignored > 0) {
-  console.warn(`note: ${ignored} error(s) in ignored paths (${IGNORED_PREFIXES.join(', ')}) — not gated, still owed.`);
-}
-
-// A gate that can't run must fail, not pass quietly. Without this, anything
-// that stops tsc producing output (missing binary, OOM, a config error) reads
-// as zero errors — which is the exact fail-open shape this gate exists to stop.
-if (result.error || (result.status !== 0 && errors.length === 0)) {
-  console.error('Could not run tsc, so types are unverified — failing closed.');
-  if (result.error) {
-    console.error(String(result.error));
+  if (ignored > 0) {
+    console.warn(`note: ${ignored} error(s) in ignored paths (${IGNORED_PREFIXES.join(', ')}) — not gated, still owed.`);
   }
-  if (result.stderr) {
-    console.error(result.stderr);
+
+  // A gate that can't run must fail, not pass quietly. Without this, anything
+  // that stops tsc producing output (missing binary, OOM, a config error) reads
+  // as zero errors — which is the exact fail-open shape this gate exists to stop.
+  if (result.error || (result.status !== 0 && errors.length === 0)) {
+    console.error('Could not run tsc, so types are unverified — failing closed.');
+    if (result.error) {
+      console.error(String(result.error));
+    }
+    if (result.stderr) {
+      console.error(result.stderr);
+    }
+    process.exit(1);
   }
-  process.exit(1);
-}
 
-if (ours.length > 0) {
-  console.error(`\n${ours.length} type error(s):\n`);
-  for (const line of ours) {
-    console.error(`  ${line}`);
+  if (ours.length > 0) {
+    console.error(`\n${ours.length} type error(s):\n`);
+    for (const line of ours) {
+      console.error(`  ${line}`);
+    }
+    process.exit(1);
   }
-  process.exit(1);
-}
 
-// Second pass: unused locals, but only where the rule is switched on. Run after
-// the real typecheck so a genuine type error is never buried under this.
-const unusedRun = tsc(['--noUnusedLocals']);
-const unusedOut = unusedRun.stdout || '';
+  // Second pass: unused locals, but only where the rule is switched on. Run after
+  // the real typecheck so a genuine type error is never buried under this.
+  const unusedRun = tsc(['--noUnusedLocals']);
+  const unusedOut = unusedRun.stdout || '';
 
-// Same fail-closed rule as above: a pass that cannot run must say so.
-if (unusedRun.error || (unusedRun.status !== 0 && !/ error TS\d+:/.test(unusedOut))) {
-  console.error('Could not run the unused-locals pass, so it is unverified — failing closed.');
-  process.exit(1);
-}
-
-const unused = unusedOut
-  .split('\n')
-  .filter(line => / error TS(6133|6192|6196):/.test(line))
-  .filter(line => UNUSED_SCOPE.some(prefix => line.startsWith(prefix)));
-
-if (unused.length > 0) {
-  console.error(`\n${unused.length} unused declaration(s) in the reporting surface:\n`);
-  for (const line of unused) {
-    console.error(`  ${line}`);
+  // Same fail-closed rule as above: a pass that cannot run must say so.
+  if (unusedRun.error || (unusedRun.status !== 0 && !/ error TS\d+:/.test(unusedOut))) {
+    console.error('Could not run the unused-locals pass, so it is unverified — failing closed.');
+    // Print what actually happened, like the pass above does. A gate that fails
+    // without saying why gets bypassed rather than fixed.
+    if (unusedRun.error) {
+      console.error(String(unusedRun.error));
+    }
+    if (unusedRun.stderr) {
+      console.error(unusedRun.stderr);
+    }
+    process.exit(1);
   }
-  console.error('\nAn unused import is dead weight; an unused handler is usually a wiring bug.');
-  process.exit(1);
+
+  const unused = unusedOut
+    .split('\n')
+    .filter(line => / error TS(6133|6192|6196):/.test(line))
+    .filter(line => inScope(line));
+
+  if (unused.length > 0) {
+    console.error(`\n${unused.length} unused declaration(s) in the reporting surface:\n`);
+    for (const line of unused) {
+      console.error(`  ${line}`);
+    }
+    console.error('\nAn unused import is dead weight; an unused handler is usually a wiring bug.');
+    process.exit(1);
+  }
+
+  console.log('Types OK.');
 }
 
-console.log('Types OK.');
+// `process.argv[1]` is the script node was asked to run. Comparing resolved
+// paths rather than substrings so a directory that merely contains the name
+// can't match.
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/check-types.mjs
+++ b/scripts/check-types.mjs
@@ -11,16 +11,38 @@
  * files are gone and the last real error is fixed, so the ignore list is now
  * empty and every file is gated. Keep it that way: an entry here is a file
  * nobody is checking.
+ *
+ * It also runs a SECOND pass with noUnusedLocals, scoped to the reporting
+ * surface. An unused import shipped through this pipeline untouched — tsconfig
+ * has no noUnusedLocals and the pre-commit eslint pass neither flagged nor
+ * stripped it — and a chart that imports a legend it no longer draws is the
+ * mild version of that.
+ *
+ * Scoped rather than global on purpose. The rest of the app has 40-odd of these
+ * today, and several are not dead code at all: an unused `handleDeleteFootballer`
+ * is more likely a button that lost its onClick than a symbol worth deleting.
+ * Turning the rule on everywhere would invite a sweep that erases the evidence
+ * of those bugs. They want reading, not a codemod.
  */
 import { spawnSync } from 'node:child_process';
 
 /** Must stay empty. Anything listed here is a file nobody typechecks. */
 const IGNORED_PREFIXES = [];
 
-const result = spawnSync('npx', ['tsc', '--noEmit', '--pretty', 'false'], {
-  encoding: 'utf8',
-  shell: process.platform === 'win32',
-});
+/**
+ * Where unused locals are an error today. Everywhere else still owes the
+ * cleanup — see the header.
+ */
+const UNUSED_SCOPE = ['app/reports/', 'components/reports/', 'components/admin/', 'hooks/', 'lib/'];
+
+function tsc(extraArgs = []) {
+  return spawnSync('npx', ['tsc', '--noEmit', '--pretty', 'false', ...extraArgs], {
+    encoding: 'utf8',
+    shell: process.platform === 'win32',
+  });
+}
+
+const result = tsc();
 
 const stdout = result.stdout || '';
 
@@ -51,6 +73,31 @@ if (ours.length > 0) {
   for (const line of ours) {
     console.error(`  ${line}`);
   }
+  process.exit(1);
+}
+
+// Second pass: unused locals, but only where the rule is switched on. Run after
+// the real typecheck so a genuine type error is never buried under this.
+const unusedRun = tsc(['--noUnusedLocals']);
+const unusedOut = unusedRun.stdout || '';
+
+// Same fail-closed rule as above: a pass that cannot run must say so.
+if (unusedRun.error || (unusedRun.status !== 0 && !/ error TS\d+:/.test(unusedOut))) {
+  console.error('Could not run the unused-locals pass, so it is unverified — failing closed.');
+  process.exit(1);
+}
+
+const unused = unusedOut
+  .split('\n')
+  .filter(line => / error TS(6133|6192|6196):/.test(line))
+  .filter(line => UNUSED_SCOPE.some(prefix => line.startsWith(prefix)));
+
+if (unused.length > 0) {
+  console.error(`\n${unused.length} unused declaration(s) in the reporting surface:\n`);
+  for (const line of unused) {
+    console.error(`  ${line}`);
+  }
+  console.error('\nAn unused import is dead weight; an unused handler is usually a wiring bug.');
   process.exit(1);
 }
 


### PR DESCRIPTION
Issue #1453, item **R3** — filed after Copilot caught an unused `Legend` import on #85 that the whole pipeline had waved through.

## The gap

`tsconfig.json` has no `noUnusedLocals`, and the pre-commit `eslint --fix` pass neither flagged nor stripped the import. **Both ran green on the commit that introduced it.** An unused import can ship here with nothing objecting.

## The fix

`scripts/check-types.mjs` now runs a second `tsc` pass with `--noUnusedLocals`, scoped to `app/reports/`, `components/reports/`, `components/admin/`, `hooks/` and `lib/`.

It found **eight** more the moment it existed:

- a stale `prettySlug` import in `GameBadge`
- an unused `GameTotals` type in two files
- `useState` imported by five report pages that no longer use it

## Why scoped and not global

The rest of the app has about forty of these, and **several are not dead code**. An unused `handleDeleteFootballer` is more likely a button that lost its `onClick` than a symbol worth deleting; same for `renderFootballer` and `hasWikipediaPositions`.

Turning the rule on everywhere invites a sweep that deletes the evidence of those bugs. They want reading, not a codemod — so that cleanup is filed as its own item rather than smuggled into a lint change.

## Fails closed

The new pass follows the same rule as the one above it: if `tsc` can't run, empty output means **unverified**, not clean. That fail-open shape is the reason this gate exists at all.

## Mutation testing

| Mutation | Result |
|---|---|
| new unused import inside the scope | caught |
| unused import outside the scope | correctly ignored (not over-scoped) |
| the unused pass can't run | fails closed |

Suite: 465 passing (70 files). Build clean.