### PR TITLE
Add a Dependabot config, matching the frontend's

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,68 @@
+version: 2
+
+# Notes
+# - Security updates run automatically once Dependabot is enabled at the repo
+#   level (Settings → Code security → Dependabot). No YAML needed for those —
+#   this file controls **version updates** (the routine "X.Y.Z is out" PRs).
+# - Schedule is weekly Monday so routine bumps land at the start of the week
+#   rather than piling onto a Friday.
+# - Patch + minor are grouped into one PR per ecosystem per week to keep review
+#   overhead low. Majors arrive separately because they need a closer look.
+#
+# - IMPORTANT, and the reason a bot PR here needs a human step: Vercel does not
+#   build pull requests opened by Dependabot, so a bump lands with no preview
+#   and no proof it still compiles. The established handling in this project is
+#   to mirror the change onto a `chore/` branch cut from `production`, let
+#   Vercel build that, and merge the mirror. A Dependabot PR merged on a green
+#   test suite alone has never been built by anything.
+#
+# - This repo installs with pnpm and Vercel uses `--frozen-lockfile`, so
+#   `pnpm-lock.yaml` must be regenerated with pnpm in the same commit as any
+#   package.json change. A lockfile edited by npm, or left stale, fails the
+#   install step before a single line is compiled — which is how production
+#   silently stopped deploying for several merges in August.
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - javascript
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+    ignore:
+      # Framework majors need a coordinated upgrade across the stack, not an
+      # auto-PR: a Next or React major moves the build, the router and the type
+      # surface at once.
+      - dependency-name: next
+        update-types: ['version-update:semver-major']
+      - dependency-name: react
+        update-types: ['version-update:semver-major']
+      - dependency-name: react-dom
+        update-types: ['version-update:semver-major']
+
+      # The typecheck gate (scripts/check-types.mjs) and the pre-commit hook
+      # both run against this TypeScript. A major lands in every commit's path
+      # at once, so it goes in deliberately rather than on a Monday morning.
+      - dependency-name: typescript
+        update-types: ['version-update:semver-major']
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    labels:
+      - dependencies
+      - github-actions
+    groups:
+      actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
Issue FootballExtraTime/App#1454 — *"create a dependabot stuff similar to the FE and how we've done it as we have 102 vulnerabilities"*.

## Where this repo stands

101 open alerts today:

| Severity | Count |
|---|---|
| High | 46 |
| Medium | 46 |
| Low | 9 |

Concentrated in a handful of packages:

| Package | Alerts |
|---|---|
| `next` | **62** |
| `undici` | 11 |
| `vite` | 5 |
| `postcss` | 4 |
| everything else | 19 |

## The config

Modelled on `extratime-web`'s — weekly Monday, patch and minor grouped into one PR, majors separate — with **two notes specific to this repo**, both learned the expensive way:

**Vercel doesn't build Dependabot PRs.** A bump lands here with no preview and no proof it compiles. The established handling is to mirror the change onto a `chore/` branch cut from `production` and let Vercel build that. A Dependabot PR merged on a green test suite alone has never been built by anything.

**Installs use pnpm with `--frozen-lockfile`.** `pnpm-lock.yaml` has to be regenerated *with pnpm* in the same commit as any `package.json` change. A lockfile edited by npm, or left stale, fails at the install step before a line is compiled — which is how production silently stopped deploying for several merges in August.

Both are in the file as comments, because the next person to hit them will be reading the config, not the git log.

## Ignored majors

`next`, `react`, `react-dom` — a framework major moves the build, the router and the type surface at once. `typescript` — it sits in the path of every commit via the typecheck gate and the pre-commit hook.

## Scope

**Config only.** The 101 alerts are a separate job, and the shape of it is already clear: 62 are `next`, and every one of them is closed by `16.0.10 → 16.2.11` (the highest `first_patched_version` across those advisories). That's a minor bump inside Next 16 and it gets its own PR, with a Vercel preview to prove it builds.