### PR TITLE
Fix five type errors that only appear under pnpm

### DIFF
--- a/components/footballer-management/__tests__/NationsEditor.test.tsx
+++ b/components/footballer-management/__tests__/NationsEditor.test.tsx
@@ -19,8 +19,8 @@ import { NationsEditor } from '@/components/footballer-management/sub-editors/Na
 import { FootballerAPI } from '@/lib/footballer-api';
 import { toast } from 'sonner';
 
-const api = vi.mocked(FootballerAPI);
-const mockToast = vi.mocked(toast);
+const api = vi.mocked(FootballerAPI, { deep: true });
+const mockToast = vi.mocked(toast, { deep: true });
 
 const POR = { id: 1, name: 'Portugal', nationality: 'Portuguese', short: 'POR' };
 const BRA = { id: 2, name: 'Brazil', nationality: 'Brazilian', short: 'BRA' };

--- a/components/footballer-management/__tests__/PicturesEditor.test.tsx
+++ b/components/footballer-management/__tests__/PicturesEditor.test.tsx
@@ -18,8 +18,8 @@ import { PicturesEditor } from '@/components/footballer-management/sub-editors/P
 import { FootballerAPI } from '@/lib/footballer-api';
 import { toast } from 'sonner';
 
-const api = vi.mocked(FootballerAPI);
-const mockToast = vi.mocked(toast);
+const api = vi.mocked(FootballerAPI, { deep: true });
+const mockToast = vi.mocked(toast, { deep: true });
 
 function pic(overrides = {}) {
   return {

--- a/components/footballer-management/__tests__/PositionsEditor.test.tsx
+++ b/components/footballer-management/__tests__/PositionsEditor.test.tsx
@@ -17,8 +17,8 @@ import { PositionsEditor } from '@/components/footballer-management/sub-editors/
 import { FootballerAPI } from '@/lib/footballer-api';
 import { toast } from 'sonner';
 
-const api = vi.mocked(FootballerAPI);
-const mockToast = vi.mocked(toast);
+const api = vi.mocked(FootballerAPI, { deep: true });
+const mockToast = vi.mocked(toast, { deep: true });
 
 import type { Position } from '@/types/player';
 

--- a/components/footballer-management/__tests__/TeamsEditor.test.tsx
+++ b/components/footballer-management/__tests__/TeamsEditor.test.tsx
@@ -22,9 +22,12 @@ import { FootballerAPI } from '@/lib/footballer-api';
 import { TeamAPI } from '@/lib/team-api';
 import { toast } from 'sonner';
 
-const api = vi.mocked(FootballerAPI);
+// `deep: true` because FootballerAPI is a class and these are its statics:
+// without it `vi.mocked` types the properties as the real functions, so
+// `.mockResolvedValueOnce` doesn't exist on them.
+const api = vi.mocked(FootballerAPI, { deep: true });
 const mockTeamSearch = vi.mocked(TeamAPI.searchTeams);
-const mockToast = vi.mocked(toast);
+const mockToast = vi.mocked(toast, { deep: true });
 
 function teamRow(over = {}) {
   return {


### PR DESCRIPTION
## The finding

**The typecheck gate has been validating an npm-installed tree.** Vercel installs this repo with **pnpm**, and pnpm doesn't hoist — so the type resolution the gate sees locally isn't the one the project ships with.

Reinstalling with pnpm surfaces five errors the gate never saw:

```
TeamsEditor.test.tsx(58,23): Property 'mockReset' does not exist on type '(message: …) => string | number'
PositionsEditor.test.tsx(123,32): Property 'mockResolvedValueOnce' does not exist on type '(footballerId: number) => Promise<FootballerPosition[]>'
PicturesEditor.test.tsx(125,31): …
```

All the same shape: `vi.mocked(FootballerAPI)` on a class of statics, and `vi.mocked(toast)` on an object, type their members as the *real* functions rather than as mocks. `{ deep: true }` is what makes the members mocks.

## How it was found

I was bumping Next and these appeared, so the first question was whether the bump caused them. **It didn't** — I reinstalled the *old* Next version with pnpm and the same five errors are there. Pre-existing, not upgrade fallout.

They never blocked anything because Vercel's `next build` excludes test files, and the local gate was reading a different `node_modules`.

## Why this matters beyond five lines

This is the same class of mistake as the August deploy outage: **a check that was green because it was validating the wrong package manager.** The gate exists to catch type errors before production; it can only do that if it type-checks the tree production is built from.

Worth following up separately (not in this PR): making the local install pnpm by default, so the gate and Vercel can't diverge again.

## Verification

Types clean under pnpm, 468 tests passing, build clean. Types only — no test behaviour changed.