### PR TITLE
Make CI actually run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,12 @@ on:
   pull_request:
     branches: [production]
 
+# Read-only by default. Nothing here writes to the repo, and install/test/build
+# all execute third-party code, so the token they run beside should be able to
+# do as little as possible.
+permissions:
+  contents: read
+
 jobs:
   verify:
     runs-on: ubuntu-latest
@@ -30,15 +36,19 @@ jobs:
           node-version: '22'
           cache: pnpm
 
-      # --frozen-lockfile, exactly as Vercel does it: a lockfile that has
-      # drifted from package.json fails here rather than at deploy time, which
-      # is how production silently stopped deploying for several merges in
-      # August.
+      # BEFORE the install, not after. --frozen-lockfile already rejects a
+      # drifted lockfile, so running this second would mean it never spoke: the
+      # install would have failed first, with pnpm's message instead of the one
+      # written for this exact trap. The script only reads two files with node
+      # builtins, so it needs no node_modules and costs milliseconds.
+      - name: Lockfile in sync
+        run: node scripts/check-lockfile.mjs
+
+      # The same install Vercel performs. A lockfile that has drifted fails here
+      # rather than at deploy time, which is how production silently stopped
+      # deploying for several merges in August.
       - name: Install
         run: pnpm install --frozen-lockfile
-
-      - name: Lockfile in sync
-        run: pnpm run check-lockfile
 
       # The gate, not raw tsc: it fails closed if tsc cannot run, and it checks
       # the reporting surface for unused declarations.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,39 +1,63 @@
-name: CI/CD Pipeline
+name: CI
 
+# `production` is this repo's trunk. The previous version of this file listened
+# for `main` and `develop`, which do not exist here, so it had never run once —
+# every merge to date was verified by Vercel's build and by whatever the author
+# ran locally.
 on:
   push:
-    branches: [main, develop]
+    branches: [production]
   pull_request:
-    branches: [main]
+    branches: [production]
 
 jobs:
-  test:
+  verify:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      # pnpm, because that is what Vercel installs with. The previous version
+      # ran `npm ci`, and this repo has no package-lock.json — it was deleted
+      # deliberately so the lockfile Vercel reads is the only one. That step
+      # could only ever have failed.
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
         with:
           node-version: '22'
-          cache: npm
+          cache: pnpm
 
-      - name: Install dependencies
-        run: npm ci
+      # --frozen-lockfile, exactly as Vercel does it: a lockfile that has
+      # drifted from package.json fails here rather than at deploy time, which
+      # is how production silently stopped deploying for several merges in
+      # August.
+      - name: Install
+        run: pnpm install --frozen-lockfile
 
-      - name: Run type check
-        run: npm run type-check
+      - name: Lockfile in sync
+        run: pnpm run check-lockfile
 
-      - name: Run linting
-        run: npm run lint
+      # The gate, not raw tsc: it fails closed if tsc cannot run, and it checks
+      # the reporting surface for unused declarations.
+      - name: Types
+        run: pnpm run check-types:app
 
-      - name: Run tests
-        run: npm run test:run
+      - name: Tests
+        run: pnpm run test:run
 
-      - name: Build project
-        run: npm run build
+      - name: Build
+        run: pnpm run build
         env:
           NEXT_PUBLIC_API_BASE_URL: ${{ secrets.NEXT_PUBLIC_API_BASE_URL }}
           NEXT_PUBLIC_N8N_WEBHOOK_URL: ${{ secrets.NEXT_PUBLIC_N8N_WEBHOOK_URL }}
           NEXT_PUBLIC_ADMIN_BASE_URL: ${{ secrets.NEXT_PUBLIC_ADMIN_BASE_URL }}
+
+      # Lint is deliberately absent. `next lint` was removed in Next 16, so the
+      # old step invoked `next <dir>` and would have failed; and running eslint
+      # directly currently cannot resolve eslint-plugin-format under pnpm's
+      # layout. Both are real and are filed separately — a step that cannot pass
+      # would make this pipeline red on arrival and get switched off again,
+      # which is how the previous one ended up unread.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "check-types:app": "node scripts/check-types.mjs",
     "check-lockfile": "node scripts/check-lockfile.mjs",
     "type-check": "npm run check-types",
-    "lint": "next lint",
+    "lint": "eslint .",
     "test": "vitest",
     "test:run": "vitest run",
     "prepare": "husky"


### PR DESCRIPTION
## The finding

`.github/workflows/ci.yml` listens for pushes to `main` and PRs to `main`. **This repo's trunk is `production`.**

```
$ gh run list --workflow "CI/CD Pipeline"
(no runs)
```

It has never executed. Every merge to date — including everything in the reporting work — was verified by Vercel's build and by whatever the author happened to run locally. There has been no independent check at all.

It would also have failed if it *had* fired: the first step is `npm ci`, and this repo's `package-lock.json` was deliberately deleted (#63) so that pnpm's lockfile is the only one and Vercel reads it.

## What it does now

The same install Vercel performs — `pnpm install --frozen-lockfile` — then:

| Step | Why |
|---|---|
| `check-lockfile` | a drifted lockfile fails here, not at deploy: that's the August outage |
| `check-types:app` | the gate, not raw `tsc` — it fails closed when tsc can't run |
| `test:run` | 468 tests |
| `build` | production build, all 22 pages |

## Lint is deliberately not a step

Two separate real problems, neither of which this PR is the place to solve:

1. **`next lint` was removed in Next 16**, so the old `lint` script invoked `next <dir>` — it errors with *"Invalid project directory provided, no such directory: …/lint"*. Fixed here to `eslint .`, so the script at least means something.
2. **eslint can't resolve `eslint-plugin-format` under pnpm's layout** — `ERR_MODULE_NOT_FOUND` on config load. Another npm-vs-pnpm divergence, like the one in #89.

A lint step would make this pipeline red on arrival, and a red pipeline gets switched off — roughly how the previous one ended up unread for months. Filed separately rather than papered over.

## Note

This PR's own checks will show whether the workflow runs, since it targets `production`. That's the point: it's self-demonstrating.