### PR TITLE
Apply the jest-dom assertion rewrites, having read them

### DIFF
--- a/app/reports/games/[key]/page.tsx
+++ b/app/reports/games/[key]/page.tsx
@@ -18,7 +18,7 @@ import { ReportError } from '@/components/reports/ReportError';
 import { ReportsShell } from '@/components/reports/ReportsShell';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
-import { useGameMeta, useGameColor } from '@/hooks/use-game-meta';
+import { useGameColor, useGameMeta } from '@/hooks/use-game-meta';
 import { useReport } from '@/hooks/use-report';
 import { useReportFilters } from '@/hooks/use-report-filters';
 import { useAuth } from '@/lib/auth';

--- a/components/admin/__tests__/SectionNav.test.tsx
+++ b/components/admin/__tests__/SectionNav.test.tsx
@@ -22,15 +22,15 @@ describe('sectionNav', () => {
     // listing it.
     render(<SectionNav groups={GROUPS} />);
 
-    expect(screen.getByText('Overview')).toBeTruthy();
-    expect(screen.getByText('People')).toBeTruthy();
+    expect(screen.getByText('Overview')).toBeInTheDocument();
+    expect(screen.getByText('People')).toBeInTheDocument();
   });
 
   it('marks only the current page as current', () => {
     render(<SectionNav groups={GROUPS} />);
 
-    expect(screen.getByRole('link', { name: /Players/ }).getAttribute('aria-current')).toBe('page');
-    expect(screen.getByRole('link', { name: /Daily Pulse/ }).getAttribute('aria-current')).toBeNull();
+    expect(screen.getByRole('link', { name: /Players/ })).toHaveAttribute('aria-current', 'page');
+    expect(screen.getByRole('link', { name: /Daily Pulse/ })).not.toHaveAttribute('aria-current');
   });
 
   it('does not light up the section root on every page', () => {
@@ -39,6 +39,7 @@ describe('sectionNav', () => {
     render(<SectionNav groups={GROUPS} />);
 
     const current = screen.getAllByRole('link').filter(link => link.getAttribute('aria-current') === 'page');
+
     expect(current).toHaveLength(1);
   });
 
@@ -48,7 +49,7 @@ describe('sectionNav', () => {
     // ten — so the same nav has to work without captions.
     const { container } = render(<SectionNav groups={[{ heading: '', items: GROUPS[0].items }]} />);
 
-    expect(screen.getByRole('link', { name: /Daily Pulse/ })).toBeTruthy();
+    expect(screen.getByRole('link', { name: /Daily Pulse/ })).toBeInTheDocument();
     // No caption element at all — an empty one still takes its line height and
     // margin, so the group would sit oddly low for no visible reason.
     expect(container.querySelector('p')).toBeNull();
@@ -62,7 +63,7 @@ describe('sectionNav', () => {
       />,
     );
 
-    expect(screen.getByRole('link', { name: /What the numbers mean/ })).toBeTruthy();
+    expect(screen.getByRole('link', { name: /What the numbers mean/ })).toBeInTheDocument();
   });
 });
 
@@ -104,7 +105,9 @@ describe('report nav groups', () => {
     const walk = (dir: string, prefix: string) => {
       for (const entry of readdirSync(dir, { withFileTypes: true })) {
         // Route groups and colocated tests are not pages.
-        if (!entry.isDirectory() || entry.name.startsWith('[') || entry.name === '__tests__') continue;
+        if (!entry.isDirectory() || entry.name.startsWith('[') || entry.name === '__tests__') {
+          continue;
+        }
         routes.add(`${prefix}/${entry.name}`);
         walk(join(dir, entry.name), `${prefix}/${entry.name}`);
       }
@@ -117,6 +120,7 @@ describe('report nav groups', () => {
     ]);
 
     const missing = [...routes].filter(route => !linked.has(route));
+
     expect(missing, `Report pages not in the nav: ${missing.join(', ')}`).toEqual([]);
   });
 });
@@ -133,9 +137,13 @@ describe('user hub nav groups', () => {
     const root = join(process.cwd(), 'app', 'user-hub');
     const routes: string[] = ['/user-hub'];
     for (const entry of readdirSync(root, { withFileTypes: true })) {
-      if (!entry.isDirectory() || entry.name.startsWith('[') || entry.name === '__tests__') continue;
+      if (!entry.isDirectory() || entry.name.startsWith('[') || entry.name === '__tests__') {
+        continue;
+      }
       const page = join(root, entry.name, 'page.tsx');
-      if (readFileSync(page, 'utf8').includes('permanentRedirect')) continue;
+      if (readFileSync(page, 'utf8').includes('permanentRedirect')) {
+        continue;
+      }
       routes.push(`/user-hub/${entry.name}`);
     }
 
@@ -145,6 +153,7 @@ describe('user hub nav groups', () => {
     ]);
 
     const missing = routes.filter(route => !linked.has(route));
+
     expect(missing, `User Hub pages not in the nav: ${missing.join(', ')}`).toEqual([]);
   });
 

--- a/components/reports/ActivityChart.tsx
+++ b/components/reports/ActivityChart.tsx
@@ -1,16 +1,14 @@
 'use client';
 
-import type { ActivityDay, MetricKey } from '@/types/reports';
-import { CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { METRIC_OPTIONS } from '@/types/reports';
+import type { ActivityDay, Granularity, MetricKey } from '@/types/reports';
 import { useTheme } from 'next-themes';
+import { CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { ChartTooltip } from '@/components/reports/ChartTooltip';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { chartTheme } from '@/lib/chart-theme';
 import { metricPanels } from '@/lib/metric-panels';
-import type { Granularity } from '@/types/reports';
-import { GRANULARITIES } from '@/types/reports';
 import { cn } from '@/lib/utils';
-import { ChartTooltip } from '@/components/reports/ChartTooltip';
+import { GRANULARITIES, METRIC_OPTIONS } from '@/types/reports';
 
 /** Day-month tick, in UTC so it renders as the intended day regardless of viewer TZ. */
 /** Labels follow the bucket: a month bar labelled "1 Aug" reads as one day. */
@@ -26,8 +24,10 @@ function formatBucket(iso: string, granularity: Granularity): string {
   return granularity === 'week' ? `w/c ${day}` : day;
 }
 
-/** A metric's total over the window, skipping uncovered days rather than
- *  counting them as zero — the same rule the chart draws by. */
+/**
+ * A metric's total over the window, skipping uncovered days rather than
+ *  counting them as zero — the same rule the chart draws by.
+ */
 function total(rows: { [key: string]: unknown }[], key: MetricKey): number {
   return rows.reduce((sum, row) => sum + (typeof row[key] === 'number' ? (row[key] as number) : 0), 0);
 }
@@ -47,7 +47,7 @@ const DEFAULT_COLORS: Record<MetricKey, string> = {
  * magnitudes flattens the small ones into a line along the bottom — distinct
  * players runs in the tens where games played runs in the thousands, so the
  * shape of the most interesting series was never visible. And a shared axis
- * *asserts* comparability: it invites reading the gap between two lines as if
+ * asserts* comparability: it invites reading the gap between two lines as if
  * it meant something, when one counts sessions and the other counts people.
  *
  * Small multiples instead. Each panel keeps its own scale, they share the

--- a/components/reports/__tests__/ActivityChart.test.tsx
+++ b/components/reports/__tests__/ActivityChart.test.tsx
@@ -39,9 +39,9 @@ describe('activityChart', () => {
     // people.
     render(chart('games_started'));
 
-    expect(screen.getByText('Finished')).toBeTruthy();
-    expect(screen.getByText('Players')).toBeTruthy();
-    expect(screen.getByText('Multiplayer')).toBeTruthy();
+    expect(screen.getByText('Finished')).toBeInTheDocument();
+    expect(screen.getByText('Players')).toBeInTheDocument();
+    expect(screen.getByText('Multiplayer')).toBeInTheDocument();
   });
 
   it('does not give the selected metric a second panel', () => {
@@ -49,16 +49,16 @@ describe('activityChart', () => {
     // are different measurements.
     render(chart('distinct_players'));
 
-    expect(screen.queryByText('Players')).toBeNull();
-    expect(screen.getByText('Played')).toBeTruthy();
+    expect(screen.queryByText('Players')).not.toBeInTheDocument();
+    expect(screen.getByText('Played')).toBeInTheDocument();
   });
 
   it('totals each panel over the window', () => {
     render(chart('games_started'));
 
-    expect(screen.getByText('1,800')).toBeTruthy();
-    expect(screen.getByText('90')).toBeTruthy();
-    expect(screen.getByText('360')).toBeTruthy();
+    expect(screen.getByText('1,800')).toBeInTheDocument();
+    expect(screen.getByText('90')).toBeInTheDocument();
+    expect(screen.getByText('360')).toBeInTheDocument();
   });
 
   it('leaves uncovered days out of a panel total rather than counting them as zero', () => {
@@ -75,7 +75,7 @@ describe('activityChart', () => {
       />,
     );
 
-    expect(screen.getByText('600')).toBeTruthy();
+    expect(screen.getByText('600')).toBeInTheDocument();
   });
 
   it('says how many days were never computed', () => {
@@ -90,6 +90,6 @@ describe('activityChart', () => {
       />,
     );
 
-    expect(screen.getByText(/1 day in this range were never computed/)).toBeTruthy();
+    expect(screen.getByText(/1 day in this range were never computed/)).toBeInTheDocument();
   });
 });

--- a/components/reports/__tests__/ActivityHeatmap.test.tsx
+++ b/components/reports/__tests__/ActivityHeatmap.test.tsx
@@ -88,8 +88,8 @@ describe('activityHeatmap', () => {
 
     render(<ActivityHeatmap rows={rows} peakCell={null} busiest={100} timezone="Europe/Sofia" />);
 
-    expect(screen.getByText('0')).toBeTruthy();
-    expect(screen.getByText(/76–100|100/)).toBeTruthy();
+    expect(screen.getByText('0')).toBeInTheDocument();
+    expect(screen.getByText(/76–100|100/)).toBeInTheDocument();
   });
 
   it('keeps ordinary cells visible against a heavy peak', () => {

--- a/components/reports/__tests__/AnomalySensitivity.test.tsx
+++ b/components/reports/__tests__/AnomalySensitivity.test.tsx
@@ -36,7 +36,7 @@ describe('anomalySensitivity', () => {
   it('says what the current setting means, not just its name', () => {
     render(<AnomalySensitivity value="strict" onChange={() => {}} />);
 
-    expect(screen.getByText(/only big games moving a lot/i)).toBeTruthy();
+    expect(screen.getByText(/only big games moving a lot/i)).toBeInTheDocument();
   });
 
   it('reports the chosen preset', async () => {

--- a/components/reports/__tests__/ChartTooltip.test.tsx
+++ b/components/reports/__tests__/ChartTooltip.test.tsx
@@ -27,26 +27,26 @@ describe('chartTooltip', () => {
     // legibility; coloured text on a small tooltip does.
     render(<ChartTooltip active payload={PAYLOAD} label="28 Jul" />);
 
-    expect(screen.getByText('20,123').getAttribute('style')).toBeNull();
+    expect(screen.getByText('20,123')).not.toHaveAttribute('style');
   });
 
   it('formats numbers so long counts stay readable', () => {
     render(<ChartTooltip active payload={PAYLOAD} label="28 Jul" />);
 
-    expect(screen.getByText('20,123')).toBeTruthy();
+    expect(screen.getByText('20,123')).toBeInTheDocument();
   });
 
   it('shows a dash for a gap rather than zero', () => {
     // Uncovered days are drawn as breaks; the tooltip must not turn one into 0.
     render(<ChartTooltip active payload={[{ name: 'Played', value: null, color: '#059669' }]} label="28 Jul" />);
 
-    expect(screen.getByText('—')).toBeTruthy();
+    expect(screen.getByText('—')).toBeInTheDocument();
   });
 
   it('renders nothing when inactive', () => {
     const { container } = render(<ChartTooltip payload={PAYLOAD} label="28 Jul" />);
 
-    expect(container.firstChild).toBeNull();
+    expect(container).toBeEmptyDOMElement();
   });
 
   it('keeps a zero label, which is a real hour', () => {
@@ -56,7 +56,7 @@ describe('chartTooltip', () => {
     // against a mutation it should have caught.
     render(<ChartTooltip active payload={PAYLOAD} label={0} />);
 
-    expect(screen.getByText('0')).toBeTruthy();
+    expect(screen.getByText('0')).toBeInTheDocument();
   });
 
   it('draws no heading when the formatter returns nothing', () => {
@@ -71,7 +71,7 @@ describe('chartTooltip', () => {
   it('applies a label formatter when given one', () => {
     render(<ChartTooltip active payload={PAYLOAD} label={14} labelFormatter={h => `${h}:00`} />);
 
-    expect(screen.getByText('14:00')).toBeTruthy();
+    expect(screen.getByText('14:00')).toBeInTheDocument();
   });
 
   it('takes the dot colour off the datum when the series has none', () => {
@@ -112,13 +112,13 @@ describe('chartTooltip', () => {
       />,
     );
 
-    expect(screen.getByText('Play-through: 42%')).toBeTruthy();
+    expect(screen.getByText('Play-through: 42%')).toBeInTheDocument();
   });
 
   it('omits the footer when there is no formatter for it', () => {
     render(<ChartTooltip active payload={PAYLOAD} label="28 Jul" />);
 
-    expect(screen.queryByText(/Play-through/)).toBeNull();
+    expect(screen.queryByText(/Play-through/)).not.toBeInTheDocument();
   });
 
   it('draws no footer rule when the datum cannot support one', () => {

--- a/components/reports/__tests__/ComparePicker.test.tsx
+++ b/components/reports/__tests__/ComparePicker.test.tsx
@@ -48,17 +48,26 @@ describe('comparePicker', () => {
     const clear = screen.getByRole('button', { name: 'Clear the comparison period' });
 
     expect(clear.tagName).toBe('BUTTON');
+
     await userEvent.tab();
+
     expect(document.activeElement).not.toBeNull();
   });
 
   it('marks the chosen offset as selected, and not while a period is named', () => {
     const { rerender } = render(<ComparePicker offset={2} onChange={() => {}} />);
-    expect(screen.getByRole('button', { name: '2 periods back' }).className).toContain('bg-');
+
+    // The selected offset renders shadcn's `default` variant; the others
+    // render `outline`. Asserting the real class rather than a `bg-` prefix:
+    // the prefix form was a substring check that an automated rewrite turned
+    // into exact-token matching, which then matched nothing.
+    expect(screen.getByRole('button', { name: '2 periods back' })).toHaveClass('bg-primary');
+    expect(screen.getByRole('button', { name: 'Previous period' })).not.toHaveClass('bg-primary');
 
     // With a named period, no offset button should read as active — the
     // comparison isn't using any of them.
     rerender(<ComparePicker offset={2} start="2026-01-01" onChange={() => {}} />);
-    expect(screen.getByRole('button', { name: /2026-01-01/ })).toBeTruthy();
+
+    expect(screen.getByRole('button', { name: /2026-01-01/ })).toBeInTheDocument();
   });
 });

--- a/components/reports/__tests__/DurationHistogram.test.tsx
+++ b/components/reports/__tests__/DurationHistogram.test.tsx
@@ -50,8 +50,8 @@ describe('durationHistogram card', () => {
   it('draws the bands for the first measurable game', () => {
     render(<DurationHistogram data={data([row({})])} meta={META as never} />);
 
-    expect(screen.getByText('under 1.0m')).toBeTruthy();
-    expect(screen.getByText('over 2.0m')).toBeTruthy();
+    expect(screen.getByText('under 1.0m')).toBeInTheDocument();
+    expect(screen.getByText('over 2.0m')).toBeInTheDocument();
   });
 
   it('skips a game whose bands are all empty rather than drawing a blank card', () => {
@@ -65,14 +65,14 @@ describe('durationHistogram card', () => {
     });
     render(<DurationHistogram data={data([empty, row({})])} meta={META as never} />);
 
-    expect(screen.getByText('Team Ties')).toBeTruthy();
-    expect(screen.queryByText('Grid')).toBeNull();
+    expect(screen.getByText('Team Ties')).toBeInTheDocument();
+    expect(screen.queryByText('Grid')).not.toBeInTheDocument();
   });
 
   it('renders nothing when no game has anything to draw', () => {
     const empty = row({ buckets: [{ under_seconds: null, count: 0 }] });
     const { container } = render(<DurationHistogram data={data([empty])} meta={META as never} />);
 
-    expect(container.firstChild).toBeNull();
+    expect(container).toBeEmptyDOMElement();
   });
 });

--- a/components/reports/__tests__/DurationSpread.test.tsx
+++ b/components/reports/__tests__/DurationSpread.test.tsx
@@ -26,7 +26,7 @@ describe('durationSpread', () => {
   it('shows where the middle half of sessions sit', () => {
     render(<DurationSpread row={row({})} />);
 
-    expect(screen.getByText('3.3m–7.3m')).toBeTruthy();
+    expect(screen.getByText('3.3m–7.3m')).toBeInTheDocument();
   });
 
   it('names every percentile behind the bar', () => {
@@ -61,12 +61,12 @@ describe('durationSpread', () => {
     // — worse than an obvious gap, because it looks measured.
     render(<DurationSpread row={row({ p25_seconds: undefined, p75_seconds: undefined })} />);
 
-    expect(screen.getByText('—')).toBeTruthy();
+    expect(screen.getByText('—')).toBeInTheDocument();
   });
 
   it('draws a dash for a game with no median at all', () => {
     render(<DurationSpread row={row({ median_seconds: null })} />);
 
-    expect(screen.getByText('—')).toBeTruthy();
+    expect(screen.getByText('—')).toBeInTheDocument();
   });
 });

--- a/components/reports/__tests__/DurationTable.test.tsx
+++ b/components/reports/__tests__/DurationTable.test.tsx
@@ -62,16 +62,16 @@ describe('durationTable long-lived section', () => {
     // attention.
     render(<DurationTable data={response([row({}), SWEPT])} meta={META as never} />);
 
-    expect(screen.getByText('Idle sweep')).toBeTruthy();
-    expect(screen.getByText(/72.5% of measured sessions were closed after 24h idle/)).toBeTruthy();
-    expect(screen.queryByText(/by design/)).toBeNull();
+    expect(screen.getByText('Idle sweep')).toBeInTheDocument();
+    expect(screen.getByText(/72.5% of measured sessions were closed after 24h idle/)).toBeInTheDocument();
+    expect(screen.queryByText(/by design/)).not.toBeInTheDocument();
   });
 
   it('shows the median among sessions that played out', () => {
     // 24h is the sweeper's clock; 8 minutes is the game.
     render(<DurationTable data={response([row({}), SWEPT])} meta={META as never} />);
 
-    expect(screen.getByText('8.0m')).toBeTruthy();
+    expect(screen.getByText('8.0m')).toBeInTheDocument();
   });
 
   it('does not explain a long game the backend has not classified', () => {
@@ -80,14 +80,14 @@ describe('durationTable long-lived section', () => {
     const unexplained = row({ game_type: 'conquest', median_seconds: 86400, single_sitting: false });
     render(<DurationTable data={response([row({}), unexplained])} meta={META as never} />);
 
-    expect(screen.queryByText('Idle sweep')).toBeNull();
-    expect(screen.queryByText('Long play')).toBeNull();
+    expect(screen.queryByText('Idle sweep')).not.toBeInTheDocument();
+    expect(screen.queryByText('Long play')).not.toBeInTheDocument();
   });
 
   it('leaves the comparable table alone', () => {
     render(<DurationTable data={response([row({}), SWEPT])} meta={META as never} />);
 
-    expect(screen.getByText('How long a session lasts')).toBeTruthy();
-    expect(screen.getByText('5.5m')).toBeTruthy();
+    expect(screen.getByText('How long a session lasts')).toBeInTheDocument();
+    expect(screen.getByText('5.5m')).toBeInTheDocument();
   });
 });

--- a/components/reports/__tests__/GameFilter.test.tsx
+++ b/components/reports/__tests__/GameFilter.test.tsx
@@ -16,15 +16,15 @@ describe('gameFilter', () => {
     // data-derived list would hide it precisely when it matters.
     render(<GameFilter meta={META} value={null} onChange={() => {}} />);
 
-    expect(screen.getByText('Grid')).toBeTruthy();
-    expect(screen.getByText('Quiz')).toBeTruthy();
-    expect(screen.getByText('Conquest')).toBeTruthy();
+    expect(screen.getByText('Grid')).toBeInTheDocument();
+    expect(screen.getByText('Quiz')).toBeInTheDocument();
+    expect(screen.getByText('Conquest')).toBeInTheDocument();
   });
 
   it('marks "All games" as the selected state when nothing is filtered', () => {
     render(<GameFilter meta={META} value={null} onChange={() => {}} />);
 
-    expect(screen.getByRole('button', { name: 'All games' }).getAttribute('aria-pressed')).toBe('true');
+    expect(screen.getByRole('button', { name: 'All games' })).toHaveAttribute('aria-pressed', 'true');
   });
 
   it('clears the filter when the active game is clicked again', async () => {
@@ -51,7 +51,7 @@ describe('gameFilter', () => {
     // Better an absent control than an empty one that looks broken.
     const { container } = render(<GameFilter meta={{}} value={null} onChange={() => {}} />);
 
-    expect(container.firstChild).toBeNull();
+    expect(container).toBeEmptyDOMElement();
   });
 
   it('lists games alphabetically so the control does not reorder itself', () => {

--- a/components/reports/__tests__/GameHourProfile.test.tsx
+++ b/components/reports/__tests__/GameHourProfile.test.tsx
@@ -34,15 +34,15 @@ describe('gameHourProfile', () => {
     // question, and counts would make every small game look flat.
     render(<GameHourProfile data={data()} gameLabel="Grid" />);
 
-    expect(screen.getByText('20:00')).toBeTruthy();
-    expect(screen.getByText(/40% of its sessions start in that hour/)).toBeTruthy();
+    expect(screen.getByText('20:00')).toBeInTheDocument();
+    expect(screen.getByText(/40% of its sessions start in that hour/)).toBeInTheDocument();
   });
 
   it('states the timezone the hours are in', () => {
     // "8pm" means nothing without it, and the platform buckets in Sofia time.
     render(<GameHourProfile data={data()} gameLabel="Grid" />);
 
-    expect(screen.getByText(/Europe\/Sofia/)).toBeTruthy();
+    expect(screen.getByText(/Europe\/Sofia/)).toBeInTheDocument();
   });
 
   it('puts each hour\'s numbers in the accessibility tree, not only in a tooltip', () => {
@@ -51,8 +51,8 @@ describe('gameHourProfile', () => {
     // this matches them.
     render(<GameHourProfile data={data()} gameLabel="Grid" />);
 
-    expect(screen.getByLabelText('20:00 — 40 sessions (40%)')).toBeTruthy();
-    expect(screen.getByLabelText('Grid sessions by hour, Europe/Sofia')).toBeTruthy();
+    expect(screen.getByLabelText('20:00 — 40 sessions (40%)')).toBeInTheDocument();
+    expect(screen.getByLabelText('Grid sessions by hour, Europe/Sofia')).toBeInTheDocument();
   });
 
   it('renders nothing for a game with no play in the window', () => {
@@ -60,6 +60,6 @@ describe('gameHourProfile', () => {
     // confident-looking answer to a question with no data behind it.
     const { container } = render(<GameHourProfile data={data({ by_hour: hours({}) })} gameLabel="Grid" />);
 
-    expect(container.firstChild).toBeNull();
+    expect(container).toBeEmptyDOMElement();
   });
 });

--- a/components/reports/__tests__/GameRetentionCard.test.tsx
+++ b/components/reports/__tests__/GameRetentionCard.test.tsx
@@ -38,8 +38,8 @@ describe('gameRetentionCard', () => {
     // questions.
     render(<GameRetentionCard data={data()} gameKey="scout" gameLabel="Scout" />);
 
-    expect(screen.getByText('12.1%')).toBeTruthy();
-    expect(screen.getByText(/\+5\.5 vs median 6\.6%/)).toBeTruthy();
+    expect(screen.getByText('12.1%')).toBeInTheDocument();
+    expect(screen.getByText(/\+5\.5 vs median 6\.6%/)).toBeInTheDocument();
   });
 
   it('says why a rate is missing rather than showing a bare dash', () => {
@@ -55,7 +55,7 @@ describe('gameRetentionCard', () => {
     // sample-size problem that is really just time.
     render(<GameRetentionCard data={data()} gameKey="scout" gameLabel="Scout" />);
 
-    expect(screen.getByText(/no cohort has reached this day yet/)).toBeTruthy();
+    expect(screen.getByText(/no cohort has reached this day yet/)).toBeInTheDocument();
   });
 
   it('says so when there is no peer median to compare with', () => {
@@ -67,6 +67,6 @@ describe('gameRetentionCard', () => {
   it('renders nothing for a game the response does not carry', () => {
     const { container } = render(<GameRetentionCard data={data()} gameKey="conquest" gameLabel="Conquest" />);
 
-    expect(container.firstChild).toBeNull();
+    expect(container).toBeEmptyDOMElement();
   });
 });

--- a/components/reports/__tests__/MultiplayerFunnel.test.tsx
+++ b/components/reports/__tests__/MultiplayerFunnel.test.tsx
@@ -23,8 +23,8 @@ describe('multiplayerFunnel', () => {
 
     // 40/100 started, then 30/40 of those finished — the second rate is of the
     // previous stage, not of rooms created, which is the easy thing to get wrong.
-    expect(screen.getByText(/40% started/)).toBeTruthy();
-    expect(screen.getByText(/75% of those finished/)).toBeTruthy();
+    expect(screen.getByText(/40% started/)).toBeInTheDocument();
+    expect(screen.getByText(/75% of those finished/)).toBeInTheDocument();
   });
 
   it('says nothing started rather than claiming 0% finished', () => {
@@ -32,16 +32,16 @@ describe('multiplayerFunnel', () => {
     // abandonment when in fact no game ever began.
     render(<MultiplayerFunnel rows={[row({ rooms_started: 0, rooms_finished: 0 })]} meta={META} />);
 
-    expect(screen.getByText(/none started, so nothing to finish/)).toBeTruthy();
-    expect(screen.queryByText(/0% of those finished/)).toBeNull();
+    expect(screen.getByText(/none started, so nothing to finish/)).toBeInTheDocument();
+    expect(screen.queryByText(/0% of those finished/)).not.toBeInTheDocument();
   });
 
   it('labels every bar with its count, so the shape is never the only signal', () => {
     render(<MultiplayerFunnel rows={[row()]} meta={META} />);
 
-    expect(screen.getByLabelText('Created: 100 rooms')).toBeTruthy();
-    expect(screen.getByLabelText('Started: 40 rooms')).toBeTruthy();
-    expect(screen.getByLabelText('Finished: 30 rooms')).toBeTruthy();
+    expect(screen.getByLabelText('Created: 100 rooms')).toBeInTheDocument();
+    expect(screen.getByLabelText('Started: 40 rooms')).toBeInTheDocument();
+    expect(screen.getByLabelText('Finished: 30 rooms')).toBeInTheDocument();
   });
 
   it('drops games with no rooms instead of drawing empty scaffolding', () => {
@@ -52,7 +52,7 @@ describe('multiplayerFunnel', () => {
       />,
     );
 
-    expect(screen.queryByLabelText('Created: 0 rooms')).toBeNull();
+    expect(screen.queryByLabelText('Created: 0 rooms')).not.toBeInTheDocument();
   });
 
   it('orders games by volume so the biggest funnel is read first', () => {
@@ -71,6 +71,6 @@ describe('multiplayerFunnel', () => {
   it('says so when there are no rooms at all', () => {
     render(<MultiplayerFunnel rows={[]} meta={META} />);
 
-    expect(screen.getByText(/no multiplayer rooms in this window/i)).toBeTruthy();
+    expect(screen.getByText(/no multiplayer rooms in this window/i)).toBeInTheDocument();
   });
 });

--- a/components/reports/__tests__/PulseTiles.test.tsx
+++ b/components/reports/__tests__/PulseTiles.test.tsx
@@ -36,7 +36,7 @@ describe('pulseTiles', () => {
     // was being compared, which is what let that survive unnoticed.
     render(<PulseTiles pulse={pulse(0.5) as never} />);
 
-    expect(screen.getByText(/Today so far, against the same 50% of a typical day/)).toBeTruthy();
+    expect(screen.getByText(/Today so far, against the same 50% of a typical day/)).toBeInTheDocument();
   });
 
   it('says "by now" on the baseline, not just "typical Thursday"', () => {
@@ -51,7 +51,7 @@ describe('pulseTiles', () => {
 
     // Built with the same formatter the component uses: a literal "548.8"
     // would assert the runtime's decimal separator, not the behaviour.
-    expect(screen.getByText(`Full Thursday: ${(548.8).toLocaleString()}`)).toBeTruthy();
+    expect(screen.getByText(`Full Thursday: ${(548.8).toLocaleString()}`)).toBeInTheDocument();
   });
 
   it('drops "by now" from the baseline once the day is complete', () => {
@@ -59,7 +59,7 @@ describe('pulseTiles', () => {
     // partial comparison that has already ended.
     render(<PulseTiles pulse={pulse(1) as never} />);
 
-    expect(screen.queryByText(/by now/)).toBeNull();
+    expect(screen.queryByText(/by now/)).not.toBeInTheDocument();
     expect(screen.getAllByText(new RegExp(`typical Thursday: ${(206.1).toLocaleString()}`)).length).toBeGreaterThan(0);
   });
 
@@ -68,7 +68,7 @@ describe('pulseTiles', () => {
     // explanation would be noise.
     render(<PulseTiles pulse={pulse(1) as never} />);
 
-    expect(screen.queryByText(/Today so far, against/)).toBeNull();
-    expect(screen.queryByText(/Full Thursday:/)).toBeNull();
+    expect(screen.queryByText(/Today so far, against/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Full Thursday:/)).not.toBeInTheDocument();
   });
 });

--- a/components/reports/__tests__/RangePicker.test.tsx
+++ b/components/reports/__tests__/RangePicker.test.tsx
@@ -24,13 +24,14 @@ describe('bots control', () => {
     setup(false);
 
     const control = screen.getByRole('switch', { name: /include bots/i });
-    expect(control.getAttribute('aria-checked')).toBe('false');
+
+    expect(control).not.toBeChecked();
   });
 
   it('shows on when bots are actually included', () => {
     setup(true);
 
-    expect(screen.getByRole('switch', { name: /include bots/i }).getAttribute('aria-checked')).toBe('true');
+    expect(screen.getByRole('switch', { name: /include bots/i })).toBeChecked();
   });
 
   it('does not present itself as a selected filter beside the window presets', () => {
@@ -39,6 +40,7 @@ describe('bots control', () => {
     setup(false);
 
     const buttons = screen.getAllByRole('button').map(b => b.textContent);
+
     expect(buttons.some(label => /bots/i.test(label ?? ''))).toBe(false);
   });
 
@@ -54,9 +56,9 @@ describe('bots control', () => {
     // "1d" beside a "Today" button would be the same range under two names.
     render(<RangePicker value={{ window: 30 }} onChange={() => {}} includeBots={false} onIncludeBotsChange={() => {}} />);
 
-    expect(screen.getByRole('button', { name: 'Today' })).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'Yesterday' })).toBeTruthy();
-    expect(screen.queryByRole('button', { name: '1d' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'Today' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Yesterday' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '1d' })).not.toBeInTheDocument();
   });
 
   it('asks for a one-day window when Today is picked', async () => {
@@ -76,6 +78,7 @@ describe('bots control', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Yesterday' }));
 
     const arg = onChange.mock.calls[0][0];
+
     expect(arg.start).toBe(arg.end);
     expect(arg.start).not.toBeUndefined();
     // The previous preset survives, so clearing the range returns to it.

--- a/components/reports/__tests__/ReportPanel.test.tsx
+++ b/components/reports/__tests__/ReportPanel.test.tsx
@@ -16,8 +16,8 @@ describe('reportPanel', () => {
       </ReportPanel>,
     );
 
-    expect(await screen.findByText(/Boom/)).toBeTruthy();
-    expect(screen.queryByText('content')).toBeNull();
+    expect(await screen.findByText(/Boom/)).toBeInTheDocument();
+    expect(screen.queryByText('content')).not.toBeInTheDocument();
   });
 
   it('retries only itself', async () => {
@@ -41,7 +41,7 @@ describe('reportPanel', () => {
       </ReportPanel>,
     );
 
-    expect(screen.getByText('loaded-true')).toBeTruthy();
+    expect(screen.getByText('loaded-true')).toBeInTheDocument();
   });
 
   it('gives children non-null data, so no call site repeats the guard', () => {
@@ -60,7 +60,7 @@ describe('reportPanel', () => {
       </ReportPanel>,
     );
 
-    expect(screen.queryByText('content')).toBeNull();
+    expect(screen.queryByText('content')).not.toBeInTheDocument();
   });
 
   it('keeps the previous numbers on screen while refetching', () => {
@@ -73,6 +73,6 @@ describe('reportPanel', () => {
       </ReportPanel>,
     );
 
-    expect(screen.getByText('content')).toBeTruthy();
+    expect(screen.getByText('content')).toBeInTheDocument();
   });
 });

--- a/components/reports/__tests__/game-name.test.tsx
+++ b/components/reports/__tests__/game-name.test.tsx
@@ -37,7 +37,7 @@ describe('gameBadge', () => {
       />,
     );
 
-    expect(screen.getByText('Career Path')).toBeTruthy();
-    expect(screen.queryByText(/Game Sessions/)).toBeNull();
+    expect(screen.getByText('Career Path')).toBeInTheDocument();
+    expect(screen.queryByText(/Game Sessions/)).not.toBeInTheDocument();
   });
 });

--- a/lib/__tests__/report-filters.test.ts
+++ b/lib/__tests__/report-filters.test.ts
@@ -115,18 +115,23 @@ describe('every report page keeps its filters in the URL', () => {
     function pages(dir: string): string[] {
       return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
         const full = join(dir, entry.name);
-        if (entry.isDirectory()) return pages(full);
+        if (entry.isDirectory()) {
+          return pages(full);
+        }
         return entry.name === 'page.tsx' ? [full] : [];
       });
     }
 
     const found = pages(root);
+
     expect(found.length).toBeGreaterThan(5);
 
     const offenders = found.filter((file) => {
       const source = readFileSync(file, 'utf8');
       // A page with no range picker has no filters to share.
-      if (!source.includes('RangePicker')) return false;
+      if (!source.includes('RangePicker')) {
+        return false;
+      }
       // Holding the range in local state is the actual anti-pattern, and the
       // shape a new page naturally reaches for. Checking only for the hook's
       // name matched even after its import was removed.
@@ -153,21 +158,28 @@ describe('every report page can be exported', () => {
     function pages(dir: string): string[] {
       return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
         const full = join(dir, entry.name);
-        if (entry.isDirectory()) return pages(full);
+        if (entry.isDirectory()) {
+          return pages(full);
+        }
         return entry.name === 'page.tsx' ? [full] : [];
       });
     }
 
     const found = pages(root);
+
     expect(found.length).toBeGreaterThan(5);
 
     const offenders = found.filter((file) => {
       const source = readFileSync(file, 'utf8');
       // The glossary is reference text, and the drill-downs are a single
       // record — neither is a dataset anyone would take to a spreadsheet.
-      if (file.includes('glossary') || file.includes('[id]') || file.includes('[key]')) return false;
+      if (file.includes('glossary') || file.includes('[id]') || file.includes('[key]')) {
+        return false;
+      }
       // A page with no range picker isn't a data view.
-      if (!source.includes('RangePicker')) return false;
+      if (!source.includes('RangePicker')) {
+        return false;
+      }
       return !source.includes('ExportButton');
     });
 

--- a/lib/__tests__/response-fields-used.test.ts
+++ b/lib/__tests__/response-fields-used.test.ts
@@ -36,7 +36,9 @@ function sources(): string {
     for (const entry of readdirSync(dir, { withFileTypes: true })) {
       const full = join(dir, entry.name);
       if (entry.isDirectory()) {
-        if (entry.name === 'node_modules' || entry.name === '__tests__') continue;
+        if (entry.name === 'node_modules' || entry.name === '__tests__') {
+          continue;
+        }
         walk(full);
       } else if (/\.tsx?$/.test(entry.name) && !full.endsWith(join('types', 'reports.ts'))) {
         // Comments are stripped: a field named only in prose is documented, not
@@ -50,7 +52,9 @@ function sources(): string {
       }
     }
   };
-  for (const dir of ['app', 'components', 'hooks', 'lib']) walk(join(ROOT, dir));
+  for (const dir of ['app', 'components', 'hooks', 'lib']) {
+    walk(join(ROOT, dir));
+  }
   return out.join('\n');
 }
 

--- a/lib/reports-api.ts
+++ b/lib/reports-api.ts
@@ -1,15 +1,15 @@
 import type {
   ActivityResponse,
-  RollupHealth,
-  GlossaryResponse,
   AnomaliesResponse,
   DurationResponse,
   GamesResponse,
+  GlossaryResponse,
   MultiplayerResponse,
   PatternsResponse,
   PlayerDetailResponse,
   ReportParams,
   RetentionResponse,
+  RollupHealth,
   SummaryResponse,
   TopPlayersResponse,
 } from '@/types/reports';

--- a/scripts/check-lockfile.mjs
+++ b/scripts/check-lockfile.mjs
@@ -44,26 +44,34 @@ function parseRootImporter(text) {
   let pendingName = null;
 
   for (const line of lines) {
-    if (/^importers:/.test(line)) {
+    if (line.startsWith('importers:')) {
       inImporters = true; continue;
     }
-    if (!inImporters) continue;
+    if (!inImporters) {
+      continue;
+    }
 
     // A new top-level key ends the importers block.
-    if (/^\S/.test(line) && !/^importers:/.test(line)) break;
+    if (/^\S/.test(line) && !line.startsWith('importers:')) {
+      break;
+    }
 
     if (/^ {2}[^\s:]+:/.test(line)) {
       inRoot = /^ {2}\.:/.test(line);
       section = null;
       continue;
     }
-    if (!inRoot) continue;
+    if (!inRoot) {
+      continue;
+    }
 
     const sectionMatch = /^ {4}(dependencies|devDependencies):/.exec(line);
     if (sectionMatch) {
       section = sectionMatch[1]; pendingName = null; continue;
     }
-    if (!section) continue;
+    if (!section) {
+      continue;
+    }
 
     const nameMatch = /^ {6}'?([^':]+)'?:\s*$/.exec(line);
     if (nameMatch) {
@@ -107,7 +115,9 @@ for (const field of ['dependencies', 'devDependencies']) {
 
 if (problems.length > 0) {
   console.error('\npnpm-lock.yaml is out of sync with package.json:\n');
-  for (const problem of problems) console.error(`  ${problem}`);
+  for (const problem of problems) {
+    console.error(`  ${problem}`);
+  }
   console.error('\nVercel installs with `pnpm install --frozen-lockfile` and will fail the deploy.');
   console.error('Fix with:  npx pnpm@10 install --lockfile-only\n');
   process.exit(1);


### PR DESCRIPTION
#104 deliberately left these: they rewrite **assertions**, and an automated rewrite that leaves the tests passing has proved nothing about itself. This applies them and then checks the thing that actually matters — that each rewritten assertion still **fails when the behaviour it describes breaks**.

## The rewrites

| Before | After | Verdict |
|---|---|---|
| `expect(getByText(x)).toBeTruthy()` | `.toBeInTheDocument()` | strictly stronger — `getByText` throws when absent, so `toBeTruthy` asserted that a thing which must exist exists |
| `expect(queryByText(x)).toBeNull()` | `.not.toBeInTheDocument()` | equivalent — jest-dom handles a null element |

## Mutation-tested, not just re-run

| Mutation | Result |
|---|---|
| strip the nav's group headings | 1 fails |
| remove the activity chart's context panels | 4 fail |
| drop the hour profile's aria-labels | 1 fails |

They still bite.

## One rewrite was wrong, and the suite caught it

The commit hook runs `eslint --fix` **unrestricted** (`lint-staged.config.js`), so beyond what I ran it also turned:

```js
expect(button.className).toContain('bg-')   // substring check
expect(button).toHaveClass('bg-')           // exact-token match
```

`toHaveClass` matches whole class names, so `'bg-'` matches nothing and the test failed immediately.

That assertion was weak to begin with — *"some class starts with `bg-`"* — so rather than reverting it, it now asserts the real class (`bg-primary`, shadcn's `default` variant) **and** that the unselected button lacks it. Mutation-tested both directions: rendering every offset as selected fails, rendering none as selected fails. **The original form could not have caught either.**

This is the concrete case for why assertion rewrites don't belong in a bulk `--fix`: one of them changed meaning, and only running the suite revealed it.

## Result

Reporting surface: **169 → 67** problems. What remains is import ordering (21) and test padding (16) — cosmetic.

468 tests passing, types clean, build compiling.