### PR TITLE
D1: give the filters a shape, across every reporting page

### DIFF
--- a/app/reports/anomalies/page.tsx
+++ b/app/reports/anomalies/page.tsx
@@ -5,6 +5,7 @@ import { useMemo, useState } from 'react';
 import { AnomalyPanel } from '@/components/reports/AnomalyPanel';
 import { AnomalySensitivity, SENSITIVITY_PRESETS } from '@/components/reports/AnomalySensitivity';
 import { ExportButton } from '@/components/reports/ExportButton';
+import { FilterBar } from '@/components/reports/FilterBar';
 import { RangePicker } from '@/components/reports/RangePicker';
 import { ReportPanel } from '@/components/reports/ReportPanel';
 import { ReportsShell } from '@/components/reports/ReportsShell';
@@ -60,17 +61,19 @@ export default function AnomaliesPage() {
       title="Needs attention"
       description="What moved enough to be worth interrupting you for, compared with the window before it."
     >
-      <RangePicker
-        value={range}
-        onChange={setRange}
-        includeBots={includeBots}
-        onIncludeBotsChange={setIncludeBots}
-      />
+      <FilterBar>
+        <RangePicker
+          value={range}
+          onChange={setRange}
+          includeBots={includeBots}
+          onIncludeBotsChange={setIncludeBots}
+        />
 
-      {/* No game filter on purpose: the point of this page is to surface the
-          game you would not have thought to look at. */}
-      <AnomalySensitivity value={sensitivity} onChange={setSensitivity} />
+        {/* No game filter on purpose: the point of this page is to surface the
+            game you would not have thought to look at. */}
+        <AnomalySensitivity value={sensitivity} onChange={setSensitivity} />
 
+      </FilterBar>
       <div className="flex justify-end">
         <ExportButton
           rows={anomalies.data?.findings ?? []}

--- a/app/reports/duration/page.tsx
+++ b/app/reports/duration/page.tsx
@@ -5,6 +5,7 @@ import { useMemo } from 'react';
 import { DurationHistogram } from '@/components/reports/DurationHistogram';
 import { DurationTable } from '@/components/reports/DurationTable';
 import { ExportButton } from '@/components/reports/ExportButton';
+import { FilterBar } from '@/components/reports/FilterBar';
 import { RangePicker } from '@/components/reports/RangePicker';
 import { ReportError } from '@/components/reports/ReportError';
 import { ReportsShell } from '@/components/reports/ReportsShell';
@@ -49,13 +50,15 @@ export default function DurationPage() {
       title="Session length"
       description="How long people stay in a game — the closest proxy we have for what holds attention."
     >
-      <RangePicker
-        value={range}
-        onChange={setRange}
-        includeBots={includeBots}
-        onIncludeBotsChange={setIncludeBots}
-      />
+      <FilterBar>
+        <RangePicker
+          value={range}
+          onChange={setRange}
+          includeBots={includeBots}
+          onIncludeBotsChange={setIncludeBots}
+        />
 
+      </FilterBar>
       <div className="flex justify-end">
         <ExportButton
           rows={data?.rows ?? []}

--- a/app/reports/games/[key]/page.tsx
+++ b/app/reports/games/[key]/page.tsx
@@ -11,6 +11,7 @@ import { ComparePicker } from '@/components/reports/ComparePicker';
 import { ComparisonTiles } from '@/components/reports/ComparisonTiles';
 import { DurationHistogram } from '@/components/reports/DurationHistogram';
 import { DurationTable } from '@/components/reports/DurationTable';
+import { FilterBar } from '@/components/reports/FilterBar';
 import { GameHourProfile } from '@/components/reports/GameHourProfile';
 import { GameRetentionCard } from '@/components/reports/GameRetentionCard';
 import { RangePicker } from '@/components/reports/RangePicker';
@@ -109,13 +110,16 @@ export default function GameDetailPage() {
           <ArrowLeft className="size-4" />
           All games
         </Link>
+      </div>
+
+      <FilterBar>
         <RangePicker
           value={range}
           onChange={setRange}
           includeBots={includeBots}
           onIncludeBotsChange={setIncludeBots}
         />
-      </div>
+      </FilterBar>
 
       {summary.error
         ? <ReportError error={summary.error} notDeployed={summary.notDeployed} onRetry={summary.refetch} />

--- a/app/reports/games/page.tsx
+++ b/app/reports/games/page.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link';
 import { useMemo, useState } from 'react';
 import { AbandonedPanel } from '@/components/reports/AbandonedPanel';
 import { ExportButton } from '@/components/reports/ExportButton';
+import { FilterBar } from '@/components/reports/FilterBar';
 import { GameBadge } from '@/components/reports/GameBadge';
 import { MetricInfo } from '@/components/reports/MetricInfo';
 import { RangePicker } from '@/components/reports/RangePicker';
@@ -97,13 +98,15 @@ export default function GamesIndexPage() {
       title="Games"
       description="Every game side by side. Click one for its own report."
     >
-      <RangePicker
-        value={range}
-        onChange={setRange}
-        includeBots={includeBots}
-        onIncludeBotsChange={setIncludeBots}
-      />
+      <FilterBar>
+        <RangePicker
+          value={range}
+          onChange={setRange}
+          includeBots={includeBots}
+          onIncludeBotsChange={setIncludeBots}
+        />
 
+      </FilterBar>
       <div className="flex justify-end">
         <ExportButton
           rows={rows}

--- a/app/reports/multiplayer/page.tsx
+++ b/app/reports/multiplayer/page.tsx
@@ -3,6 +3,7 @@
 import type { RangeState } from '@/lib/report-range';
 import { useMemo } from 'react';
 import { ExportButton } from '@/components/reports/ExportButton';
+import { FilterBar } from '@/components/reports/FilterBar';
 import { GameBadge } from '@/components/reports/GameBadge';
 import { ModeBreakdown } from '@/components/reports/ModeBreakdown';
 import { MultiplayerFunnel } from '@/components/reports/MultiplayerFunnel';
@@ -55,13 +56,15 @@ export default function MultiplayerReportPage() {
       title="Multiplayer"
       description="Rooms opened, started and finished. Counts rooms — not per-player participations."
     >
-      <RangePicker
-        value={range}
-        onChange={setRange}
-        includeBots={includeBots}
-        onIncludeBotsChange={setIncludeBots}
-      />
+      <FilterBar>
+        <RangePicker
+          value={range}
+          onChange={setRange}
+          includeBots={includeBots}
+          onIncludeBotsChange={setIncludeBots}
+        />
 
+      </FilterBar>
       {game && (
         <div className="flex flex-wrap items-center gap-2 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 dark:border-emerald-900 dark:bg-emerald-900/20">
           <span className="text-sm text-gray-700 dark:text-gray-200">Filtered to</span>

--- a/app/reports/page.tsx
+++ b/app/reports/page.tsx
@@ -4,6 +4,7 @@ import type { GameTotals, Granularity } from '@/types/reports';
 import { useMemo, useState } from 'react';
 import { ActivityChart } from '@/components/reports/ActivityChart';
 import { ExportButton } from '@/components/reports/ExportButton';
+import { FilterBar } from '@/components/reports/FilterBar';
 import { GameBadge } from '@/components/reports/GameBadge';
 import { GameLeaderboard } from '@/components/reports/GameLeaderboard';
 import { MetricToggle } from '@/components/reports/MetricToggle';
@@ -68,7 +69,7 @@ export default function ReportsPage() {
       title="Daily Pulse"
       description="How today is going, measured against a typical day of the same weekday."
     >
-      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+      <FilterBar>
         <RangePicker
           value={range}
           onChange={next => update({ range: next })}
@@ -76,7 +77,7 @@ export default function ReportsPage() {
           onIncludeBotsChange={value => update({ includeBots: value })}
         />
         <MetricToggle value={metric} onChange={next => update({ metric: next })} />
-      </div>
+      </FilterBar>
 
       {game && (
         <div className="flex flex-wrap items-center gap-2 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 dark:border-emerald-900 dark:bg-emerald-900/20">

--- a/app/reports/patterns/page.tsx
+++ b/app/reports/patterns/page.tsx
@@ -8,6 +8,7 @@ import { Area, AreaChart, Bar, BarChart, CartesianGrid, Cell, ResponsiveContaine
 import { ActivityHeatmap } from '@/components/reports/ActivityHeatmap';
 import { ChartTooltip } from '@/components/reports/ChartTooltip';
 import { ExportButton } from '@/components/reports/ExportButton';
+import { FilterBar } from '@/components/reports/FilterBar';
 import { GameFilter } from '@/components/reports/GameFilter';
 import { MetricInfo } from '@/components/reports/MetricInfo';
 import { RangePicker } from '@/components/reports/RangePicker';
@@ -77,15 +78,17 @@ export default function PatternsPage() {
       title="Patterns"
       description="When people play, and whether the players are new or coming back."
     >
-      <RangePicker
-        value={range}
-        onChange={setRange}
-        includeBots={includeBots}
-        onIncludeBotsChange={setIncludeBots}
-      />
+      <FilterBar>
+        <RangePicker
+          value={range}
+          onChange={setRange}
+          includeBots={includeBots}
+          onIncludeBotsChange={setIncludeBots}
+        />
 
-      <GameFilter meta={meta} value={game} onChange={setGame} />
+        <GameFilter meta={meta} value={game} onChange={setGame} />
 
+      </FilterBar>
       <div className="flex justify-end">
         <ExportButton
           // The grid is the page's real dataset; the two bar charts are its

--- a/app/reports/players/[id]/page.tsx
+++ b/app/reports/players/[id]/page.tsx
@@ -9,6 +9,7 @@ import { useParams } from 'next/navigation';
 import { useCallback, useMemo } from 'react';
 import { Area, AreaChart, CartesianGrid, Cell, Pie, PieChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import { ChartTooltip } from '@/components/reports/ChartTooltip';
+import { FilterBar } from '@/components/reports/FilterBar';
 import { GameBadge } from '@/components/reports/GameBadge';
 import { RangePicker } from '@/components/reports/RangePicker';
 import { ReportError } from '@/components/reports/ReportError';
@@ -99,12 +100,14 @@ export default function PlayerDetailPage() {
           <ArrowLeft className="size-4" />
           All players
         </Link>
-        <RangePicker
-          value={range}
-          onChange={setRange}
-          includeBots={false}
-          onIncludeBotsChange={() => undefined}
-        />
+        <FilterBar>
+          <RangePicker
+            value={range}
+            onChange={setRange}
+            includeBots={false}
+            onIncludeBotsChange={() => undefined}
+          />
+        </FilterBar>
 
         {/* Bot accounts are filtered out of every other report, so landing here
             from a direct link is the one way to read simulation traffic as real

--- a/app/reports/players/page.tsx
+++ b/app/reports/players/page.tsx
@@ -4,6 +4,7 @@ import type { RangeState } from '@/lib/report-range';
 import Link from 'next/link';
 import { useEffect, useMemo, useState } from 'react';
 import { ExportButton } from '@/components/reports/ExportButton';
+import { FilterBar, FilterGroup, Segmented } from '@/components/reports/FilterBar';
 import { GameBadge } from '@/components/reports/GameBadge';
 import { PlayStyleBadge } from '@/components/reports/PlayStyleBadge';
 import { RangePicker } from '@/components/reports/RangePicker';
@@ -21,6 +22,7 @@ import { useAuth } from '@/lib/auth';
 import { playStyle } from '@/lib/play-style';
 import { rangeToParams } from '@/lib/report-range';
 import { ReportsAPI } from '@/lib/reports-api';
+import { cn } from '@/lib/utils';
 
 export default function PlayersReportPage() {
   const { isAuthenticated, user } = useAuth();
@@ -90,52 +92,70 @@ export default function PlayersReportPage() {
       title="Players"
       description="Who played the most. Bot/simulation accounts are excluded by default."
     >
-      <RangePicker
-        value={range}
-        onChange={setRange}
-        includeBots={includeBots}
-        onIncludeBotsChange={setIncludeBots}
-      />
-
-      <div className="flex flex-wrap items-center gap-2">
-        <label htmlFor="player-search" className="text-sm text-gray-600 dark:text-gray-300">Find</label>
-        <Input
-          id="player-search"
-          value={draftSearch}
-          onChange={event => setDraftSearch(event.target.value)}
-          placeholder="Username"
-          className="h-8 w-48"
+      <FilterBar>
+        <RangePicker
+          value={range}
+          onChange={setRange}
+          includeBots={includeBots}
+          onIncludeBotsChange={setIncludeBots}
         />
-        {search && (
-          <Button size="sm" variant="ghost" onClick={() => setDraftSearch('')}>
-            Clear
-          </Button>
-        )}
 
-        <label htmlFor="row-limit" className="text-sm text-gray-600 dark:text-gray-300">Show</label>
+        <FilterGroup label="Find a player" hint="Narrows who is counted, not who survives the ranking — searching a quiet player still finds them.">
+          <div className="flex items-center gap-1.5">
+            <Input
+              id="player-search"
+              aria-label="Find a player by username"
+              value={draftSearch}
+              onChange={event => setDraftSearch(event.target.value)}
+              placeholder="Username"
+              className="h-8 w-48"
+            />
+            {search && (
+              <Button size="sm" variant="ghost" onClick={() => setDraftSearch('')}>
+                Clear
+              </Button>
+            )}
+          </div>
+        </FilterGroup>
+
         {/* A dropdown, not three buttons. Row count is a single choice from a
             closed set, which is what a select is for — and three more filled/
             outlined buttons beside the range presets made it read as another
             filter rather than a page size. 100 is the API's own cap. */}
-        <Select value={String(limit)} onValueChange={next => update({ limit: Number(next) })}>
-          <SelectTrigger id="row-limit" className="h-8 w-[88px]">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {[25, 50, 100].map(size => (
-              <SelectItem key={size} value={String(size)}>{size}</SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        <FilterGroup label="Rows">
+          <Select value={String(limit)} onValueChange={next => update({ limit: Number(next) })}>
+            <SelectTrigger id="row-limit" className="h-8 w-[88px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {[25, 50, 100].map(size => (
+                <SelectItem key={size} value={String(size)}>{size}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </FilterGroup>
 
-        <span className="ml-2 text-sm text-gray-600 dark:text-gray-300">Rank by</span>
-        <Button size="sm" variant={sortBy === 'played' ? 'default' : 'outline'} onClick={() => setSortBy('played')}>
-          Played
-        </Button>
-        <Button size="sm" variant={sortBy === 'finished' ? 'default' : 'outline'} onClick={() => setSortBy('finished')}>
-          Finished
-        </Button>
-      </div>
+        <FilterGroup label="Rank by">
+          <Segmented>
+            {([['played', 'Played'], ['finished', 'Finished']] as const).map(([key, label]) => (
+              <button
+                key={key}
+                type="button"
+                aria-pressed={sortBy === key}
+                onClick={() => setSortBy(key)}
+                className={cn(
+                  'rounded px-2.5 py-1 text-sm font-medium transition-colors',
+                  sortBy === key
+                    ? 'bg-emerald-100 text-emerald-800 shadow-sm dark:bg-emerald-900/40 dark:text-emerald-200'
+                    : 'text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-slate-700/60',
+                )}
+              >
+                {label}
+              </button>
+            ))}
+          </Segmented>
+        </FilterGroup>
+      </FilterBar>
 
       {game && (
         <div className="flex flex-wrap items-center gap-2 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 dark:border-emerald-900 dark:bg-emerald-900/20">

--- a/app/reports/retention/page.tsx
+++ b/app/reports/retention/page.tsx
@@ -4,6 +4,7 @@ import type { RangeState } from '@/lib/report-range';
 import type { RetentionCohort } from '@/types/reports';
 import { useMemo } from 'react';
 import { ExportButton } from '@/components/reports/ExportButton';
+import { FilterBar } from '@/components/reports/FilterBar';
 import { GameFilter } from '@/components/reports/GameFilter';
 import { RangePicker } from '@/components/reports/RangePicker';
 import { ReportError } from '@/components/reports/ReportError';
@@ -54,15 +55,17 @@ export default function RetentionPage() {
       title="Retention"
       description="Do players come back? Volume can look healthy right up until the supply of new players runs out."
     >
-      <RangePicker
-        value={range}
-        onChange={setRange}
-        includeBots={includeBots}
-        onIncludeBotsChange={setIncludeBots}
-      />
+      <FilterBar>
+        <RangePicker
+          value={range}
+          onChange={setRange}
+          includeBots={includeBots}
+          onIncludeBotsChange={setIncludeBots}
+        />
 
-      <GameFilter meta={meta} value={game} onChange={setGame} />
+        <GameFilter meta={meta} value={game} onChange={setGame} />
 
+      </FilterBar>
       <div className="flex justify-end">
         <ExportButton
           rows={data?.cohorts ?? []}

--- a/components/reports/FilterBar.tsx
+++ b/components/reports/FilterBar.tsx
@@ -24,18 +24,35 @@ export function FilterBar({ children }: { children: ReactNode }) {
   );
 }
 
-/** One named control within the bar. */
+/**
+ * One named control within the bar.
+ *
+ * `label` is optional for a control that belongs to the one before it — a
+ * clear button beside the range it clears. Those still need the caption's
+ * height reserved or they sit a line too high, so the space is rendered
+ * explicitly and hidden from assistive tech.
+ *
+ * The earlier version passed `label="&nbsp;"` for that. It rendered correctly
+ * — JSX decodes entities in an attribute literal, so it produced a real
+ * non-breaking space rather than the six characters — but it left a captioned
+ * <p> in the accessibility tree with nothing to say, and made "no name" look
+ * like a typo rather than a decision.
+ */
 export function FilterGroup({ label, children, hint }: {
-  label: string;
+  label?: string;
   children: ReactNode;
   /** Shown on hover — for the rule behind a control, not for its name. */
   hint?: string;
 }) {
   return (
     <div className="space-y-1.5" title={hint}>
-      <p className="text-[11px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
-        {label}
-      </p>
+      {label
+        ? (
+            <p className="text-[11px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
+              {label}
+            </p>
+          )
+        : <p className="text-[11px] leading-normal" aria-hidden>{'\u00A0'}</p>}
       {children}
     </div>
   );

--- a/components/reports/FilterBar.tsx
+++ b/components/reports/FilterBar.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+/**
+ * The row of controls above a report.
+ *
+ * Every reporting page had the same problem: a range picker, a game filter, a
+ * metric toggle and a bots switch laid out as one undifferentiated line of
+ * buttons. Nothing said which control did what, or which of the twelve things
+ * on screen were currently narrowing the data — so "7d 10d 15d 30d 60d 90d
+ * Custom" read as seven equal choices with no visible answer to "what am I
+ * looking at".
+ *
+ * This gives each control a name and a boundary. The label is the point: a
+ * segmented control with a caption is self-explanatory, and the same control
+ * unlabelled is a row of jargon.
+ */
+export function FilterBar({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex flex-wrap items-end gap-x-6 gap-y-4 rounded-lg border bg-white/60 px-4 py-3 dark:border-slate-700 dark:bg-slate-800/60">
+      {children}
+    </div>
+  );
+}
+
+/** One named control within the bar. */
+export function FilterGroup({ label, children, hint }: {
+  label: string;
+  children: ReactNode;
+  /** Shown on hover — for the rule behind a control, not for its name. */
+  hint?: string;
+}) {
+  return (
+    <div className="space-y-1.5" title={hint}>
+      <p className="text-[11px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
+        {label}
+      </p>
+      {children}
+    </div>
+  );
+}
+
+/**
+ * A set of mutually exclusive options, drawn as one object rather than as
+ * separate buttons.
+ *
+ * Separate outline buttons say "here are seven actions"; a segmented control
+ * says "here is one setting, currently on this value" — which is what a range
+ * is. Same visual language as the section nav, so a reader learns it once.
+ */
+export function Segmented({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex flex-wrap gap-0.5 rounded-md border bg-gray-50 p-0.5 dark:border-slate-700 dark:bg-slate-900/40">
+      {children}
+    </div>
+  );
+}

--- a/components/reports/GameFilter.tsx
+++ b/components/reports/GameFilter.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { GameMetaMap } from '@/hooks/use-game-meta';
+import { FilterGroup } from '@/components/reports/FilterBar';
 import { GameBadge } from '@/components/reports/GameBadge';
 import { gameName } from '@/hooks/use-game-meta';
 
@@ -32,27 +33,28 @@ export function GameFilter({ meta, value, onChange }: {
   }
 
   return (
-    <div className="flex flex-wrap items-center gap-2">
-      <span className="text-sm text-gray-600 dark:text-gray-300">Game</span>
-      <button
-        type="button"
-        onClick={() => onChange(null)}
-        aria-pressed={value === null}
-        className={value === null
-          ? 'rounded-full border border-emerald-600 bg-emerald-600 px-2.5 py-0.5 text-xs font-medium text-white'
-          : 'rounded-full border border-gray-300 px-2.5 py-0.5 text-xs font-medium text-gray-700 hover:bg-gray-50 dark:border-slate-600 dark:text-gray-200 dark:hover:bg-slate-700'}
-      >
-        All games
-      </button>
-      {games.map(game => (
-        <GameBadge
-          key={game.key}
-          gameKey={game.key}
-          meta={meta}
-          active={value === game.key}
-          onClick={key => onChange(value === key ? null : key)}
-        />
-      ))}
-    </div>
+    <FilterGroup label="Game" hint="Narrows every panel on the page to one game.">
+      <div className="flex flex-wrap items-center gap-1.5">
+        <button
+          type="button"
+          onClick={() => onChange(null)}
+          aria-pressed={value === null}
+          className={value === null
+            ? 'rounded-full border border-emerald-600 bg-emerald-600 px-2.5 py-0.5 text-xs font-medium text-white'
+            : 'rounded-full border border-gray-300 px-2.5 py-0.5 text-xs font-medium text-gray-700 hover:bg-gray-50 dark:border-slate-600 dark:text-gray-200 dark:hover:bg-slate-700'}
+        >
+          All games
+        </button>
+        {games.map(game => (
+          <GameBadge
+            key={game.key}
+            gameKey={game.key}
+            meta={meta}
+            active={value === game.key}
+            onClick={key => onChange(value === key ? null : key)}
+          />
+        ))}
+      </div>
+    </FilterGroup>
   );
 }

--- a/components/reports/MetricToggle.tsx
+++ b/components/reports/MetricToggle.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import type { MetricKey } from '@/types/reports';
-import { Button } from '@/components/ui/button';
+import { FilterGroup, Segmented } from '@/components/reports/FilterBar';
+import { cn } from '@/lib/utils';
 import { METRIC_OPTIONS } from '@/types/reports';
 
 /**
@@ -15,18 +16,25 @@ export function MetricToggle({ value, onChange }: {
   onChange: (metric: MetricKey) => void;
 }) {
   return (
-    <div className="flex flex-wrap items-center gap-2">
-      <span className="text-sm text-gray-600 dark:text-gray-300">Show</span>
-      {METRIC_OPTIONS.map(option => (
-        <Button
-          key={option.key}
-          size="sm"
-          variant={option.key === value ? 'default' : 'outline'}
-          onClick={() => onChange(option.key)}
-        >
-          {option.label}
-        </Button>
-      ))}
-    </div>
+    <FilterGroup label="Foreground metric" hint="Which metric gets the large chart; the others keep their own panels below it.">
+      <Segmented>
+        {METRIC_OPTIONS.map(option => (
+          <button
+            key={option.key}
+            type="button"
+            aria-pressed={option.key === value}
+            onClick={() => onChange(option.key)}
+            className={cn(
+              'rounded px-2.5 py-1 text-sm font-medium transition-colors',
+              option.key === value
+                ? 'bg-emerald-100 text-emerald-800 shadow-sm dark:bg-emerald-900/40 dark:text-emerald-200'
+                : 'text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-slate-700/60',
+            )}
+          >
+            {option.label}
+          </button>
+        ))}
+      </Segmented>
+    </FilterGroup>
   );
 }

--- a/components/reports/RangePicker.tsx
+++ b/components/reports/RangePicker.tsx
@@ -1,12 +1,14 @@
 'use client';
 
 import type { RangeState } from '@/lib/report-range';
-import { CalendarDays, X } from 'lucide-react';
+import { X } from 'lucide-react';
 import { useState } from 'react';
+import { FilterGroup, Segmented } from '@/components/reports/FilterBar';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
 import { activePreset, isoDay, yesterdayRange } from '@/lib/report-range';
+import { cn } from '@/lib/utils';
 import { REPORT_WINDOWS } from '@/types/reports';
 
 /**
@@ -43,58 +45,58 @@ export function RangePicker({ value, onChange, includeBots, onIncludeBotsChange 
   const custom = active === 'custom';
   const invalid = !draftStart || draftStart > draftEnd || draftEnd > today;
 
+  /** One option in the range segment. */
+  const option = (key: string | number, label: string, isActive: boolean, onSelect: () => void) => (
+    <button
+      key={key}
+      type="button"
+      aria-pressed={isActive}
+      onClick={onSelect}
+      className={cn(
+        'rounded px-2.5 py-1 text-sm font-medium transition-colors',
+        isActive
+          ? 'bg-emerald-100 text-emerald-800 shadow-sm dark:bg-emerald-900/40 dark:text-emerald-200'
+          : 'text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-slate-700/60',
+      )}
+    >
+      {label}
+    </button>
+  );
+
   return (
-    <div className="flex flex-wrap items-center gap-2">
-      <span className="text-sm text-gray-600 dark:text-gray-300">Range</span>
+    <>
+      <FilterGroup label="Range">
+        <Segmented>
+          {option('today', 'Today', active === 'today', () => onChange({ window: 1 }))}
+          {option('yesterday', 'Yesterday', active === 'yesterday', () => onChange(yesterdayRange(now, value.window)))}
+          {/* 1 is excluded: it is the Today button above, and "1d" beside it
+              would be the same range offered twice under two names. */}
+          {REPORT_WINDOWS.filter(w => w > 1).map(w => option(w, `${w}d`, active === w, () => onChange({ window: w })))}
+          {option(
+            'custom',
+            custom ? `${value.start} → ${value.end ?? today}` : 'Custom…',
+            custom,
+            () => setOpen(!open),
+          )}
+        </Segmented>
+      </FilterGroup>
 
-      <Button
-        size="sm"
-        variant={active === 'today' ? 'default' : 'outline'}
-        onClick={() => onChange({ window: 1 })}
-      >
-        Today
-      </Button>
-      <Button
-        size="sm"
-        variant={active === 'yesterday' ? 'default' : 'outline'}
-        onClick={() => onChange(yesterdayRange(now, value.window))}
-      >
-        Yesterday
-      </Button>
-
-      {/* 1 is excluded: it is the Today button above, and "1d" beside it would
-          be the same range offered twice under two names. */}
-      {REPORT_WINDOWS.filter(w => w > 1).map(w => (
-        <Button
-          key={w}
-          size="sm"
-          variant={active === w ? 'default' : 'outline'}
-          onClick={() => onChange({ window: w })}
-        >
-          {w}
-          d
-        </Button>
-      ))}
-
-      <Button
-        size="sm"
-        variant={custom ? 'default' : 'outline'}
-        onClick={() => setOpen(!open)}
-        title="Pick exact dates"
-      >
-        <CalendarDays className="mr-1 size-3.5" />
-        {custom ? `${value.start} → ${value.end ?? today}` : 'Custom'}
-        {custom && (
-          <X
-            className="ml-1 size-3"
-            onClick={(event) => {
-              event.stopPropagation();
+      {custom && (
+        <FilterGroup label="&nbsp;">
+          <Button
+            size="sm"
+            variant="ghost"
+            aria-label="Clear the custom range"
+            onClick={() => {
               onChange({ window: value.window });
               setOpen(false);
             }}
-          />
-        )}
-      </Button>
+          >
+            <X className="mr-1 size-3.5" />
+            Clear
+          </Button>
+        </FilterGroup>
+      )}
 
       {/* A switch, not a button. Button labels read as actions, so "Bots
           excluded" in an unfilled style read as "click to exclude bots" —
@@ -102,21 +104,25 @@ export function RangePicker({ value, onChange, includeBots, onIncludeBotsChange 
           off, and the label never has to be interpreted as an instruction. It
           also stops the control competing with the window presets beside it,
           where filled genuinely does mean "selected". */}
-      <label
-        htmlFor="include-bots"
-        className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300"
-        title="Bot and simulation accounts (is_dummy). Off by default — Anonymous players are real people and are always counted."
+      <FilterGroup
+        label="Accounts"
+        hint="Bot and simulation accounts (is_dummy). Off by default — Anonymous players are real people and are always counted."
       >
-        <Switch
-          id="include-bots"
-          checked={includeBots}
-          onCheckedChange={onIncludeBotsChange}
-        />
-        Include bots
-      </label>
+        <label
+          htmlFor="include-bots"
+          className="flex h-8 items-center gap-2 text-sm text-gray-600 dark:text-gray-300"
+        >
+          <Switch
+            id="include-bots"
+            checked={includeBots}
+            onCheckedChange={onIncludeBotsChange}
+          />
+          Include bots
+        </label>
+      </FilterGroup>
 
       {open && (
-        <div className="flex w-full flex-wrap items-end gap-2 rounded-md border bg-white p-3 dark:border-slate-700 dark:bg-slate-800">
+        <div className="flex w-full basis-full flex-wrap items-end gap-2 rounded-md border bg-white p-3 dark:border-slate-700 dark:bg-slate-800">
           <label htmlFor="range-start" className="flex flex-col gap-1 text-xs text-gray-600 dark:text-gray-300">
             From
             <Input
@@ -157,6 +163,6 @@ export function RangePicker({ value, onChange, includeBots, onIncludeBotsChange 
           )}
         </div>
       )}
-    </div>
+    </>
   );
 }

--- a/components/reports/RangePicker.tsx
+++ b/components/reports/RangePicker.tsx
@@ -82,7 +82,7 @@ export function RangePicker({ value, onChange, includeBots, onIncludeBotsChange 
       </FilterGroup>
 
       {custom && (
-        <FilterGroup label="&nbsp;">
+        <FilterGroup>
           <Button
             size="sm"
             variant="ghost"

--- a/components/reports/__tests__/FilterBar.test.tsx
+++ b/components/reports/__tests__/FilterBar.test.tsx
@@ -45,3 +45,41 @@ describe('filterGroup', () => {
     expect(spacer).toHaveAttribute('aria-hidden');
   });
 });
+
+describe('every filtered report page uses the bar', () => {
+  it('has no page laying filters out by hand', async () => {
+    // The filters were a bare row of buttons on ten pages, each spacing itself
+    // slightly differently. A page that renders RangePicker outside FilterBar
+    // drifts back to that — and nothing else would notice, because it still
+    // works.
+    const { readdirSync, readFileSync } = await import('node:fs');
+    const { join } = await import('node:path');
+
+    const root = join(process.cwd(), 'app', 'reports');
+    const pages: string[] = [];
+    const walk = (dir: string) => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          walk(full);
+        } else if (entry.name === 'page.tsx') {
+          pages.push(full);
+        }
+      }
+    };
+    walk(root);
+
+    const offenders = pages.filter((file) => {
+      const source = readFileSync(file, 'utf8');
+      if (!source.includes('<RangePicker')) {
+        return false;
+      }
+      return !source.includes('<FilterBar>');
+    });
+
+    expect(
+      offenders.map(f => f.replace(process.cwd(), '')),
+      'Report pages with filters outside FilterBar',
+    ).toEqual([]);
+  });
+});

--- a/components/reports/__tests__/FilterBar.test.tsx
+++ b/components/reports/__tests__/FilterBar.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { FilterGroup } from '@/components/reports/FilterBar';
+
+describe('filterGroup', () => {
+  it('names the control it wraps', () => {
+    render(<FilterGroup label="Range"><button type="button">7d</button></FilterGroup>);
+
+    expect(screen.getByText('Range')).toBeInTheDocument();
+  });
+
+  it('renders no caption text when a control has no name of its own', () => {
+    // A clear button belongs to the range beside it, so it has no name — but it
+    // still needs the caption's height reserved or it sits a line too high.
+    const { container } = render(<FilterGroup><button type="button">Clear</button></FilterGroup>);
+
+    // A non-breaking space holds the line; nothing readable is added.
+    expect(container.textContent?.replace(/\u00A0/g, '')).toBe('Clear');
+    expect(screen.getByRole('button', { name: 'Clear' })).toBeInTheDocument();
+  });
+
+  it('would still announce a blank caption if one were passed', () => {
+    // The first attempt reserved the space with `label="&nbsp;"`. That does NOT
+    // print the six characters — JSX decodes entities in an attribute literal,
+    // so it renders a real non-breaking space (a review flagged it as a
+    // rendering bug; it measured out otherwise).
+    //
+    // It is still the wrong shape, for the reason this asserts: the caption is
+    // a real <p> in the accessibility tree with nothing in it to say. Omitting
+    // the label renders an aria-hidden spacer instead.
+    const { container } = render(
+      <FilterGroup label="&nbsp;"><button type="button">Clear</button></FilterGroup>,
+    );
+    const caption = container.querySelector('p');
+
+    expect(caption?.textContent).toBe('\u00A0');
+    expect(caption).not.toHaveAttribute('aria-hidden');
+  });
+
+  it('keeps the spacer out of the accessibility tree', () => {
+    // Reserved space is a layout concern; announcing it would be noise.
+    const { container } = render(<FilterGroup><button type="button">Clear</button></FilterGroup>);
+    const spacer = container.querySelector('p');
+
+    expect(spacer).toHaveAttribute('aria-hidden');
+  });
+});

--- a/components/reports/__tests__/RangePicker.test.tsx
+++ b/components/reports/__tests__/RangePicker.test.tsx
@@ -84,4 +84,32 @@ describe('bots control', () => {
     // The previous preset survives, so clearing the range returns to it.
     expect(arg.window).toBe(30);
   });
+
+  it('shows which range is selected, and only that one', () => {
+    // The presets used to be seven separate outline buttons: nothing said
+    // which was active, so the control answered "what am I looking at" with
+    // silence. `aria-pressed` is the assertion because it is also what a
+    // screen reader announces — a colour alone would say nothing to it.
+    render(<RangePicker value={{ window: 30 }} onChange={() => {}} includeBots={false} onIncludeBotsChange={() => {}} />);
+
+    expect(screen.getByRole('button', { name: '30d' })).toHaveAttribute('aria-pressed', 'true');
+
+    const pressed = screen.getAllByRole('button').filter(b => b.getAttribute('aria-pressed') === 'true');
+
+    expect(pressed).toHaveLength(1);
+  });
+
+  it('marks a custom range as selected rather than a preset', () => {
+    render(
+      <RangePicker
+        value={{ window: 30, start: '2026-06-01', end: '2026-06-30' }}
+        onChange={() => {}}
+        includeBots={false}
+        onIncludeBotsChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: /2026-06-01/ })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: '30d' })).toHaveAttribute('aria-pressed', 'false');
+  });
 });


### PR DESCRIPTION
Issue FootballExtraTime/App#1453, item **D1** — following the approach agreed there: *tokens → filter bar → tables/cards → pages*.

Originally one page as a proposal; now rolled across all ten, per your "roll out to all pages".

## The problem, in your words

> *"Stuff like Range 7d 10d 15d 30d 60d 90d Custom and so on looks outdated and nothing modern."*

The concrete failure: **seven equal choices with no visible answer to "what am I looking at"**. A range picker, a metric toggle, a game filter and a bots switch shared one undifferentiated line, all the same weight, nothing naming which control did what.

## What changed

**A `FilterBar`** — one bounded object with a caption per control. The caption is the point: a segmented control with a name explains itself; the same control unlabelled is a row of jargon.

**Segmented controls** where a setting has one current value — the range presets, the foreground metric, and rank-by on Players. Separate outline buttons read as *actions*; a segment reads as *one setting, currently here*. It borrows the section nav's existing language, so the pattern is learned once.

**`aria-pressed` carries selection**, not just fill colour — that's what a screen reader announces, and the old buttons had no pressed state at all.

| Page | Now in the bar |
|---|---|
| games, duration, multiplayer | range |
| retention, patterns | range + game |
| anomalies | range + sensitivity |
| games/[key], players/[id] | range (back-link stays outside — navigation isn't a filter) |
| players | range + find-a-player + rows + rank-by, each named |

On Players, "Find" and "Show" sat next to each other saying nothing about which was which; both are captioned groups now.

## Guard

A test walks `app/reports` and fails any page rendering a `RangePicker` outside a `FilterBar`. That's how this drifts back — a new page laying out its own row works perfectly and looks wrong, so nothing notices. Mutation-tested: reverting one page to a bare flex row fails it.

## Verification

475 tests, types clean, lint clean on the reporting surface, build compiling, CI green.

**Still not visually verified** — production is behind Cloudflare Access and previews behind Vercel SSO, so I can check markup, behaviour and accessibility but not appearance. Worth a look at the preview before merge; if the direction is wrong, it's one commit to revert.