### PR TITLE
Lint the reporting surface in CI, now that it passes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
       # which is how the previous one went unread for months. The scope widens
       # as areas are cleaned, not before.
       - name: Lint (reporting surface)
-        run: pnpm exec eslint app/reports components/reports components/admin lib hooks scripts --max-warnings 0
+        run: pnpm run lint:reports
 
       - name: Tests
         run: pnpm run test:run
@@ -79,9 +79,5 @@ jobs:
           NEXT_PUBLIC_N8N_WEBHOOK_URL: ${{ secrets.NEXT_PUBLIC_N8N_WEBHOOK_URL }}
           NEXT_PUBLIC_ADMIN_BASE_URL: ${{ secrets.NEXT_PUBLIC_ADMIN_BASE_URL }}
 
-      # Lint is deliberately absent. `next lint` was removed in Next 16, so the
-      # old step invoked `next <dir>` and would have failed; and running eslint
-      # directly currently cannot resolve eslint-plugin-format under pnpm's
-      # layout. Both are real and are filed separately — a step that cannot pass
-      # would make this pipeline red on arrival and get switched off again,
-      # which is how the previous one ended up unread.
+      # Lint covers the reporting surface only — see the note on that step. The
+      # rest of the app is not linted here yet.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,16 @@ jobs:
       - name: Types
         run: pnpm run check-types:app
 
+      # Scoped to the reporting surface, which is clean. The rest of the app
+      # still has ~1,250 problems from a config that was added and then never
+      # executed (`next lint` was removed in Next 16, and eslint could not
+      # resolve eslint-plugin-format under pnpm until #103). Linting everything
+      # here would be red on arrival, and a red pipeline gets switched off —
+      # which is how the previous one went unread for months. The scope widens
+      # as areas are cleaned, not before.
+      - name: Lint (reporting surface)
+        run: pnpm exec eslint app/reports components/reports components/admin lib hooks scripts --max-warnings 0
+
       - name: Tests
         run: pnpm run test:run
 

--- a/app/reports/anomalies/page.tsx
+++ b/app/reports/anomalies/page.tsx
@@ -4,6 +4,7 @@ import type { Sensitivity } from '@/components/reports/AnomalySensitivity';
 import { useMemo, useState } from 'react';
 import { AnomalyPanel } from '@/components/reports/AnomalyPanel';
 import { AnomalySensitivity, SENSITIVITY_PRESETS } from '@/components/reports/AnomalySensitivity';
+import { ExportButton } from '@/components/reports/ExportButton';
 import { RangePicker } from '@/components/reports/RangePicker';
 import { ReportPanel } from '@/components/reports/ReportPanel';
 import { ReportsShell } from '@/components/reports/ReportsShell';
@@ -13,7 +14,6 @@ import { useReportFilters } from '@/hooks/use-report-filters';
 import { useAuth } from '@/lib/auth';
 import { rangeToParams } from '@/lib/report-range';
 import { ReportsAPI } from '@/lib/reports-api';
-import { ExportButton } from '@/components/reports/ExportButton';
 
 /**
  * What moved enough to be worth attention.

--- a/app/reports/patterns/page.tsx
+++ b/app/reports/patterns/page.tsx
@@ -2,12 +2,14 @@
 
 import type { RangeState } from '@/lib/report-range';
 import type { HourWeekdayRow } from '@/types/reports';
+import { useTheme } from 'next-themes';
 import { useMemo } from 'react';
 import { Area, AreaChart, Bar, BarChart, CartesianGrid, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import { ActivityHeatmap } from '@/components/reports/ActivityHeatmap';
-import { MetricInfo } from '@/components/reports/MetricInfo';
+import { ChartTooltip } from '@/components/reports/ChartTooltip';
 import { ExportButton } from '@/components/reports/ExportButton';
 import { GameFilter } from '@/components/reports/GameFilter';
+import { MetricInfo } from '@/components/reports/MetricInfo';
 import { RangePicker } from '@/components/reports/RangePicker';
 import { ReportError } from '@/components/reports/ReportError';
 import { ReportsShell } from '@/components/reports/ReportsShell';
@@ -17,11 +19,9 @@ import { useGameMeta } from '@/hooks/use-game-meta';
 import { useReport } from '@/hooks/use-report';
 import { useReportFilters } from '@/hooks/use-report-filters';
 import { useAuth } from '@/lib/auth';
+import { chartTheme } from '@/lib/chart-theme';
 import { rangeToParams } from '@/lib/report-range';
 import { ReportsAPI } from '@/lib/reports-api';
-import { useTheme } from 'next-themes';
-import { chartTheme } from '@/lib/chart-theme';
-import { ChartTooltip } from '@/components/reports/ChartTooltip';
 
 function Tile({ label, value, hint, metric }: { label: string; value: string; hint: string; metric?: string }) {
   return (

--- a/app/reports/players/[id]/page.tsx
+++ b/app/reports/players/[id]/page.tsx
@@ -3,10 +3,12 @@
 import type { RangeState } from '@/lib/report-range';
 import type { ReportParams } from '@/types/reports';
 import { ArrowLeft } from 'lucide-react';
+import { useTheme } from 'next-themes';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { useCallback, useMemo } from 'react';
 import { Area, AreaChart, CartesianGrid, Cell, Pie, PieChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { ChartTooltip } from '@/components/reports/ChartTooltip';
 import { GameBadge } from '@/components/reports/GameBadge';
 import { RangePicker } from '@/components/reports/RangePicker';
 import { ReportError } from '@/components/reports/ReportError';
@@ -14,15 +16,13 @@ import { ReportsShell } from '@/components/reports/ReportsShell';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useGameColor, useGameMeta } from '@/hooks/use-game-meta';
-import { playStyle } from '@/lib/play-style';
 import { useReport } from '@/hooks/use-report';
 import { useReportFilters } from '@/hooks/use-report-filters';
 import { useAuth } from '@/lib/auth';
+import { chartTheme } from '@/lib/chart-theme';
+import { playStyle } from '@/lib/play-style';
 import { rangeToParams } from '@/lib/report-range';
 import { ReportsAPI } from '@/lib/reports-api';
-import { useTheme } from 'next-themes';
-import { chartTheme } from '@/lib/chart-theme';
-import { ChartTooltip } from '@/components/reports/ChartTooltip';
 
 function Tile({ label, value, hint }: { label: string; value: string; hint?: string }) {
   return (

--- a/app/reports/players/page.tsx
+++ b/app/reports/players/page.tsx
@@ -40,6 +40,10 @@ export default function PlayersReportPage() {
   // request keys on. Without the split, every keystroke would refetch — and
   // useReport keys on params by value, so it genuinely would fire each time.
   const [draftSearch, setDraftSearch] = useState(search);
+  // Syncing the draft when the URL-derived value changes is the point: a shared
+  // link or a Back navigation must land in the box. A one-way sync from a value
+  // this component does not own, not a render loop.
+  // eslint-disable-next-line react-hooks-extra/no-direct-set-state-in-use-effect
   useEffect(() => setDraftSearch(search), [search]);
   useEffect(() => {
     // Compare what will actually be committed. Comparing the raw draft meant

--- a/components/admin/SectionNav.tsx
+++ b/components/admin/SectionNav.tsx
@@ -37,7 +37,7 @@ export function SectionNav({ groups, trailing }: {
     <nav aria-label="Section" className="rounded-lg border bg-white/60 p-2 dark:border-slate-700 dark:bg-slate-800/60">
       <div className="flex flex-wrap items-start gap-x-6 gap-y-3">
         {groups.map(group => (
-          <div key={group.heading || 'ungrouped'} className="min-w-[10rem] flex-1">
+          <div key={group.heading || 'ungrouped'} className="min-w-40 flex-1">
             {group.heading && (
               <p className="mb-1 px-2 text-[11px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
                 {group.heading}

--- a/components/admin/SectionShell.tsx
+++ b/components/admin/SectionShell.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import type { NavGroup, NavItem } from '@/components/admin/SectionNav';
 import type { ReactNode } from 'react';
+import type { NavGroup, NavItem } from '@/components/admin/SectionNav';
 import { AlertTriangle } from 'lucide-react';
 import { SectionNav } from '@/components/admin/SectionNav';
 import { LoadingSpinner } from '@/components/loading-spinner';

--- a/components/reports/ActivityHeatmap.tsx
+++ b/components/reports/ActivityHeatmap.tsx
@@ -25,6 +25,10 @@ const RAMP_LIGHT = ['#10b981', '#059669', '#047857', '#064e3b'];
 const RAMP_DARK = ['#047857', '#059669', '#34d399', '#a7f3d0'];
 
 /** Exported so the per-surface choice is testable rather than implicit. */
+// The cost is fast-refresh reloading this file rather than hot-swapping it.
+// measurable in jsdom, so the pure part has to be reachable from a test.
+// Exported beside its component on purpose: a recharts tree renders nothing
+// eslint-disable-next-line react-refresh/only-export-components
 export function heatmapRamp(isDark: boolean): string[] {
   return isDark ? RAMP_DARK : RAMP_LIGHT;
 }

--- a/components/reports/ActivityHeatmap.tsx
+++ b/components/reports/ActivityHeatmap.tsx
@@ -25,9 +25,9 @@ const RAMP_LIGHT = ['#10b981', '#059669', '#047857', '#064e3b'];
 const RAMP_DARK = ['#047857', '#059669', '#34d399', '#a7f3d0'];
 
 /** Exported so the per-surface choice is testable rather than implicit. */
-// The cost is fast-refresh reloading this file rather than hot-swapping it.
-// measurable in jsdom, so the pure part has to be reachable from a test.
 // Exported beside its component on purpose: a recharts tree renders nothing
+// measurable in jsdom, so the pure part has to be reachable from a test. The
+// cost is fast-refresh reloading this file rather than hot-swapping it.
 // eslint-disable-next-line react-refresh/only-export-components
 export function heatmapRamp(isDark: boolean): string[] {
   return isDark ? RAMP_DARK : RAMP_LIGHT;

--- a/components/reports/AnomalySensitivity.tsx
+++ b/components/reports/AnomalySensitivity.tsx
@@ -16,9 +16,9 @@ import { Button } from '@/components/ui/button';
  */
 export type Sensitivity = 'broad' | 'default' | 'strict';
 
-// The cost is fast-refresh reloading this file rather than hot-swapping it.
-// measurable in jsdom, so the pure part has to be reachable from a test.
 // Exported beside its component on purpose: a recharts tree renders nothing
+// measurable in jsdom, so the pure part has to be reachable from a test. The
+// cost is fast-refresh reloading this file rather than hot-swapping it.
 // eslint-disable-next-line react-refresh/only-export-components
 export const SENSITIVITY_PRESETS: Record<Sensitivity, {
   label: string;

--- a/components/reports/AnomalySensitivity.tsx
+++ b/components/reports/AnomalySensitivity.tsx
@@ -16,6 +16,10 @@ import { Button } from '@/components/ui/button';
  */
 export type Sensitivity = 'broad' | 'default' | 'strict';
 
+// The cost is fast-refresh reloading this file rather than hot-swapping it.
+// measurable in jsdom, so the pure part has to be reachable from a test.
+// Exported beside its component on purpose: a recharts tree renders nothing
+// eslint-disable-next-line react-refresh/only-export-components
 export const SENSITIVITY_PRESETS: Record<Sensitivity, {
   label: string;
   hint: string;

--- a/components/reports/ChartTooltip.tsx
+++ b/components/reports/ChartTooltip.tsx
@@ -80,7 +80,11 @@ export function ChartTooltip({
       {payload.map((entry, index) => (
         <p
           // Series can share a name across a stacked chart, so the key includes
-          // the dataKey rather than trusting the label to be unique.
+          // the dataKey rather than trusting the label to be unique. The index
+          // is the tiebreaker of last resort, not the key itself: this list is
+          // one tooltip's rows, rebuilt from scratch on every hover, so there
+          // is no reordering for a positional key to corrupt.
+          // eslint-disable-next-line react/no-array-index-key
           key={`${entry.dataKey ?? entry.name ?? 'series'}-${index}`}
           className="flex items-center gap-1.5 text-muted-foreground"
         >

--- a/components/reports/ComparePicker.tsx
+++ b/components/reports/ComparePicker.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState } from 'react';
 import { CalendarDays, X } from 'lucide-react';
+import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { isoDay } from '@/lib/report-range';

--- a/components/reports/GameLeaderboard.tsx
+++ b/components/reports/GameLeaderboard.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import type { GameMetaMap } from '@/hooks/use-game-meta';
-import { useGameColor } from '@/hooks/use-game-meta';
 import type { GameTotals, MetricKey } from '@/types/reports';
 import { ChevronDown, ChevronRight, Minus, TrendingDown, TrendingUp } from 'lucide-react';
 import Link from 'next/link';
 import { useState } from 'react';
 import { GameBadge } from '@/components/reports/GameBadge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { useGameColor } from '@/hooks/use-game-meta';
 import { cn } from '@/lib/utils';
 
 /** '—' rather than 0 for a null rate: no data is not the same as zero. */

--- a/components/reports/ModeBreakdown.tsx
+++ b/components/reports/ModeBreakdown.tsx
@@ -2,13 +2,13 @@
 
 import type { GameMetaMap } from '@/hooks/use-game-meta';
 import type { MultiplayerModeRow } from '@/types/reports';
+import { useTheme } from 'next-themes';
 import { Bar, BarChart, CartesianGrid, Cell, LabelList, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { ChartTooltip } from '@/components/reports/ChartTooltip';
 import { GameBadge } from '@/components/reports/GameBadge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { useGameColor } from '@/hooks/use-game-meta';
-import { useTheme } from 'next-themes';
 import { chartTheme } from '@/lib/chart-theme';
-import { ChartTooltip } from '@/components/reports/ChartTooltip';
 
 /** Quiz has no mode column, so its rooms arrive as null rather than being dropped. */
 function modeLabel(mode: string | null): string {

--- a/components/reports/RangePicker.tsx
+++ b/components/reports/RangePicker.tsx
@@ -5,9 +5,9 @@ import { CalendarDays, X } from 'lucide-react';
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui/switch';
 import { activePreset, isoDay, yesterdayRange } from '@/lib/report-range';
 import { REPORT_WINDOWS } from '@/types/reports';
-import { Switch } from '@/components/ui/switch';
 
 /**
  * Presets for the common case, explicit dates for everything else.

--- a/components/reports/ReachDepthChart.tsx
+++ b/components/reports/ReachDepthChart.tsx
@@ -2,8 +2,8 @@
 
 import type { GameMetaMap } from '@/hooks/use-game-meta';
 import type { GameTotals } from '@/types/reports';
-import { useMemo } from 'react';
 import { useTheme } from 'next-themes';
+import { useMemo } from 'react';
 import {
   CartesianGrid,
   Cell,

--- a/components/reports/ReportPanel.tsx
+++ b/components/reports/ReportPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import type { UseReport } from '@/hooks/use-report';
 import type { ReactNode } from 'react';
+import type { UseReport } from '@/hooks/use-report';
 import { ReportError } from '@/components/reports/ReportError';
 import { Skeleton } from '@/components/ui/skeleton';
 

--- a/components/reports/__tests__/PlayStyleBadge.test.tsx
+++ b/components/reports/__tests__/PlayStyleBadge.test.tsx
@@ -10,14 +10,14 @@ describe('playStyleBadge', () => {
     render(<PlayStyleBadge played={41} mp={35} />);
     const badge = screen.getByText('Mostly multiplayer');
 
-    expect(badge.getAttribute('aria-label')).toBe('Mostly multiplayer: 35 multiplayer, 6 solo (85.4%)');
-    expect(badge.getAttribute('title')).toBe(badge.getAttribute('aria-label'));
+    expect(badge).toHaveAttribute('aria-label', 'Mostly multiplayer: 35 multiplayer, 6 solo (85.4%)');
+    expect(badge).toHaveAttribute('title', badge.getAttribute('aria-label'));
   });
 
   it('renders nothing when the backend has not sent a count', () => {
     // Absent is not zero: a badge reading "Solo" would claim we know.
     const { container } = render(<PlayStyleBadge played={41} />);
 
-    expect(container.firstChild).toBeNull();
+    expect(container).toBeEmptyDOMElement();
   });
 });

--- a/components/reports/__tests__/chart-theme.test.ts
+++ b/components/reports/__tests__/chart-theme.test.ts
@@ -28,6 +28,7 @@ describe('chartTheme', () => {
     // would compete with the data for attention.
     for (const isDark of [false, true]) {
       const theme = chartTheme(isDark);
+
       expect(theme.grid.stroke).not.toBe(theme.tooltip.contentStyle.color);
     }
   });

--- a/components/reports/favourites/AdoptionTrendsChart.tsx
+++ b/components/reports/favourites/AdoptionTrendsChart.tsx
@@ -1,15 +1,15 @@
 'use client';
 
 import type { AdoptionTrendsResponse, TrendGranularity } from '@/types/user-hub';
+import { useTheme } from 'next-themes';
 import { Area, AreaChart, CartesianGrid, Legend, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import { ChartTooltip } from '@/components/reports/ChartTooltip';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
+import { chartTheme } from '@/lib/chart-theme';
 import { formatTrendDate } from '@/lib/user-hub-analytics';
 import { cn } from '@/lib/utils';
-import { useTheme } from 'next-themes';
-import { chartTheme } from '@/lib/chart-theme';
 
 type Props = {
   data: AdoptionTrendsResponse | null;

--- a/components/reports/favourites/FavouredVsPlayedChart.tsx
+++ b/components/reports/favourites/FavouredVsPlayedChart.tsx
@@ -2,8 +2,8 @@
 
 import type { GameMetaMap } from '@/hooks/use-game-meta';
 import type { FavouredVsPlayedResponse } from '@/types/user-hub';
-import { useMemo } from 'react';
 import { useTheme } from 'next-themes';
+import { useMemo } from 'react';
 import { Bar, BarChart, CartesianGrid, Legend, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import { ChartTooltip } from '@/components/reports/ChartTooltip';
 import { Button } from '@/components/ui/button';

--- a/components/reports/favourites/GamePopularityChart.tsx
+++ b/components/reports/favourites/GamePopularityChart.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import type { GameMetaMap } from '@/hooks/use-game-meta';
-import { useMemo } from 'react';
 import { useTheme } from 'next-themes';
+import { useMemo } from 'react';
 import { Bar, BarChart, CartesianGrid, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import { ChartTooltip } from '@/components/reports/ChartTooltip';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';

--- a/hooks/__tests__/use-report.test.tsx
+++ b/hooks/__tests__/use-report.test.tsx
@@ -90,6 +90,7 @@ describe('useReport', () => {
     render(<BoundArg />);
     await screen.findByText('loaded-18');
     await new Promise(resolve => setTimeout(resolve, 60));
+
     expect(calls).toEqual([18]);
 
     await act(async () => setId(19));
@@ -97,6 +98,7 @@ describe('useReport', () => {
 
     // And having refetched once, it settles rather than looping on the new id.
     await new Promise(resolve => setTimeout(resolve, 60));
+
     expect(calls).toEqual([18, 19]);
   });
 });

--- a/hooks/use-glossary.ts
+++ b/hooks/use-glossary.ts
@@ -51,6 +51,9 @@ export function useGlossary(enabled = true): GlossaryState {
       return;
     }
     let cancelled = false;
+    // The fetch starts here, so the loading flag starts here too. Deriving it
+    // during render would mean rendering a request that has not been made.
+    // eslint-disable-next-line react-hooks-extra/no-direct-set-state-in-use-effect
     setIsLoading(true);
     fetchGlossaryOnce()
       .then((res) => {

--- a/hooks/use-mobile.tsx
+++ b/hooks/use-mobile.tsx
@@ -11,8 +11,10 @@ export function useIsMobile() {
       setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
     };
     mql.addEventListener('change', onChange);
-    // The first read has to happen after mount: `window` does not exist during
-    // the server render, and starting from a guess would flash the wrong layout.
+    // `window` does not exist during the server render, so the first real read
+    // can only happen after mount. Until it does the hook reports false, which
+    // IS a guess — the trade is a possible layout shift on first paint against
+    // not being renderable on the server at all.
     // eslint-disable-next-line react-hooks-extra/no-direct-set-state-in-use-effect
     setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
     return () => mql.removeEventListener('change', onChange);

--- a/hooks/use-mobile.tsx
+++ b/hooks/use-mobile.tsx
@@ -11,6 +11,9 @@ export function useIsMobile() {
       setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
     };
     mql.addEventListener('change', onChange);
+    // The first read has to happen after mount: `window` does not exist during
+    // the server render, and starting from a guess would flash the wrong layout.
+    // eslint-disable-next-line react-hooks-extra/no-direct-set-state-in-use-effect
     setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
     return () => mql.removeEventListener('change', onChange);
   }, []);

--- a/hooks/use-report.ts
+++ b/hooks/use-report.ts
@@ -70,6 +70,14 @@ export function useReport<T>(
     } finally {
       setIsLoading(false);
     }
+    // `key` and `resourceKey` are not read inside this callback, and the rule
+    // is right that they are unnecessary for correctness of its BODY. They are
+    // here to control its IDENTITY: the effect below depends on `load`, so a
+    // new key produces a new `load` and therefore a refetch. That indirection
+    // is what stopped the loop this hook was built to fix — the fetcher itself
+    // is deliberately not a dependency, because callers rebuild it every
+    // render. Removing these two would leave nothing to trigger a refetch.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [key, resourceKey, endpointLabel]);
 
   useEffect(() => {

--- a/lib/__tests__/abandoned.test.ts
+++ b/lib/__tests__/abandoned.test.ts
@@ -43,6 +43,7 @@ describe('abandonedSessions', () => {
 
   it('names a lever only when one game genuinely dominates', () => {
     const clear = abandonedSessions([game('big', 1000, 100), game('small', 100, 90)]);
+
     expect(clear.lever?.game_type).toBe('big');
   });
 

--- a/lib/__tests__/report-sort.test.ts
+++ b/lib/__tests__/report-sort.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
 import type { GameRowWithDuration } from '@/lib/report-sort';
+import { describe, expect, it } from 'vitest';
 import { sortGameTotals } from '@/lib/report-sort';
 
 function game(game_type: string, overrides: Partial<GameRowWithDuration> = {}): GameRowWithDuration {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "check-lockfile": "node scripts/check-lockfile.mjs",
     "type-check": "npm run check-types",
     "lint": "eslint .",
+    "lint:reports": "eslint app/reports components/reports components/admin lib hooks scripts --max-warnings 0",
     "test": "vitest",
     "test:run": "vitest run",
     "prepare": "husky"

--- a/scripts/check-lockfile.mjs
+++ b/scripts/check-lockfile.mjs
@@ -45,7 +45,8 @@ function parseRootImporter(text) {
 
   for (const line of lines) {
     if (line.startsWith('importers:')) {
-      inImporters = true; continue;
+      inImporters = true;
+      continue;
     }
     if (!inImporters) {
       continue;
@@ -67,7 +68,9 @@ function parseRootImporter(text) {
 
     const sectionMatch = /^ {4}(dependencies|devDependencies):/.exec(line);
     if (sectionMatch) {
-      section = sectionMatch[1]; pendingName = null; continue;
+      section = sectionMatch[1];
+      pendingName = null;
+      continue;
     }
     if (!section) {
       continue;
@@ -75,10 +78,14 @@ function parseRootImporter(text) {
 
     const nameMatch = /^ {6}'?([^':]+)'?:\s*$/.exec(line);
     if (nameMatch) {
-      pendingName = nameMatch[1]; continue;
+      pendingName = nameMatch[1];
+      continue;
     }
 
-    const specMatch = /^ {8}specifier:\s*(.+?)\s*$/.exec(line);
+    // `(.+?)\s*$` lets the lazy group and the trailing \s* trade characters,
+    // which is quadratic on a pathological line. `(\S.*\S|\S)` pins both ends
+    // to non-space and matches exactly the same specifiers.
+    const specMatch = /^ {8}specifier:\s*(\S.*\S|\S)\s*$/.exec(line);
     if (specMatch && pendingName) {
       found[section][pendingName] = specMatch[1].replace(/^['"]|['"]$/g, '');
       pendingName = null;

--- a/scripts/check-types.mjs
+++ b/scripts/check-types.mjs
@@ -121,7 +121,7 @@ function main() {
 
   const unused = unusedOut
     .split('\n')
-    .filter(line => / error TS(6133|6192|6196):/.test(line))
+    .filter(line => / error TS(?:6133|6192|6196):/.test(line))
     .filter(line => inScope(line));
 
   if (unused.length > 0) {


### PR DESCRIPTION
Closes the thread that started when #101 found CI had never run and #103 found eslint couldn't load its config.

## Where lint got to

**420 → 67 → 0** on the reporting surface (`app/reports`, `components/reports`, `components/admin`, `lib`, `hooks`, `scripts`).

The last 14 weren't sweepable, which is precisely why they were left for a human pass:

| What | Verdict |
|---|---|
| 3 × `setState` inside an effect | All correct. Now each says why: syncing a draft from the URL so a shared link lands in the search box; reading `window` after mount because it doesn't exist during the server render; starting a loading flag where the fetch starts. |
| 2 × component file exporting a helper | Deliberate — a recharts tree renders nothing measurable in jsdom, so the pure part must be reachable from a test. Cost is a full reload instead of a hot swap. |
| 1 × `exhaustive-deps` | The rule is right that `key`/`resourceKey` are unused in the callback **body**, and wrong about what they're for: they control its **identity**, which is what drives refetching. That indirection is what stopped the 2,000-requests-in-400ms loop. |
| 1 × index in key | A list rebuilt from scratch on every hover — nothing to reorder. |
| 3 × multi-statement lines, 1 × unused capture group | Mechanical, in the scripts. |
| 3 × `no-super-linear-backtracking` | **Real**: `specifier:\s*(.+?)\s*$` lets the lazy group trade characters with the trailing `\s*` — quadratic on a pathological line. Rewritten to pin both ends. Both scripts verified still working afterwards. |

Every suppression carries its reason. A bare `eslint-disable` is a rule someone will delete later without knowing what it protected.

## The gate

CI now runs eslint over that scope with `--max-warnings 0`, plus a `lint:reports` script for local use.

**Scoped, not global.** The rest of the app still has ~1,250 problems from a config that was added and never executed. Linting everything would be red on arrival, and a red pipeline gets switched off — which is exactly how the previous one went unread for months. The scope widens as areas are cleaned.

## Mutation-tested

| Mutation | Result |
|---|---|
| new violation inside the scope | gate fails ✓ |
| violation outside the scope | gate passes ✓ (not over-scoped) |

468 tests, types clean, build compiling.