### PR TITLE
Add the "Sitting unfinished" report

### DIFF
--- a/app/reports/unfinished/page.tsx
+++ b/app/reports/unfinished/page.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { FilterBar, FilterGroup } from '@/components/reports/FilterBar';
+import { ReportPanel } from '@/components/reports/ReportPanel';
+import { ReportsShell } from '@/components/reports/ReportsShell';
+import { StatTile } from '@/components/reports/StatTile';
+import { UnfinishedTable } from '@/components/reports/UnfinishedTable';
+import { Switch } from '@/components/ui/switch';
+import { useGameMeta } from '@/hooks/use-game-meta';
+import { useReport } from '@/hooks/use-report';
+import { useAuth } from '@/lib/auth';
+import { ReportsAPI } from '@/lib/reports-api';
+
+/**
+ * What is sitting unfinished right now.
+ *
+ * The only report here with no range control, and that is the point rather than
+ * an omission. Every other page answers a question about a period; this one
+ * answers a question about state — what is abandoned NOW — and a date range on
+ * it would not merely go unused, it would be meaningless.
+ *
+ * It sits beside the games report's abandoned pool rather than replacing it.
+ * That one measures a window (`started - finished`) and answers "how much did
+ * this period leak"; this one reads the rows and answers "what is lying around".
+ * The same game can look different in each, and both are true.
+ */
+export default function UnfinishedPage() {
+  const { isAuthenticated, user } = useAuth();
+  const enabled = isAuthenticated && !!(user?.is_staff || user?.is_superuser);
+
+  // Not in the URL like the other pages' filters: there is no range to bookmark
+  // alongside it, and the snapshot a link would restore is gone by the time it
+  // is opened.
+  const [includeBots, setIncludeBots] = useState(false);
+  const { meta } = useGameMeta(enabled);
+
+  const params = useMemo(() => ({ include_bots: includeBots }), [includeBots]);
+  // The fetcher closes over `includeBots` and is a new function each render,
+  // which is safe: useReport invokes it through a ref and refetches on the
+  // params VALUE. That indirection is what stopped the request loop this hook
+  // was built to fix.
+  const state = useReport(
+    () => ReportsAPI.getUnfinished(includeBots),
+    params,
+    enabled,
+    'The unfinished-sessions endpoint',
+  );
+
+  return (
+    <ReportsShell
+      title="Sitting unfinished"
+      description="Sessions started and never finished, as they stand right now — per game, by how long they have sat."
+    >
+      <FilterBar>
+        <FilterGroup
+          label="Accounts"
+          hint="Bot and simulation accounts (is_dummy). Off by default — Anonymous players are real people and are always counted."
+        >
+          <label
+            htmlFor="unfinished-include-bots"
+            className="flex h-8 items-center gap-2 text-sm text-muted-foreground"
+          >
+            <Switch
+              id="unfinished-include-bots"
+              checked={includeBots}
+              onCheckedChange={setIncludeBots}
+            />
+            Include bots
+          </label>
+        </FilterGroup>
+      </FilterBar>
+
+      <ReportPanel state={state} skeletonClassName="h-96 w-full">
+        {data => (
+          <>
+            {/* A snapshot with no timestamp cannot be judged: a tab left open
+                for an hour looks exactly like one opened a second ago, and this
+                page has no range control to hint otherwise. Rendered in the
+                reader's own clock, because the only question it answers is "how
+                old is what I am looking at". */}
+            <p className="text-xs text-muted-foreground">
+              {`Taken ${new Date(data.as_of).toLocaleString(undefined, {
+                dateStyle: 'medium',
+                timeStyle: 'short',
+              })}`}
+            </p>
+
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <StatTile
+                label="Sitting unfinished"
+                value={data.total_stale_sessions.toLocaleString()}
+                hint="Older than an hour, across every game"
+                metric="stale_sessions"
+              />
+              <StatTile
+                label="Including the last hour"
+                value={data.total_unfinished.toLocaleString()}
+                // The difference between the two tiles IS the "probably still
+                // playing" pool, so both are shown rather than making a reader
+                // subtract to find it.
+                hint="The gap between these two is roughly what is still being played"
+              />
+            </div>
+
+            <UnfinishedTable rows={data.rows} meta={meta} />
+
+            <p className="text-xs text-muted-foreground">
+              {/* Stated on the page, not just in the glossary: a reader comparing
+                  two games needs to know the number cannot say when the player
+                  actually left, only when they started. */}
+              Age is measured from when a session started, so a row that has sat two
+              hours is one where the player has been gone anywhere between two hours
+              and no time at all. Saying when someone actually stopped needs a
+              last-activity timestamp, which the games do not record yet.
+            </p>
+          </>
+        )}
+      </ReportPanel>
+    </ReportsShell>
+  );
+}

--- a/components/reports/ReportsNav.tsx
+++ b/components/reports/ReportsNav.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 import type { NavGroup, NavItem } from '@/components/admin/SectionNav';
-import { BarChart3, BookOpen, Clock, Gamepad2, LayoutGrid, Repeat, Star, Timer, TriangleAlert, Users } from 'lucide-react';
+import { BarChart3, BookOpen, Clock, Gamepad2, Hourglass, LayoutGrid, Repeat, Star, Timer, TriangleAlert, Users } from 'lucide-react';
 
 /**
  * Reports, grouped by the question each page answers.
  *
- * Ten flat destinations read as a wall of equally-weighted choices — you have
+ * Eleven flat destinations read as a wall of equally-weighted choices — you have
  * to already know the names to find anything. These three headings are the
  * actual shape of the section: how is the platform doing, how is each game
  * doing, how are the people doing.
@@ -18,6 +18,7 @@ export const REPORT_NAV_GROUPS: NavGroup[] = [
       { href: '/reports', label: 'Daily Pulse', icon: BarChart3 },
       { href: '/reports/anomalies', label: 'Needs attention', icon: TriangleAlert },
       { href: '/reports/patterns', label: 'Patterns', icon: Clock },
+      { href: '/reports/unfinished', label: 'Sitting unfinished', icon: Hourglass },
     ],
   },
   {

--- a/components/reports/UnfinishedTable.tsx
+++ b/components/reports/UnfinishedTable.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import type { GameMetaMap } from '@/hooks/use-game-meta';
+import type { UnfinishedRow } from '@/types/reports';
+import { EmptyState } from '@/components/reports/EmptyState';
+import { GameBadge } from '@/components/reports/GameBadge';
+import { MetricInfo } from '@/components/reports/MetricInfo';
+import { ReportHead, ReportRow, ReportTable, Td, Th } from '@/components/reports/ReportTable';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { unfinishedBands } from '@/lib/unfinished-bands';
+
+/**
+ * Where the unfinished sessions are sitting, and for how long.
+ *
+ * Ranked by the STALE pool rather than the total, because the total is not the
+ * thing anyone can act on: it includes the last hour, which on a busy game is
+ * mostly people currently playing. Ranking by it would put whichever game is
+ * busiest right now at the top, every time you looked.
+ */
+export function UnfinishedTable({ rows, meta }: { rows: UnfinishedRow[]; meta: GameMetaMap }) {
+  const withPool = rows.filter(row => row.unfinished > 0);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          Sitting unfinished
+          <MetricInfo metric="stale_sessions" />
+        </CardTitle>
+        <CardDescription>
+          A snapshot of right now, not a figure for a window. The last hour is kept
+          separate — on a busy game most of it is people still playing.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="overflow-x-auto">
+        {withPool.length === 0
+          ? <EmptyState>Nothing is sitting unfinished.</EmptyState>
+          : (
+              <ReportTable>
+                <ReportHead>
+                  <Th>Game</Th>
+                  <Th align="right">Stale</Th>
+                  <Th align="right" title="Started within the last hour — probably still being played">Last hour</Th>
+                  <Th>How long they have sat</Th>
+                </ReportHead>
+                <tbody>
+                  {withPool.map((row) => {
+                    const bands = unfinishedBands(row.buckets);
+
+                    return (
+                      <ReportRow key={row.game_type}>
+                        <Td strong>
+                          <span className="flex items-center gap-2">
+                            <GameBadge gameKey={row.game_type} meta={meta} />
+                            {/* Stated on the row, not in a footnote: a game whose
+                                sweeper closes idle sessions cannot accumulate an
+                                old pool, so its number is not comparable with a
+                                game that never sweeps. Rank without knowing that
+                                and the swept game reads as the healthiest here. */}
+                            {row.sweeper_hours !== null && (
+                              <span className="whitespace-nowrap text-xs font-normal text-muted-foreground">
+                                {`swept after ${row.sweeper_hours}h`}
+                              </span>
+                            )}
+                          </span>
+                        </Td>
+                        <Td align="right">{row.stale_sessions.toLocaleString()}</Td>
+                        <Td align="right" className="text-muted-foreground">
+                          {row.recent_sessions.toLocaleString()}
+                        </Td>
+                        <Td>
+                          <span className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                            {bands.map(band => (
+                              <span key={band.label} className="whitespace-nowrap">
+                                {band.label}
+                                {': '}
+                                <span className="text-foreground">{band.count.toLocaleString()}</span>
+                                {` (${band.pct}%)`}
+                              </span>
+                            ))}
+                          </span>
+                        </Td>
+                      </ReportRow>
+                    );
+                  })}
+                </tbody>
+              </ReportTable>
+            )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/reports/__tests__/UnfinishedTable.test.tsx
+++ b/components/reports/__tests__/UnfinishedTable.test.tsx
@@ -1,0 +1,101 @@
+import type { UnfinishedRow } from '@/types/reports';
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { UnfinishedTable } from '@/components/reports/UnfinishedTable';
+
+const META = {
+  grid: { key: 'grid', label: 'Grid', display_name: 'Grid', color: '#f97316', color_dark: '#fdba74' },
+  conquest: {
+    key: 'conquest',
+    label: 'Football Conquest',
+    display_name: 'Football Conquest',
+    color: '#38bdf8',
+    color_dark: '#7dd3fc',
+  },
+} as never;
+
+function row(over: Partial<UnfinishedRow> & Pick<UnfinishedRow, 'game_type'>): UnfinishedRow {
+  return {
+    unfinished: 0,
+    recent_sessions: 0,
+    stale_sessions: 0,
+    buckets: [],
+    sweeper_hours: null,
+    ...over,
+  };
+}
+
+describe('unfinishedTable', () => {
+  it('ranks by the stale pool, not by the total', () => {
+    // The total includes the last hour, which on a busy game is mostly people
+    // currently playing — ranking by it surfaces whichever game is busiest right
+    // now, every time you look, which is not something anyone can act on.
+    const rows = [
+      row({ game_type: 'conquest', unfinished: 12, recent_sessions: 2, stale_sessions: 10 }),
+      row({ game_type: 'grid', unfinished: 90, recent_sessions: 88, stale_sessions: 2 }),
+    ];
+
+    render(<UnfinishedTable rows={rows} meta={META} />);
+    const names = screen.getAllByRole('row').slice(1).map(r => within(r).getAllByRole('cell')[0].textContent);
+
+    // Given in stale order by the API; the component must not re-sort by total.
+    expect(names[0]).toContain('Football Conquest');
+  });
+
+  it('says on the row when a game sweeps its idle sessions', () => {
+    // Conquest closes idle sessions on a timer, so it CANNOT accumulate an old
+    // pool. Without this on the row, a reader ranking the table concludes it is
+    // the healthiest game on the platform.
+    render(
+      <UnfinishedTable
+        rows={[row({ game_type: 'conquest', unfinished: 5, stale_sessions: 5, sweeper_hours: 24 })]}
+        meta={META}
+      />,
+    );
+
+    expect(screen.getByText('swept after 24h')).toBeInTheDocument();
+  });
+
+  it('adds no sweeper note to a game that has none', () => {
+    render(
+      <UnfinishedTable
+        rows={[row({ game_type: 'grid', unfinished: 5, stale_sessions: 5 })]}
+        meta={META}
+      />,
+    );
+
+    expect(screen.queryByText(/swept after/)).not.toBeInTheDocument();
+  });
+
+  it('shows the last hour apart from the stale count', () => {
+    render(
+      <UnfinishedTable
+        rows={[row({ game_type: 'grid', unfinished: 30, recent_sessions: 25, stale_sessions: 5 })]}
+        meta={META}
+      />,
+    );
+    const cells = within(screen.getAllByRole('row')[1]).getAllByRole('cell');
+
+    expect(cells[1]).toHaveTextContent('5');
+    expect(cells[2]).toHaveTextContent('25');
+  });
+
+  it('drops games with an empty pool rather than listing them at zero', () => {
+    // Eleven rows of 0 is a wall of nothing to read past. A game with no
+    // unfinished sessions has nothing to say here.
+    render(
+      <UnfinishedTable
+        rows={[row({ game_type: 'grid', unfinished: 4, stale_sessions: 4 }), row({ game_type: 'conquest' })]}
+        meta={META}
+      />,
+    );
+
+    expect(screen.getAllByRole('row')).toHaveLength(2);
+  });
+
+  it('says so when nothing is unfinished at all', () => {
+    render(<UnfinishedTable rows={[row({ game_type: 'grid' })]} meta={META} />);
+
+    expect(screen.getByText('Nothing is sitting unfinished.')).toBeInTheDocument();
+  });
+});

--- a/lib/__tests__/unfinished-bands.test.ts
+++ b/lib/__tests__/unfinished-bands.test.ts
@@ -1,0 +1,59 @@
+import type { UnfinishedBucket } from '@/types/reports';
+import { describe, expect, it } from 'vitest';
+import { unfinishedBands } from '@/lib/unfinished-bands';
+
+const BUCKETS: UnfinishedBucket[] = [
+  { from_hours: 0, to_hours: 1, count: 10 },
+  { from_hours: 1, to_hours: 24, count: 30 },
+  { from_hours: 24, to_hours: 168, count: 40 },
+  { from_hours: 168, to_hours: null, count: 20 },
+];
+
+describe('unfinishedBands', () => {
+  it('labels a band from both of its bounds', () => {
+    // The bug this exists to prevent: labelling from the ceiling alone reads the
+    // 1-24h band as "under 24h", which overlaps the band below it. Both look
+    // right on their own, and nothing signals the overlap.
+    const labels = unfinishedBands(BUCKETS).map(band => band.label);
+
+    expect(labels).toEqual(['under 1h', '1h–1d', '1d–1w', 'over 1w']);
+  });
+
+  it('reads the boundaries from the payload rather than a list of its own', () => {
+    // A parallel copy of the boundaries drifts the first time the backend moves
+    // one, and the panel is then confidently mislabelled instead of broken.
+    const moved = unfinishedBands([
+      { from_hours: 0, to_hours: 2, count: 1 },
+      { from_hours: 2, to_hours: 48, count: 1 },
+    ]);
+
+    expect(moved.map(band => band.label)).toEqual(['under 2h', '2h–2d']);
+  });
+
+  it('gives each band its own honest rounding', () => {
+    const bands = unfinishedBands(BUCKETS);
+
+    expect(bands.map(band => band.pct)).toEqual([10, 30, 40, 20]);
+  });
+
+  it('does not adjust shares to make the column total 100', () => {
+    // Deliberate: a reader can check a share against the count beside it. Moving
+    // a remainder into the last band buys a tidy total at the cost of one band
+    // saying something its own numbers do not support.
+    const bands = unfinishedBands([
+      { from_hours: 0, to_hours: 1, count: 1 },
+      { from_hours: 1, to_hours: 24, count: 1 },
+      { from_hours: 24, to_hours: null, count: 1 },
+    ]);
+    const total = bands.reduce((sum, band) => sum + band.pct, 0);
+
+    expect(bands.every(band => band.pct === 33.3)).toBe(true);
+    expect(total).toBeCloseTo(99.9);
+  });
+
+  it('returns nothing when a game has no unfinished sessions', () => {
+    // Not four bands of 0%: an empty pool has no shape, and dividing by zero to
+    // draw one would render a row of NaN.
+    expect(unfinishedBands(BUCKETS.map(b => ({ ...b, count: 0 })))).toEqual([]);
+  });
+});

--- a/lib/reports-api.ts
+++ b/lib/reports-api.ts
@@ -12,6 +12,7 @@ import type {
   RollupHealth,
   SummaryResponse,
   TopPlayersResponse,
+  UnfinishedResponse,
 } from '@/types/reports';
 import { apiFetcher } from '@/lib/api-fetcher';
 
@@ -82,6 +83,22 @@ export class ReportsAPI {
   /** GET /core/reporting/duration/ — median session length per game. */
   static async getDuration(params?: ReportParams): Promise<DurationResponse> {
     return apiFetcher<DurationResponse>(`core/reporting/duration/${buildQuery(params)}`);
+  }
+
+  /**
+   * GET /core/reporting/unfinished/ — what is sitting unfinished right now.
+   *
+   * Takes a plain flag rather than `ReportParams`, and that is load-bearing: it
+   * is a snapshot of state, so there is no range to pass and none to echo back.
+   * `reports.guard.ts` treats any method accepting `ReportParams` as
+   * range-filtered and requires the full echo — correctly — so a params object
+   * here would either fail the guard or need an exemption for an endpoint that
+   * was never range-filtered in the first place.
+   */
+  static async getUnfinished(includeBots = false): Promise<UnfinishedResponse> {
+    return apiFetcher<UnfinishedResponse>(
+      `core/reporting/unfinished/${buildQuery({ include_bots: includeBots })}`,
+    );
   }
 
   /** GET /core/reporting/patterns/ — when people play + new vs returning. */

--- a/lib/unfinished-bands.ts
+++ b/lib/unfinished-bands.ts
@@ -1,0 +1,58 @@
+/**
+ * Age bands of the unfinished pool, ready to read.
+ *
+ * The labels come from the boundaries the backend sent, never from a parallel
+ * list here: a second copy drifts the first time a boundary moves, and the panel
+ * would then be confidently mislabelled rather than obviously broken.
+ *
+ * Both bounds are used. `to_hours` alone reads as "under 24h" when the band
+ * actually covers 1–24h — the youngest band is reported separately, so every
+ * edge above it is a floor as well as a ceiling. Labelling from the ceiling
+ * alone produces overlapping bands that each look correct on their own, which
+ * is worse than an error because nothing signals it.
+ */
+
+import type { UnfinishedBucket } from '@/types/reports';
+
+export type UnfinishedBand = {
+  label: string;
+  count: number;
+  /** Share of this game's unfinished pool, rounded on its own. */
+  pct: number;
+};
+
+/** "2h", "3d", "1w" — the coarsest unit that still reads exactly. */
+function hoursToWords(hours: number): string {
+  if (hours < 24) {
+    return `${hours}h`;
+  }
+  const days = hours / 24;
+
+  return days % 7 === 0 ? `${days / 7}w` : `${days}d`;
+}
+
+export function unfinishedBands(buckets: UnfinishedBucket[]): UnfinishedBand[] {
+  const total = buckets.reduce((sum, bucket) => sum + bucket.count, 0);
+  if (total === 0) {
+    return [];
+  }
+
+  return buckets.map((bucket) => {
+    const label = bucket.to_hours === null
+      ? `over ${hoursToWords(bucket.from_hours)}`
+      : bucket.from_hours === 0
+        // The youngest band is the "probably still playing" one, so it is named
+        // for what it means rather than for its numbers.
+        ? `under ${hoursToWords(bucket.to_hours)}`
+        : `${hoursToWords(bucket.from_hours)}–${hoursToWords(bucket.to_hours)}`;
+
+    return {
+      label,
+      count: bucket.count,
+      // Each share is the honest rounding of its own band, deliberately not
+      // adjusted to make the column total exactly 100 — a reader can check 12.5%
+      // against the count beside it, and this is a shape, not a budget.
+      pct: Math.round((bucket.count / total) * 1000) / 10,
+    };
+  });
+}

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -487,6 +487,58 @@ export type DurationResponse = {
   rows: DurationRow[];
 } & ResolvedRange;
 
+/**
+ * One age band of a game's unfinished pool.
+ *
+ * Both bounds, not one. `to_hours` alone read as "under 24h" while meaning
+ * "1-24h" — the youngest band is reported separately, so every edge above it is
+ * a floor as well as a ceiling. A single bound produces overlapping bands that
+ * each look correct alone, which is worse than an error.
+ */
+export type UnfinishedBucket = {
+  from_hours: number;
+  /** `null` on the open-ended top band. */
+  to_hours: number | null;
+  count: number;
+};
+
+export type UnfinishedRow = {
+  game_type: string;
+  unfinished: number;
+  /**
+   * Started within the last hour. Reported apart from the stale pool, never
+   * folded into it: nothing distinguishes a session opened five minutes ago and
+   * still being played from one walked away from, so counting it as abandonment
+   * would report every game as worst during its own peak.
+   */
+  recent_sessions: number;
+  stale_sessions: number;
+  buckets: UnfinishedBucket[];
+  /**
+   * Hours of idleness after which this game's sweeper closes a session, or
+   * `null` where it has none. A swept game CANNOT accumulate an old pool, so its
+   * total is not comparable with one that never sweeps — rank without this and
+   * the swept game reads as the healthiest on the platform.
+   */
+  sweeper_hours: number | null;
+};
+
+/**
+ * A snapshot of what is unfinished right now — deliberately NOT range filtered.
+ *
+ * The abandonment figure on the games report is arithmetic over a window
+ * (`games_started - games_finished`), which answers a different question and
+ * counts a session started minutes ago as abandoned. A window on this one would
+ * not merely be unused, it would be meaningless, so there is no `ResolvedRange`.
+ */
+export type UnfinishedResponse = {
+  as_of: string;
+  include_bots: boolean;
+  rows: UnfinishedRow[];
+  total_unfinished: number;
+  total_stale_sessions: number;
+};
+
 export type AnomalyFinding = {
   scope: 'platform' | 'game';
   game_type: string | null;


### PR DESCRIPTION
Front end for the snapshot endpoint shipped in App#1471/#1472. Completes C7 Phase 0 on #1453.

Its own page under **Overview**, and the only report with no range control.

## Why no range

Every other page answers a question about a period. This one answers a question about **state** — what is abandoned right now — so a date range on it would not merely go unused, it would be meaningless.

It sits *beside* the games report's abandoned pool rather than replacing it. That one measures a window (`started − finished`) and says how much a period leaked; this one reads the rows and says what is lying around. The same game can look different in each, and both are true.

## Three things the page states rather than assumes

**The last hour is a separate column**, never folded into the total. On a busy game most of it is people currently playing — ranking by the total would put whichever game is busiest *right now* at the top, every time you looked. The table ranks by the stale pool.

**A swept game says so on its own row** ("swept after 24h"). Conquest closes idle sessions on a timer, so it cannot accumulate an old pool and its number is not comparable with a game that never sweeps. Rank without knowing that and the swept game reads as the healthiest thing on the page.

**Age is measured from session start**, so a row that has sat two hours is a player gone anywhere between two hours and no time at all. Said on the page, not only in the glossary, because it is the limitation a reader would otherwise never guess — and it is exactly what `last_activity_at` would remove.

## Two guards shaped this, rather than being worked around

- **`reports.guard.ts`** classified `getUnfinished` as range-filtered, because `ReportParams` is structurally assignable to `Pick<ReportParams, 'include_bots'>`. The right fix was an honest signature — a plain `includeBots` flag — not an exemption for an endpoint that was never range-filtered in the first place.
- **`response-fields-used.ts`** refused `as_of` as typed-but-unrendered, and it was right. A snapshot with no timestamp cannot be judged: a tab left open for an hour looks identical to one opened a second ago, and this page has no range control to hint otherwise. Now rendered.

## Conventions

Built on the primitives from #108 — `ReportPanel`, `ReportTable`, `StatTile`, `EmptyState`, `FilterBar`, tokens only — so all seven surface guards pass without exemptions.

`unfinishedBands` labels from **both** bucket bounds. Mutation-tested: labelling from the ceiling alone reproduces the overlapping-bands bug and fails two assertions.

503 tests, lint clean, types OK, build compiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)