### PR TITLE
Band labels must divide exactly, not merely reach the unit

### DIFF
--- a/lib/__tests__/unfinished-bands.test.ts
+++ b/lib/__tests__/unfinished-bands.test.ts
@@ -30,6 +30,28 @@ describe('unfinishedBands', () => {
     expect(moved.map(band => band.label)).toEqual(['under 2h', '2h–2d']);
   });
 
+  it('only uses a coarser unit when the boundary divides into it exactly', () => {
+    // The label has to stay a boundary. Dividing by 24 whenever the count merely
+    // reaches it turned a 25-hour edge into "1.0416666666666667d" — invisible
+    // today because 1/24/168 all divide cleanly, and waiting for the first time
+    // one of them moved.
+    const bands = unfinishedBands([
+      { from_hours: 0, to_hours: 25, count: 1 },
+      { from_hours: 25, to_hours: 36, count: 1 },
+      { from_hours: 36, to_hours: 48, count: 1 },
+      { from_hours: 48, to_hours: 336, count: 1 },
+      { from_hours: 336, to_hours: null, count: 1 },
+    ]);
+
+    expect(bands.map(band => band.label)).toEqual([
+      'under 25h',
+      '25h–36h',
+      '36h–2d',
+      '2d–2w',
+      'over 2w',
+    ]);
+  });
+
   it('gives each band its own honest rounding', () => {
     const bands = unfinishedBands(BUCKETS);
 

--- a/lib/__tests__/unfinished-bands.test.ts
+++ b/lib/__tests__/unfinished-bands.test.ts
@@ -52,6 +52,16 @@ describe('unfinishedBands', () => {
     ]);
   });
 
+  it('does not call zero a week', () => {
+    // `0 % 168 === 0`, so the divisibility check alone labels a band starting at
+    // zero "0w". Not reachable from the current payload — the open-ended band
+    // starts at the last boundary — but the same shape as the bug above, and
+    // that one was also unreachable right up until a boundary moved.
+    const bands = unfinishedBands([{ from_hours: 0, to_hours: null, count: 3 }]);
+
+    expect(bands[0].label).toBe('over 0h');
+  });
+
   it('gives each band its own honest rounding', () => {
     const bands = unfinishedBands(BUCKETS);
 

--- a/lib/unfinished-bands.ts
+++ b/lib/unfinished-bands.ts
@@ -21,14 +21,24 @@ export type UnfinishedBand = {
   pct: number;
 };
 
-/** "2h", "3d", "1w" — the coarsest unit that still reads exactly. */
+/**
+ * "2h", "3d", "1w" — the coarsest unit that still reads EXACTLY.
+ *
+ * Divisibility is the whole condition. Dividing by 24 whenever the count merely
+ * reaches 24 turns a 25-hour boundary into "1.0416666666666667d" — the label
+ * stops being a boundary and becomes a float. Today's boundaries (1, 24, 168)
+ * all divide cleanly, so this was invisible; it would have surfaced the first
+ * time one of them moved, in a band label nobody re-reads.
+ */
 function hoursToWords(hours: number): string {
-  if (hours < 24) {
-    return `${hours}h`;
+  if (hours % 168 === 0) {
+    return `${hours / 168}w`;
   }
-  const days = hours / 24;
+  if (hours % 24 === 0) {
+    return `${hours / 24}d`;
+  }
 
-  return days % 7 === 0 ? `${days / 7}w` : `${days}d`;
+  return `${hours}h`;
 }
 
 export function unfinishedBands(buckets: UnfinishedBucket[]): UnfinishedBand[] {

--- a/lib/unfinished-bands.ts
+++ b/lib/unfinished-bands.ts
@@ -31,6 +31,15 @@ export type UnfinishedBand = {
  * time one of them moved, in a band label nobody re-reads.
  */
 function hoursToWords(hours: number): string {
+  // Below a day there is no coarser unit to reach for, and this also settles
+  // zero: `0 % 168 === 0` is true, so without it a band starting at 0 would be
+  // labelled "0w". Not reachable from the current payload — the open-ended band
+  // starts at the last boundary, never at 0 — but it is the same shape of bug as
+  // the one this function was just fixed for, and "unreachable today" is what
+  // was said about that one too.
+  if (hours < 24) {
+    return `${hours}h`;
+  }
   if (hours % 168 === 0) {
     return `${hours / 168}w`;
   }


### PR DESCRIPTION
Copilot's finding on #113, which merged before it was addressed — so this is on `production`, latent.

## The bug

`hoursToWords` divided by 24 whenever the count **reached** 24:

```
  25 -> 1.0416666666666667d
  36 -> 1.5d
 200 -> 8.333333333333334d
```

At that point the label stops being a boundary and becomes a float, in a band caption nobody re-reads.

## Why it hasn't shown

The boundaries are currently 1, 24 and 168 — all divide cleanly. It was waiting for the first time one of them moved, and moving a boundary is exactly the kind of change someone makes without re-reading a label helper. The docstring already claimed *"the coarsest unit that still reads exactly"*; the code only implemented "reaches".

## The fix

Divisibility is the whole condition:

```
   1 -> 1h      25 -> 25h     36 -> 36h
  24 -> 1d      48 -> 2d     336 -> 2w
 168 -> 1w     200 -> 200h
```

## Test

A band set built entirely from non-divisible boundaries, asserting `['under 25h', '25h–36h', '36h–2d', '2d–2w', 'over 2w']`.

Mutation-tested against the shipped bug itself — restoring `hours >= 24` fails with `"under 1.0416666666666667d"`.

510 tests, lint clean, types OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)