### PR TITLE
Let the player numbers say what they leave out

### DIFF
--- a/app/reports/games/[key]/page.tsx
+++ b/app/reports/games/[key]/page.tsx
@@ -135,20 +135,24 @@ export default function GameDetailPage() {
                   <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
                     <StatTile
                       label="Completion"
+                      metric="completion_pct"
                       value={row.completion_pct === null ? '—' : `${row.completion_pct}%`}
                       hint="Of games started"
                     />
                     <StatTile
                       label="Repeat rate"
+                      metric="repeat_rate_pct"
                       value={row.repeat_rate_pct === null ? '—' : `${row.repeat_rate_pct}%`}
                       hint="Players who came back another day"
                     />
                     <StatTile
                       label="Sessions per player"
+                      metric="sessions_per_player"
                       value={row.sessions_per_player?.toString() ?? '—'}
                     />
                     <StatTile
                       label="Share of platform"
+                      metric="share_pct"
                       value={row.share_pct === null ? '—' : `${row.share_pct}%`}
                       hint="Of all games played"
                     />

--- a/components/reports/GameLeaderboard.tsx
+++ b/components/reports/GameLeaderboard.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link';
 import { useState } from 'react';
 import { EmptyState } from '@/components/reports/EmptyState';
 import { GameBadge } from '@/components/reports/GameBadge';
+import { MetricInfo } from '@/components/reports/MetricInfo';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { useGameColor } from '@/hooks/use-game-meta';
 import { cn } from '@/lib/utils';
@@ -142,19 +143,28 @@ export function GameLeaderboard({ rows, meta, metric, selected, onSelect }: {
 
               {isOpen && (
                 <dl className="grid grid-cols-2 gap-3 border-t px-4 py-3 text-sm sm:grid-cols-3 lg:grid-cols-6">
-                  {[
-                    ['Started', row.games_started.toLocaleString()],
-                    ['Finished', row.games_finished.toLocaleString()],
-                    ['Players', row.distinct_players.toLocaleString()],
-                    ['Sessions / player', row.sessions_per_player ?? '—'],
-                    ['Multiplayer', row.mp_player_sessions.toLocaleString()],
-                    ['Solo', (row.games_started - row.mp_player_sessions).toLocaleString()],
-                    ['Repeat players', row.repeat_players.toLocaleString()],
-                    ['Share of platform', rate(row.share_pct)],
-                    ['Previous window', row.previous_games_started.toLocaleString()],
-                  ].map(([label, value]) => (
-                    <div key={label as string}>
-                      <dt className="text-xs text-muted-foreground">{label}</dt>
+                  {/* The third element is a glossary key. Players and
+                      sessions-per-player carry one because both deliberately
+                      leave anonymous play out — every anonymous session belongs
+                      to one shared account, so counting it would read hundreds
+                      of people as one. That is not inferable from the figure,
+                      and it is why the number is lower than a reader expects. */}
+                  {([
+                    ['Started', row.games_started.toLocaleString(), 'games_started'],
+                    ['Finished', row.games_finished.toLocaleString(), 'games_finished'],
+                    ['Players', row.distinct_players.toLocaleString(), 'distinct_players'],
+                    ['Sessions / player', row.sessions_per_player ?? '—', 'sessions_per_player'],
+                    ['Multiplayer', row.mp_player_sessions.toLocaleString(), 'mp_sessions'],
+                    ['Solo', (row.games_started - row.mp_player_sessions).toLocaleString(), undefined],
+                    ['Repeat players', row.repeat_players.toLocaleString(), 'repeat_rate_pct'],
+                    ['Share of platform', rate(row.share_pct), 'share_pct'],
+                    ['Previous window', row.previous_games_started.toLocaleString(), undefined],
+                  ] as [string, string | number, string | undefined][]).map(([label, value, glossaryKey]) => (
+                    <div key={label}>
+                      <dt className="flex items-center gap-1 text-xs text-muted-foreground">
+                        {label}
+                        {glossaryKey && <MetricInfo metric={glossaryKey} />}
+                      </dt>
                       <dd className="font-medium tabular-nums text-foreground">{value}</dd>
                     </div>
                   ))}

--- a/components/reports/GameLeaderboard.tsx
+++ b/components/reports/GameLeaderboard.tsx
@@ -156,7 +156,12 @@ export function GameLeaderboard({ rows, meta, metric, selected, onSelect }: {
                     ['Sessions / player', row.sessions_per_player ?? '—', 'sessions_per_player'],
                     ['Multiplayer', row.mp_player_sessions.toLocaleString(), 'mp_sessions'],
                     ['Solo', (row.games_started - row.mp_player_sessions).toLocaleString(), undefined],
-                    ['Repeat players', row.repeat_players.toLocaleString(), 'repeat_rate_pct'],
+                    // No glossary key: this is the COUNT, and the only definition that
+                    // exists is `repeat_rate_pct`, a percentage. Pointing at it put the
+                    // definition of a rate beside a headcount, and the popover's
+                    // accessible name disagreed with the visible label once the glossary
+                    // loaded (Copilot on #116). The rate keeps its own key, one column left.
+                    ['Repeat players', row.repeat_players.toLocaleString(), undefined],
                     ['Share of platform', rate(row.share_pct), 'share_pct'],
                     ['Previous window', row.previous_games_started.toLocaleString(), undefined],
                   ] as [string, string | number, string | undefined][]).map(([label, value, glossaryKey]) => (

--- a/components/reports/PulseTiles.tsx
+++ b/components/reports/PulseTiles.tsx
@@ -5,11 +5,19 @@ import { Minus, TrendingDown, TrendingUp } from 'lucide-react';
 import { StatTile } from '@/components/reports/StatTile';
 import { cn } from '@/lib/utils';
 
-const TILES: { key: keyof ActivityMetrics; label: string; hint: string }[] = [
-  { key: 'games_started', label: 'Games started', hint: 'Sessions begun today' },
-  { key: 'games_finished', label: 'Games finished', hint: 'Of those, played to the end' },
-  { key: 'distinct_players', label: 'Players', hint: 'Distinct people who played' },
-  { key: 'mp_player_sessions', label: 'Multiplayer', hint: 'Participations in rooms' },
+/**
+ * `metric` keys into the BE glossary so a tile explains itself in place.
+ *
+ * Players needs it most: the figure deliberately leaves out anonymous play,
+ * because every anonymous session belongs to one shared account and counting it
+ * would read hundreds of people as one. A reader cannot infer that from "3,412",
+ * and the number is lower than they expect precisely because of it.
+ */
+const TILES: { key: keyof ActivityMetrics; label: string; hint: string; metric: string }[] = [
+  { key: 'games_started', label: 'Games started', hint: 'Sessions begun today', metric: 'games_started' },
+  { key: 'games_finished', label: 'Games finished', hint: 'Of those, played to the end', metric: 'games_finished' },
+  { key: 'distinct_players', label: 'Players', hint: 'Distinct people who played', metric: 'distinct_players' },
+  { key: 'mp_player_sessions', label: 'Multiplayer', hint: 'Participations in rooms', metric: 'mp_sessions' },
 ];
 
 /**
@@ -93,12 +101,13 @@ export function PulseTiles({ pulse }: { pulse: Pulse }) {
       )}
 
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        {TILES.map(({ key, label, hint }) => {
+        {TILES.map(({ key, label, hint, metric: glossaryKey }) => {
           const metric = pulse.metrics[key];
           return (
             <StatTile
               key={key}
               label={label}
+              metric={glossaryKey}
               value={metric.today.toLocaleString()}
               delta={<Delta metric={metric} />}
               hint={(

--- a/components/reports/__tests__/player-metrics-explain-themselves.test.tsx
+++ b/components/reports/__tests__/player-metrics-explain-themselves.test.tsx
@@ -1,0 +1,100 @@
+import type { GameTotals, Pulse } from '@/types/reports';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { GameLeaderboard } from '@/components/reports/GameLeaderboard';
+import { PulseTiles } from '@/components/reports/PulseTiles';
+
+/**
+ * Player-level figures have to be discoverable as player-level figures.
+ *
+ * `distinct_players` and `sessions_per_player` deliberately leave anonymous play
+ * out (App#1476): every anonymous session belongs to one shared account, so
+ * counting it would read hundreds of people as one. On production that account
+ * was the biggest "player" on the platform — 2,234 sessions in 30 days against
+ * 792 for the busiest real player.
+ *
+ * So both numbers are LOWER than a reader expects, for a reason they cannot
+ * possibly infer from the figure. `MetricInfo` renders the backend glossary's
+ * `excludes` text in place; these assert the affordance is actually there.
+ *
+ * Asserted on the RENDER, not on the source. The first version of this test
+ * scanned files for the metric name and passed happily when the glossary key was
+ * stripped — the name still appeared as a data key on the same line. A guard
+ * that survives the mutation it exists to catch is worse than no guard.
+ *
+ * `MetricInfo` labels its trigger `What "<label or key>" means`, and with no
+ * glossary provider mounted the definition is undefined, so the key itself is
+ * the accessible name. That is what these look for.
+ */
+function pulseMetric(today: number) {
+  return {
+    today,
+    baseline_same_weekday: today,
+    baseline_full_day: today,
+    change_pct: 0,
+  } as never;
+}
+
+const PULSE = {
+  date: '2026-08-15',
+  weekday: 'Saturday',
+  baseline_weeks: 4,
+  baseline_covered: true,
+  baseline_missing_days: [],
+  elapsed_share: 1,
+  metrics: {
+    games_started: pulseMetric(120),
+    games_finished: pulseMetric(90),
+    distinct_players: pulseMetric(40),
+    mp_player_sessions: pulseMetric(12),
+  },
+} as unknown as Pulse;
+
+const META = {
+  grid: { key: 'grid', label: 'Grid', display_name: 'Grid', color: '#f97316', color_dark: '#fdba74' },
+} as never;
+
+const ROW = {
+  game_type: 'grid',
+  games_started: 120,
+  games_finished: 90,
+  distinct_players: 40,
+  sessions_per_player: 3,
+  mp_player_sessions: 12,
+  repeat_players: 8,
+  repeat_rate_pct: 20,
+  share_pct: 50,
+  completion_pct: 75,
+  previous_games_started: 100,
+  trend_pct: 20,
+} as unknown as GameTotals;
+
+describe('the Daily Pulse explains its player figure', () => {
+  it('offers the definition beside Players', () => {
+    render(<PulseTiles pulse={PULSE} />);
+
+    expect(screen.getByLabelText('What "distinct_players" means')).toBeInTheDocument();
+  });
+});
+
+describe('the game leaderboard explains its player figures', () => {
+  it('offers the definition for both, on the expanded row', () => {
+    render(
+      <GameLeaderboard
+        rows={[ROW]}
+        meta={META}
+        metric="games_started"
+        selected="grid"
+        onSelect={() => {}}
+      />,
+    );
+
+    // The detail rows live behind a disclosure, and the `selected` prop is the
+    // FILTER, not the disclosure — opening it is the only way to see the figures
+    // this is about.
+    fireEvent.click(screen.getByRole('button', { expanded: false }));
+
+    expect(screen.getByLabelText('What "distinct_players" means')).toBeInTheDocument();
+    expect(screen.getByLabelText('What "sessions_per_player" means')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
FE half of **R1** (#1474 / App#1476).

The backend now excludes anonymous play from `distinct_players` and `sessions_per_player` — every anonymous session belongs to one shared account, and on production that account was the biggest "player" on the platform (2,234 sessions in 30 days vs 792 for the busiest real player).

## Why this half matters

Both numbers are now **lower than a reader expects**, for a reason no figure can convey on its own.

`MetricInfo` already renders the backend glossary's `excludes` text in place — but nothing keyed these two into it. The Daily Pulse's Players tile, the leaderboard's per-game rows and the single-game report all showed the numbers with **no route to their definition**. That gap is exactly where "why is this number wrong?" comes from.

All three now offer it. The per-game tiles pick up completion, repeat rate and share-of-platform while they were being touched.

## The guard is asserted on the render, and that mattered

The first version of the test scanned source files for the metric name. It **passed** when I stripped the glossary key from the Players tile — because `key: 'distinct_players'` still appears on the same line. It survived the exact mutation it existed to catch, which makes it worse than no test.

Rewritten to render the components and look for `MetricInfo`'s accessible name (`What "distinct_players" means`). Same mutation now fails with `Unable to find a label with the text of: What "distinct_players" means`.

Worth noting the leaderboard test has to *open the disclosure* first — `selected` is the filter, not the expansion, so asserting without clicking would have tested an unrendered row.

519 tests, lint clean, types OK, build compiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)