### PR TITLE
Show where new players start, next to whether games keep them

### DIFF
--- a/app/reports/retention/page.tsx
+++ b/app/reports/retention/page.tsx
@@ -6,10 +6,12 @@ import { useMemo } from 'react';
 import { FilterBar } from '@/components/reports/filters/FilterBar';
 import { GameFilter } from '@/components/reports/filters/GameFilter';
 import { RangePicker } from '@/components/reports/filters/RangePicker';
+import { FirstSessionFollowup } from '@/components/reports/panels/FirstSessionFollowup';
 import { RetentionByGame } from '@/components/reports/panels/RetentionByGame';
 import { RetentionTable } from '@/components/reports/panels/RetentionTable';
 import { ExportButton } from '@/components/reports/primitives/ExportButton';
 import { ReportPanel } from '@/components/reports/primitives/ReportPanel';
+import { SectionHeader } from '@/components/reports/primitives/SectionHeader';
 import { ReportsShell } from '@/components/reports/shell/ReportsShell';
 import { useGameMeta } from '@/hooks/use-game-meta';
 import { useReport } from '@/hooks/use-report';
@@ -47,6 +49,12 @@ export default function RetentionPage() {
     params,
     enabled,
     'The retention reporting endpoint',
+  );
+  const firstSession = useReport(
+    ReportsAPI.getFirstSession,
+    params,
+    enabled,
+    'The first-session reporting endpoint',
   );
 
   return (
@@ -99,6 +107,19 @@ export default function RetentionPage() {
             <RetentionTable data={data} />
           </>
         )}
+      </ReportPanel>
+
+      {/* Beside retention rather than on its own page: the two are easy to
+          confuse, and reading either alone gets the conclusion backwards. A game
+          can hold nobody itself and still be the best front door on the
+          platform. Its own panel, so one request cannot blank the other. */}
+      <SectionHeader
+        title="Where new players start"
+        description="Retention above asks whether a game keeps its own players. This asks which game keeps people on the platform at all."
+      />
+
+      <ReportPanel state={firstSession} skeletonClassName="h-72 w-full">
+        {data => <FirstSessionFollowup data={data} meta={meta} />}
       </ReportPanel>
     </ReportsShell>
   );

--- a/components/reports/__tests__/FirstSessionFollowup.test.tsx
+++ b/components/reports/__tests__/FirstSessionFollowup.test.tsx
@@ -1,0 +1,78 @@
+import type { FirstSessionResponse, FirstSessionRow } from '@/types/reports';
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { FirstSessionFollowup } from '@/components/reports/panels/FirstSessionFollowup';
+
+const META = {
+  grid: { key: 'grid', label: 'Grid', display_name: 'Grid', color: '#f97316', color_dark: '#fdba74' },
+  tenable: { key: 'tenable', label: 'Tenable', display_name: 'Tenable', color: '#b91c1c', color_dark: '#ef4444' },
+} as never;
+
+function row(over: Partial<FirstSessionRow> & Pick<FirstSessionRow, 'game_type'>): FirstSessionRow {
+  return {
+    new_players: 100,
+    below_threshold: false,
+    returned_24h: 40,
+    returned_48h: 55,
+    returned_168h: 70,
+    returned_24h_pct: 40,
+    returned_48h_pct: 55,
+    returned_168h_pct: 70,
+    ...over,
+  };
+}
+
+function response(rows: FirstSessionRow[]): FirstSessionResponse {
+  return {
+    min_players: 20,
+    total_new_players: rows.reduce((sum, r) => sum + r.new_players, 0),
+    rows,
+  } as unknown as FirstSessionResponse;
+}
+
+describe('firstSessionFollowup', () => {
+  it('shows a rate and the count behind it', () => {
+    render(<FirstSessionFollowup data={response([row({ game_type: 'grid' })])} meta={META} />);
+    const cells = within(screen.getAllByRole('row')[1]).getAllByRole('cell');
+
+    expect(cells[2]).toHaveTextContent('40%');
+    expect(cells[2]).toHaveTextContent('(40)');
+  });
+
+  it('withholds every rate below the threshold but still shows the count', () => {
+    // "3 people started here" is a fact worth having; "33% came back" from three
+    // people is not. Withholding one without the other would leave a blank row
+    // that reads as no data at all.
+    render(
+      <FirstSessionFollowup
+        data={response([row({ game_type: 'tenable', new_players: 3, below_threshold: true })])}
+        meta={META}
+      />,
+    );
+    const cells = within(screen.getAllByRole('row')[1]).getAllByRole('cell');
+
+    expect(cells[1]).toHaveTextContent('3');
+    expect(screen.getAllByText('— 3 players, needs 20')).toHaveLength(3);
+  });
+
+  it('labels the windows as cumulative', () => {
+    // The trap: read as disjoint bands, 40 / 55 / 70 looks like 165 people came
+    // back out of 100. The headers have to say they contain each other.
+    render(<FirstSessionFollowup data={response([row({ game_type: 'grid' })])} meta={META} />);
+
+    expect(screen.getByTitle(/includes the 24h column/)).toBeInTheDocument();
+    expect(screen.getByTitle(/includes both columns to its left/)).toBeInTheDocument();
+  });
+
+  it('links each starting game to its own report', () => {
+    render(<FirstSessionFollowup data={response([row({ game_type: 'grid' })])} meta={META} />);
+
+    expect(screen.getByRole('link', { name: /Grid/ })).toHaveAttribute('href', '/reports/games/grid');
+  });
+
+  it('says so when nobody started in the window', () => {
+    render(<FirstSessionFollowup data={response([])} meta={META} />);
+
+    expect(screen.getByText('Nobody played for the first time in this window.')).toBeInTheDocument();
+  });
+});

--- a/components/reports/panels/FirstSessionFollowup.tsx
+++ b/components/reports/panels/FirstSessionFollowup.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import type { GameMetaMap } from '@/hooks/use-game-meta';
+import type { FirstSessionResponse } from '@/types/reports';
+import { EmptyState } from '@/components/reports/primitives/EmptyState';
+import { GameBadge } from '@/components/reports/primitives/GameBadge';
+import { MetricInfo } from '@/components/reports/primitives/MetricInfo';
+import { MetricRow } from '@/components/reports/primitives/MetricRow';
+import { ReportHead, ReportRow, ReportTable, Td, Th } from '@/components/reports/primitives/ReportTable';
+import { SmallSampleNotice } from '@/components/reports/primitives/SmallSampleNotice';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+/**
+ * Which game hooks people onto the platform, rather than onto itself.
+ *
+ * Sits beside the retention table on purpose, because the two answer questions
+ * that are easy to confuse. Retention asks whether people who started a game
+ * came back TO THAT GAME. This asks whether they came back at all, split by
+ * where they started — so a game can hold nobody itself and still be the best
+ * front door on the platform. Reading either alone gets that backwards.
+ */
+export function FirstSessionFollowup({ data, meta }: { data: FirstSessionResponse; meta: GameMetaMap }) {
+  const rows = data.rows;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          Where new players start
+          <MetricInfo metric="returned_within" />
+        </CardTitle>
+        <CardDescription>
+          First-timers only — their first session anywhere, ever. Coming back for a
+          different game counts: the platform kept them, whatever introduced them.
+          The windows are cumulative, so everyone in 24h is also in 48h and 7 days.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4 overflow-x-auto">
+        <MetricRow
+          columns={3}
+          metrics={[
+            { label: 'New players', value: data.total_new_players.toLocaleString(), metric: 'new_players' },
+            { label: 'Starting games', value: rows.length.toLocaleString() },
+            { label: 'Rate needs', value: `${data.min_players} first-timers` },
+          ]}
+        />
+
+        {rows.length === 0
+          ? (
+              <EmptyState hint="Try a wider date range.">
+                Nobody played for the first time in this window.
+              </EmptyState>
+            )
+          : (
+              <ReportTable>
+                <ReportHead>
+                  <Th>Started on</Th>
+                  <Th align="right">First-timers</Th>
+                  <Th align="right" title="Came back to anything within a day">Within 24h</Th>
+                  <Th align="right" title="Within two days — includes the 24h column">Within 48h</Th>
+                  <Th align="right" title="Within a week — includes both columns to its left">Within 7 days</Th>
+                </ReportHead>
+                <tbody>
+                  {rows.map(row => (
+                    <ReportRow key={row.game_type}>
+                      <Td strong>
+                        <GameBadge
+                          gameKey={row.game_type}
+                          meta={meta}
+                          href={`/reports/games/${row.game_type}`}
+                        />
+                      </Td>
+                      <Td align="right">{row.new_players.toLocaleString()}</Td>
+                      {/* The count is always shown and the rate is not: below the
+                          threshold one player moves the percentage enough to
+                          mislead, but "3 started here" is still a fact. */}
+                      {([
+                        ['24h', row.returned_24h, row.returned_24h_pct],
+                        ['48h', row.returned_48h, row.returned_48h_pct],
+                        ['7d', row.returned_168h, row.returned_168h_pct],
+                      ] as [string, number, number | null][]).map(([window, count, pct]) => (
+                        <Td key={window} align="right">
+                          {row.below_threshold
+                            ? <SmallSampleNotice have={row.new_players} need={data.min_players} />
+                            : (
+                                <>
+                                  {`${pct}%`}
+                                  <span className="ml-1 text-xs text-muted-foreground">
+                                    {`(${count.toLocaleString()})`}
+                                  </span>
+                                </>
+                              )}
+                        </Td>
+                      ))}
+                    </ReportRow>
+                  ))}
+                </tbody>
+              </ReportTable>
+            )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/lib/reports-api.ts
+++ b/lib/reports-api.ts
@@ -2,6 +2,7 @@ import type {
   ActivityResponse,
   AnomaliesResponse,
   DurationResponse,
+  FirstSessionResponse,
   GamesResponse,
   GlossaryResponse,
   MultiplayerResponse,
@@ -99,6 +100,14 @@ export class ReportsAPI {
     return apiFetcher<UnfinishedResponse>(
       `core/reporting/unfinished/${buildQuery({ include_bots: includeBots })}`,
     );
+  }
+
+  /**
+   * GET /core/reporting/first-session/ — which game hooks people onto the
+   * platform, rather than onto itself.
+   */
+  static async getFirstSession(params?: ReportParams): Promise<FirstSessionResponse> {
+    return apiFetcher<FirstSessionResponse>(`core/reporting/first-session/${buildQuery(params)}`);
   }
 
   /** GET /core/reporting/patterns/ — when people play + new vs returning. */

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -539,6 +539,35 @@ export type UnfinishedResponse = {
   total_stale_sessions: number;
 };
 
+/**
+ * One starting game's first-timers, and how quickly they came back.
+ *
+ * The `returned_*` counts are CUMULATIVE: everyone in 24h is also in 48h and
+ * 7d. Reported as disjoint bands they would each look smaller than they are and
+ * could not be read against one another.
+ */
+export type FirstSessionRow = {
+  game_type: string;
+  /** Players whose first-ever session was this game, in the window. */
+  new_players: number;
+  /** True when there are too few first-timers for a rate to mean anything. */
+  below_threshold: boolean;
+  returned_24h: number;
+  returned_48h: number;
+  returned_168h: number;
+  /** Null below the threshold — the count is still given. */
+  returned_24h_pct: number | null;
+  returned_48h_pct: number | null;
+  returned_168h_pct: number | null;
+};
+
+export type FirstSessionResponse = {
+  /** First-timers needed before a rate is stated. */
+  min_players: number;
+  total_new_players: number;
+  rows: FirstSessionRow[];
+} & ResolvedRange;
+
 export type AnomalyFinding = {
   scope: 'platform' | 'game';
   game_type: string | null;


### PR DESCRIPTION
FE half of **R2** (App#1477). Stacked on #118 — the base retargets as the stack merges.

Renders `/core/reporting/first-session/`: of players whose **first ever** session fell in the window, how many came back within 24h / 48h / 7 days, split by the game they started on.

## On the retention page, not a seventh destination

R4 cut the nav from ten to six on the grounds that it was bigger than the platform. Adding one back a day later would need a better reason than "the data is new".

It also genuinely belongs here. **Retention asks whether a game keeps its own players. This asks which game keeps people on the platform at all** — and the two are easy to confuse. A game can hold nobody itself and still be the best front door there is. Reading either alone gets that backwards, so they sit together under a section header saying which is which.

## Three things the panel states rather than assuming

**The windows are cumulative**, said in the column titles. Read as disjoint bands, `40 / 55 / 70` looks like 165 people came back out of 100.

**Below the threshold the rate is withheld and the count is not.** "3 people started here" is a fact worth having; "33% came back" from three people is noise. Withholding both leaves a blank row that reads as *no data at all* — mutation-tested, and hiding the count fails the test.

**Coming back for a different game counts**, in the description, because the alternative reading recommends cutting the game that introduced them.

## Adoption

`MetricRow` gets its first caller here — the summary figures above the table. That was the plan when it shipped unadopted in R9: its other natural caller is `GameLeaderboard`, which an open PR edits, and taking it there would have handed you a conflict for no benefit.

`SmallSampleNotice` and `SectionHeader` are used here too, so three of R9's four primitives now have real callers.

521 tests, lint clean, types OK, build compiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)