### PR TITLE
Show where sessions stop, under the table that says they stopped

### DIFF
--- a/app/reports/games/page.tsx
+++ b/app/reports/games/page.tsx
@@ -10,6 +10,7 @@ import { FilterBar } from '@/components/reports/filters/FilterBar';
 import { RangePicker } from '@/components/reports/filters/RangePicker';
 import { AbandonedPanel } from '@/components/reports/panels/AbandonedPanel';
 import { DurationTable } from '@/components/reports/panels/DurationTable';
+import { ProgressDropOff } from '@/components/reports/panels/ProgressDropOff';
 import { UnfinishedTable } from '@/components/reports/panels/UnfinishedTable';
 import { EmptyState } from '@/components/reports/primitives/EmptyState';
 import { ExportButton } from '@/components/reports/primitives/ExportButton';
@@ -79,6 +80,12 @@ export default function GamesIndexPage() {
   // ranged page because the question ("what is lying around for this game") is a
   // per-game one; the panel says so itself rather than inheriting the filter.
   const unfinishedParams = useMemo(() => ({ include_bots: includeBots }), [includeBots]);
+  const progress = useReport(
+    ReportsAPI.getProgress,
+    params,
+    enabled,
+    'The in-session progress endpoint',
+  );
   const unfinished = useReport(
     () => ReportsAPI.getUnfinished(includeBots),
     unfinishedParams,
@@ -244,6 +251,20 @@ export default function GamesIndexPage() {
           same request, so a reader comparing games had the ranking here and the
           shape of it somewhere else. Its own panel, because the duration request
           can fail or lag independently of the games one. */}
+      {/* Under the games table, not on a page of its own: it answers the next
+          question that table raises. "Abandoned: 5,399" says a session ended
+          incomplete; this says 44% of those got nowhere at all, which is a
+          different problem with a different fix. Its own panel, so one slow
+          request cannot blank the table above. */}
+      <SectionHeader
+        title="Where sessions stop"
+        description="Started versus finished says a session ended incomplete. It cannot say whether the player quit on the first screen or the last."
+      />
+
+      <ReportPanel state={progress} skeletonClassName="h-80 w-full">
+        {data => <ProgressDropOff data={data} meta={meta} />}
+      </ReportPanel>
+
       <SectionHeader
         title="What is lying around"
         description="A snapshot of unfinished sessions, and whether favouriting a game predicts playing it."

--- a/components/reports/__tests__/ProgressDropOff.test.tsx
+++ b/components/reports/__tests__/ProgressDropOff.test.tsx
@@ -1,0 +1,136 @@
+import type { ProgressResponse, ProgressRow } from '@/types/reports';
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ProgressDropOff } from '@/components/reports/panels/ProgressDropOff';
+
+const META = {
+  missing11: { key: 'missing11', label: 'Missing11', display_name: 'Guess The Line Up', color: '#2563eb', color_dark: '#60a5fa' },
+  scout: { key: 'scout', label: 'Scout', display_name: 'Scout', color: '#16a34a', color_dark: '#4ade80' },
+} as never;
+
+function band(key: string, count: number, pct: number) {
+  return { key, from_pct: 0, to_pct: null, count, pct };
+}
+
+function row(over: Partial<ProgressRow> & Pick<ProgressRow, 'game_type'>): ProgressRow {
+  return {
+    supported: true,
+    reason: null,
+    unit: 'lineup slots filled',
+    never_started: 0,
+    sessions: 100,
+    abandoned: 50,
+    finished: 50,
+    abandoned_bands: [
+      band('none', 22, 44),
+      band('under_25', 9, 18),
+      band('under_50', 10, 20),
+      band('under_75', 6, 12),
+      band('under_100', 3, 6),
+      band('complete', 0, 0),
+    ],
+    finished_bands: [band('complete', 50, 100)],
+    abandoned_no_progress_pct: 44,
+    finished_no_progress_pct: 3.6,
+    ...over,
+  };
+}
+
+function response(rows: ProgressRow[]): ProgressResponse {
+  // Cast past the range echo: it is on every response and none of it is read here.
+  return {
+    rows,
+    games_without_progress: rows.filter(r => !r.supported).map(r => r.game_type),
+    total_abandoned: rows.reduce((sum, r) => sum + r.abandoned, 0),
+  } as unknown as ProgressResponse;
+}
+
+describe('progressDropOff', () => {
+  it('shows the abandoned figure beside the finished one', () => {
+    // The comparison IS the finding. 44% of abandoned sessions getting nowhere
+    // reads as an indictment of the game until 3.6% of finished ones show it is
+    // something players do too — so the two are columns of the same row, never
+    // one number with the other a page away.
+    render(<ProgressDropOff data={response([row({ game_type: 'missing11' })])} meta={META} />);
+    const cells = within(screen.getAllByRole('row')[1]).getAllByRole('cell');
+
+    expect(cells[2]).toHaveTextContent('44%');
+    expect(cells[3]).toHaveTextContent('3.6%');
+  });
+
+  it('separates sessions that were never started from ones that stalled', () => {
+    // Grid keeps 959 of the first against 164 of the second. One combined
+    // number would read as the second and send someone to fix the wrong thing.
+    render(
+      <ProgressDropOff
+        data={response([row({ game_type: 'missing11', abandoned: 1123, never_started: 959 })])}
+        meta={META}
+      />,
+    );
+
+    expect(screen.getByText('959 never started')).toBeInTheDocument();
+  });
+
+  it('names every game that reports no progress, with its reason', () => {
+    // Eight missing games on a per-game table reads as a broken request.
+    render(
+      <ProgressDropOff
+        data={response([
+          row({ game_type: 'missing11' }),
+          row({
+            game_type: 'scout',
+            supported: false,
+            unit: null,
+            reason: 'guesses count against the player here — more of them is worse, not further along',
+            abandoned: 0,
+            finished: 0,
+            abandoned_bands: [],
+            finished_bands: [],
+            abandoned_no_progress_pct: null,
+            finished_no_progress_pct: null,
+          }),
+        ])}
+        meta={META}
+      />,
+    );
+
+    expect(screen.getByText('One game reports no progress')).toBeInTheDocument();
+    expect(screen.getByText(/count against the player/)).toBeInTheDocument();
+  });
+
+  it('keeps a game out of the table when it cannot report progress', () => {
+    // Rendered as a row of dashes it would sit in the ranking, and a reader
+    // sorting by drop-off would read "no bar" as "no drop-off".
+    render(
+      <ProgressDropOff
+        data={response([row({
+          game_type: 'scout',
+          supported: false,
+          reason: 'guesses count against the player here',
+          abandoned: 0,
+          abandoned_bands: [],
+          abandoned_no_progress_pct: null,
+        })])}
+        meta={META}
+      />,
+    );
+
+    expect(screen.getByText('No sessions were abandoned in this window.')).toBeInTheDocument();
+  });
+
+  it('links each game to its own report', () => {
+    render(<ProgressDropOff data={response([row({ game_type: 'missing11' })])} meta={META} />);
+
+    expect(screen.getByRole('link', { name: /Guess The Line Up/ }))
+      .toHaveAttribute('href', '/reports/games/missing11');
+  });
+
+  it('says what a step is for this game, since the games disagree', () => {
+    // Missing11 counts lineup slots FILLED CORRECTLY and Grid counts
+    // footballers REACHED — its cursor moves on a wrong guess too. Two bars of
+    // the same length mean different things.
+    render(<ProgressDropOff data={response([row({ game_type: 'missing11' })])} meta={META} />);
+
+    expect(screen.getByText('measured in lineup slots filled')).toBeInTheDocument();
+  });
+});

--- a/components/reports/__tests__/ProgressDropOff.test.tsx
+++ b/components/reports/__tests__/ProgressDropOff.test.tsx
@@ -115,6 +115,20 @@ describe('progressDropOff', () => {
       />,
     );
 
+    // "Nothing measurable" — not "nothing abandoned", which claims a quiet
+    // window when the truth is that no game here can report progress at all
+    // (Copilot on #120).
+    expect(screen.getByText('No game in this window records how far a session got.')).toBeInTheDocument();
+  });
+
+  it('says a quiet window is quiet, not unmeasurable', () => {
+    render(
+      <ProgressDropOff
+        data={response([row({ game_type: 'missing11', abandoned: 0, abandoned_bands: [] })])}
+        meta={META}
+      />,
+    );
+
     expect(screen.getByText('No sessions were abandoned in this window.')).toBeInTheDocument();
   });
 

--- a/components/reports/panels/ProgressDropOff.tsx
+++ b/components/reports/panels/ProgressDropOff.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import type { Band } from '@/components/reports/primitives/Distribution';
+import type { GameMetaMap } from '@/hooks/use-game-meta';
+import type { ProgressBand, ProgressResponse, ProgressRow } from '@/types/reports';
+import { Distribution } from '@/components/reports/primitives/Distribution';
+import { EmptyState } from '@/components/reports/primitives/EmptyState';
+import { GameBadge } from '@/components/reports/primitives/GameBadge';
+import { MetricInfo } from '@/components/reports/primitives/MetricInfo';
+import { ReportHead, ReportRow, ReportTable, Td, Th } from '@/components/reports/primitives/ReportTable';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { useGameColor } from '@/hooks/use-game-meta';
+
+/**
+ * Where inside a session people stop.
+ *
+ * The table above this one says a session ended incomplete. It cannot say
+ * whether the player quit on the first screen or the last, and those are
+ * different problems: one is about getting in, the other about keeping going.
+ */
+
+/** Band labels, in the payload's order. `complete` is unreachable when abandoned. */
+const BAND_LABELS: Record<string, string> = {
+  none: 'Nowhere',
+  under_25: 'Under a quarter',
+  under_50: 'Under half',
+  under_75: 'Under three quarters',
+  under_100: 'Nearly done',
+  complete: 'All the way',
+};
+
+function toBands(bands: ProgressBand[]): Band[] {
+  return bands.map(band => ({
+    label: BAND_LABELS[band.key] ?? band.key,
+    count: band.count,
+    pct: band.pct,
+  }));
+}
+
+function ProgressCell({ row, colour }: { row: ProgressRow; colour: string }) {
+  if (row.abandoned === 0) {
+    return <span className="text-xs text-muted-foreground/70">Nothing abandoned</span>;
+  }
+  return <Distribution bands={toBands(row.abandoned_bands)} colour={colour} />;
+}
+
+export function ProgressDropOff({ data, meta }: { data: ProgressResponse; meta: GameMetaMap }) {
+  const colourFor = useGameColor();
+  const supported = data.rows.filter(row => row.supported);
+  const unsupported = data.rows.filter(row => !row.supported);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          Where sessions stop
+          <MetricInfo metric="progress_reached" />
+        </CardTitle>
+        <CardDescription>
+          Abandoned sessions, by how far they got through their own length. A share
+          rather than a step number, because a 3×3 Grid is 23 footballers and a 6×4
+          is 56 — and the games count different things on the way.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6 overflow-x-auto">
+        {supported.length === 0
+          ? (
+              <EmptyState hint="Try a wider date range.">
+                No sessions were abandoned in this window.
+              </EmptyState>
+            )
+          : (
+              <ReportTable>
+                <ReportHead>
+                  <Th>Game</Th>
+                  <Th align="right">Abandoned</Th>
+                  <Th align="right" title="Of those, the share that made no progress at all">
+                    Got nowhere
+                  </Th>
+                  <Th align="right" title="The same figure for sessions that DID finish — the comparison, not a footnote">
+                    vs finished
+                  </Th>
+                  <Th>How far the abandoned ones got</Th>
+                </ReportHead>
+                <tbody>
+                  {supported.map(row => (
+                    <ReportRow key={row.game_type}>
+                      <Td strong>
+                        <GameBadge gameKey={row.game_type} meta={meta} href={`/reports/games/${row.game_type}`} />
+                        <span className="mt-0.5 block text-xs font-normal text-muted-foreground">
+                          {`measured in ${row.unit}`}
+                        </span>
+                      </Td>
+                      <Td align="right">
+                        {row.abandoned.toLocaleString()}
+                        {row.never_started > 0 && (
+                          // Split out, because "opened and never started" and
+                          // "started and stalled" are different failures. Grid
+                          // keeps 959 of the first against 164 of the second,
+                          // and one number would read as the second.
+                          <span
+                            className="mt-0.5 block text-xs font-normal text-muted-foreground"
+                            title="Opened and never started — a different failure from stalling partway"
+                          >
+                            {`${row.never_started.toLocaleString()} never started`}
+                          </span>
+                        )}
+                      </Td>
+                      <Td align="right" strong>
+                        {row.abandoned_no_progress_pct === null ? '—' : `${row.abandoned_no_progress_pct}%`}
+                      </Td>
+                      {/* Beside it, not below: 44% is an indictment of the game
+                          until you see that 3.6% of finished sessions did the
+                          same, and it becomes something players do. */}
+                      <Td align="right" className="text-muted-foreground">
+                        {row.finished_no_progress_pct === null ? '—' : `${row.finished_no_progress_pct}%`}
+                      </Td>
+                      <Td>
+                        <ProgressCell row={row} colour={colourFor(meta, row.game_type)} />
+                      </Td>
+                    </ReportRow>
+                  ))}
+                </tbody>
+              </ReportTable>
+            )}
+
+        {unsupported.length > 0 && (
+          // Named with their reasons rather than omitted. Eight missing games on
+          // a per-game table reads as a broken request; eight stated reasons
+          // reads as the measurement it is.
+          <div className="space-y-1.5 border-t pt-4">
+            <p className="text-xs font-medium text-muted-foreground">
+              {unsupported.length === 1
+                ? 'One game reports no progress'
+                : `${unsupported.length} games report no progress`}
+            </p>
+            <dl className="space-y-1">
+              {unsupported.map(row => (
+                <div key={row.game_type} className="flex flex-wrap items-baseline gap-x-2 text-xs">
+                  <dt>
+                    <GameBadge gameKey={row.game_type} meta={meta} href={`/reports/games/${row.game_type}`} />
+                  </dt>
+                  <dd className="text-muted-foreground">{row.reason}</dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/reports/panels/ProgressDropOff.tsx
+++ b/components/reports/panels/ProgressDropOff.tsx
@@ -48,6 +48,12 @@ export function ProgressDropOff({ data, meta }: { data: ProgressResponse; meta: 
   const colourFor = useGameColor();
   const supported = data.rows.filter(row => row.supported);
   const unsupported = data.rows.filter(row => !row.supported);
+  // "Nothing abandoned" and "nothing measurable" are different answers, and the
+  // condition used to be `supported.length === 0` while the copy said the first
+  // (Copilot on #120). A window where every supported game happens to have zero
+  // abandoned sessions is genuinely quiet; a window with only unsupported games
+  // is not — it is a window this report cannot describe.
+  const measurable = supported.filter(row => row.abandoned > 0);
 
   return (
     <Card>
@@ -63,10 +69,12 @@ export function ProgressDropOff({ data, meta }: { data: ProgressResponse; meta: 
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-6 overflow-x-auto">
-        {supported.length === 0
+        {measurable.length === 0
           ? (
-              <EmptyState hint="Try a wider date range.">
-                No sessions were abandoned in this window.
+              <EmptyState hint={supported.length === 0 ? undefined : 'Try a wider date range.'}>
+                {supported.length === 0
+                  ? 'No game in this window records how far a session got.'
+                  : 'No sessions were abandoned in this window.'}
               </EmptyState>
             )
           : (
@@ -83,13 +91,18 @@ export function ProgressDropOff({ data, meta }: { data: ProgressResponse; meta: 
                   <Th>How far the abandoned ones got</Th>
                 </ReportHead>
                 <tbody>
-                  {supported.map(row => (
+                  {measurable.map(row => (
                     <ReportRow key={row.game_type}>
                       <Td strong>
                         <GameBadge gameKey={row.game_type} meta={meta} href={`/reports/games/${row.game_type}`} />
-                        <span className="mt-0.5 block text-xs font-normal text-muted-foreground">
-                          {`measured in ${row.unit}`}
-                        </span>
+                        {row.unit && (
+                          // Guarded: `unit` is nullable on the wire, and an
+                          // unsupported row that slipped into this table would
+                          // otherwise print "measured in null" (Copilot on #120).
+                          <span className="mt-0.5 block text-xs font-normal text-muted-foreground">
+                            {`measured in ${row.unit}`}
+                          </span>
+                        )}
                       </Td>
                       <Td align="right">
                         {row.abandoned.toLocaleString()}

--- a/lib/__tests__/response-fields-used.test.ts
+++ b/lib/__tests__/response-fields-used.test.ts
@@ -26,6 +26,8 @@ const ROOT = process.cwd();
 const NOT_RENDERED: Record<string, string> = {
   grain: 'A reminder in the payload that multiplayer counts rooms; the card description says it in prose.',
   games_without_duration: 'Derived per row as `supported`, which DurationTable already groups by.',
+  games_without_progress: 'Derived per row as `supported`, which ProgressDropOff already lists with each reason.',
+  total_abandoned: 'The games table above it carries abandonment per game and in total; a second total on the same page would be the same number twice.',
   long_lived_session_games: 'Derived per row as `single_sitting`, which DurationTable already groups by.',
   window_totals: 'The comparison tiles render the same window from `comparison`, with movement attached.',
   // #1474 R4 removed the Patterns page: play-by-hour and play-by-weekday move

--- a/lib/reports-api.ts
+++ b/lib/reports-api.ts
@@ -8,6 +8,7 @@ import type {
   MultiplayerResponse,
   PatternsResponse,
   PlayerDetailResponse,
+  ProgressResponse,
   ReportParams,
   RetentionResponse,
   RollupHealth,
@@ -108,6 +109,11 @@ export class ReportsAPI {
    */
   static async getFirstSession(params?: ReportParams): Promise<FirstSessionResponse> {
     return apiFetcher<FirstSessionResponse>(`core/reporting/first-session/${buildQuery(params)}`);
+  }
+
+  /** GET /core/reporting/progress/ — how far into a session players got. */
+  static async getProgress(params?: ReportParams): Promise<ProgressResponse> {
+    return apiFetcher<ProgressResponse>(`core/reporting/progress/${buildQuery(params)}`);
   }
 
   /** GET /core/reporting/patterns/ — when people play + new vs returning. */

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -594,3 +594,53 @@ export type AnomaliesResponse = {
   coverage: { complete: boolean; missing_days: string[] };
   findings: AnomalyFinding[];
 } & ResolvedRange;
+
+/** One band of "how far did they get", as a share of the session's own length. */
+export type ProgressBand = {
+  /** `none`, `under_25` … `under_100`, `complete`. */
+  key: string;
+  from_pct: number;
+  /** `null` on `complete`, which has no ceiling above it. */
+  to_pct: number | null;
+  count: number;
+  pct: number;
+};
+
+/**
+ * How far into a session players got, for one game.
+ *
+ * Both shapes are present because either alone reads wrong: 44% of abandoned
+ * Missing11 sessions made zero progress, which is an indictment of the game
+ * until `finished_no_progress_pct` shows 3.6% of finished ones did the same.
+ *
+ * `supported: false` carries a `reason` and empty bands. Eight of the eleven
+ * games are in that state, each for a different cause — a length that changes
+ * with the mode, a length the map decides, or a game where guesses count
+ * against the player — so the reason is printed rather than summarised.
+ */
+export type ProgressRow = {
+  game_type: string;
+  supported: boolean;
+  reason: string | null;
+  /** What is counted, plural and qualified: 'lineup slots filled'. Printed verbatim. */
+  unit: string | null;
+  /**
+   * Opened and never started. Counted rather than filtered out: the games
+   * disagree on when the flag is set, and excluding these would report Grid's
+   * drop-off at a seventh of its real size.
+   */
+  never_started: number;
+  sessions: number;
+  abandoned: number;
+  finished: number;
+  abandoned_bands: ProgressBand[];
+  finished_bands: ProgressBand[];
+  abandoned_no_progress_pct: number | null;
+  finished_no_progress_pct: number | null;
+};
+
+export type ProgressResponse = {
+  rows: ProgressRow[];
+  games_without_progress: string[];
+  total_abandoned: number;
+} & ResolvedRange;


### PR DESCRIPTION
FE half of **R3** (backend: FootballExtraTime/App#1478). Stacked on #119 — the base retargets as the stack merges.

Renders `/core/reporting/progress/` under the games table, because it answers the next question that table raises. "Abandoned: 5,399" says a session ended incomplete; this says **44% of those got nowhere at all** — a different problem with a different fix.

## Four things the panel refuses to simplify

Each one mutation-tested by removing it and watching a test fail.

**The finished column sits beside the abandoned one.** 44% getting nowhere is an indictment of the game until 3.6% of *finished* sessions show it's something players do too. A page apart, only the first number gets read.

**Never-started is split out** of the abandoned count. Grid keeps 959 of those against 164 that started and stalled — one combined number reads as the second and sends someone to fix the wrong thing.

**Games that can't report progress are named with their reasons**, below the table rather than inside it. Eight missing games reads as a broken request; eight rows of dashes sit in the ranking, where "no bar" reads as "no drop-off".

**The unit is printed per row.** Missing11 counts lineup slots filled correctly, Grid counts footballers reached — and its cursor moves on a wrong guess too. Two bars of the same length mean different things.

## Adoption

Uses R9's `Distribution` for the bands. Third caller, first one that didn't have to hand-roll it.

## What the guards caught

Three existing guards fired on the way in and all three were right: the range echo missing from the response type, two payload fields rendered nowhere (both now carry a documented reason), and import order. Building the panel also found a backend bug — the unit was declared singular, so `measured in ${unit}s` rendered "lineup slot filleds". Fixed at the source on #1478 rather than patched here, since the client can't know which phrases pluralise.

527 tests, lint clean, types OK, build compiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)