### PR TITLE
Put the timer in a column, not a footnote

### DIFF
--- a/app/reports/games/page.tsx
+++ b/app/reports/games/page.tsx
@@ -9,6 +9,8 @@ import { FavouredVsPlayedChart } from '@/components/reports/favourites/FavouredV
 import { FilterBar } from '@/components/reports/filters/FilterBar';
 import { RangePicker } from '@/components/reports/filters/RangePicker';
 import { AbandonedPanel } from '@/components/reports/panels/AbandonedPanel';
+import { AttemptSpread } from '@/components/reports/panels/AttemptSpread';
+import { DifficultyOutcomes } from '@/components/reports/panels/DifficultyOutcomes';
 import { DurationTable } from '@/components/reports/panels/DurationTable';
 import { ProgressDropOff } from '@/components/reports/panels/ProgressDropOff';
 import { UnfinishedTable } from '@/components/reports/panels/UnfinishedTable';
@@ -80,6 +82,18 @@ export default function GamesIndexPage() {
   // ranged page because the question ("what is lying around for this game") is a
   // per-game one; the panel says so itself rather than inheriting the filter.
   const unfinishedParams = useMemo(() => ({ include_bots: includeBots }), [includeBots]);
+  const difficulty = useReport(
+    ReportsAPI.getDifficulty,
+    params,
+    enabled,
+    'The difficulty reporting endpoint',
+  );
+  const attempts = useReport(
+    ReportsAPI.getAttempts,
+    params,
+    enabled,
+    'The wrong-attempts reporting endpoint',
+  );
   const progress = useReport(
     ReportsAPI.getProgress,
     params,
@@ -251,6 +265,23 @@ export default function GamesIndexPage() {
           same request, so a reader comparing games had the ranking here and the
           shape of it somewhere else. Its own panel, because the duration request
           can fail or lag independently of the games one. */}
+      {/* Before the drop-off panel, because "is this game hard" comes before
+          "where do people give up on it" — and because one of the numbers the
+          table above carries is wrong until this panel corrects it. Conquest
+          reads 99% complete there and 44% here; the difference is a timer. */}
+      <SectionHeader
+        title="How hard each game is"
+        description="Completion has been standing in for difficulty, and on two games it does not hold."
+      />
+
+      <ReportPanel state={difficulty} skeletonClassName="h-96 w-full">
+        {data => <DifficultyOutcomes data={data} meta={meta} />}
+      </ReportPanel>
+
+      <ReportPanel state={attempts} skeletonClassName="h-56 w-full">
+        {data => <AttemptSpread data={data} meta={meta} />}
+      </ReportPanel>
+
       {/* Under the games table, not on a page of its own: it answers the next
           question that table raises. "Abandoned: 5,399" says a session ended
           incomplete; this says 44% of those got nowhere at all, which is a

--- a/components/reports/__tests__/DifficultyOutcomes.test.tsx
+++ b/components/reports/__tests__/DifficultyOutcomes.test.tsx
@@ -1,0 +1,241 @@
+import type { AttemptRow, AttemptsResponse, DifficultyBucket, DifficultyResponse, DifficultyRow } from '@/types/reports';
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { AttemptSpread } from '@/components/reports/panels/AttemptSpread';
+import { DifficultyOutcomes } from '@/components/reports/panels/DifficultyOutcomes';
+
+const META = {
+  conquest: { key: 'conquest', label: 'Conquest', display_name: 'Football Conquest', color: '#7c3aed', color_dark: '#a78bfa' },
+  grid: { key: 'grid', label: 'Grid', display_name: 'Grid', color: '#f97316', color_dark: '#fdba74' },
+  missing_team: { key: 'missing_team', label: 'Missing Team', display_name: 'Missing Team', color: '#0891b2', color_dark: '#22d3ee' },
+  missing11: { key: 'missing11', label: 'Missing11', display_name: 'Guess The Line Up', color: '#2563eb', color_dark: '#60a5fa' },
+} as never;
+
+function bucket(over: Partial<DifficultyBucket> & Pick<DifficultyBucket, 'value'>): DifficultyBucket {
+  return {
+    off_scale: false,
+    below_threshold: false,
+    sessions: 100,
+    finished: 80,
+    swept: 0,
+    completion_pct: 80,
+    wins: null,
+    decided: null,
+    win_rate_pct: null,
+    ...over,
+  };
+}
+
+function row(over: Partial<DifficultyRow> & Pick<DifficultyRow, 'game_type'>): DifficultyRow {
+  return {
+    sessions: 1000,
+    finished: 800,
+    swept: 0,
+    sweeper_hours: null,
+    completion_pct: 80,
+    has_verdict: false,
+    decided: null,
+    verdict_coverage_pct: null,
+    win_rate_pct: null,
+    difficulty_label: null,
+    difficulty: [],
+    ...over,
+  };
+}
+
+function response(rows: DifficultyRow[], minSessions = 30): DifficultyResponse {
+  return {
+    rows,
+    games_with_difficulty: rows.filter(r => r.difficulty_label).map(r => r.game_type),
+    min_sessions: minSessions,
+  } as unknown as DifficultyResponse;
+}
+
+describe('difficultyOutcomes', () => {
+  it('shows what the timer closed beside what the players finished', () => {
+    // The correction is the point. Conquest reads 99% complete with swept
+    // sessions in and 44% with them out — putting the swept count in a footnote
+    // leaves the corrected figure looking like an unexplained drop.
+    render(
+      <DifficultyOutcomes
+        data={response([row({
+          game_type: 'conquest',
+          sessions: 2347,
+          completion_pct: 44.4,
+          swept: 1283,
+          sweeper_hours: 24,
+          has_verdict: true,
+          win_rate_pct: 19.6,
+          verdict_coverage_pct: 44.4,
+        })])}
+        meta={META}
+      />,
+    );
+    const cells = within(screen.getAllByRole('row')[1]).getAllByRole('cell');
+
+    expect(cells[2]).toHaveTextContent('44.4%');
+    expect(cells[3]).toHaveTextContent('1,283');
+    expect(cells[3]).toHaveTextContent('after 24h idle');
+  });
+
+  it('says a game has no verdict rather than reporting it as 0% won', () => {
+    // 0% would rank a game with no result column as the hardest on the
+    // platform, when the reason it has none is that it records no win.
+    render(<DifficultyOutcomes data={response([row({ game_type: 'grid' })])} meta={META} />);
+
+    expect(screen.getByText('no verdict')).toBeInTheDocument();
+    expect(screen.queryByText('0%')).not.toBeInTheDocument();
+  });
+
+  it('states how much of the data a win rate is drawn from', () => {
+    // Four games write `result` for multiplayer rounds only. 3.6% coverage
+    // printed beside 100% coverage invites a comparison that is not one.
+    render(
+      <DifficultyOutcomes
+        data={response([row({
+          game_type: 'missing_team',
+          has_verdict: true,
+          win_rate_pct: 35.9,
+          verdict_coverage_pct: 3.6,
+        })])}
+        meta={META}
+      />,
+    );
+
+    expect(screen.getByText('from 3.6% of sessions')).toBeInTheDocument();
+  });
+
+  it('withholds a bucket rate below the threshold but keeps its count', () => {
+    // 11 EXTREME sessions: one moves completion nine points. "Nobody plays
+    // EXTREME" is itself the answer to whether its difficulty needs tuning.
+    render(
+      <DifficultyOutcomes
+        data={response([row({
+          game_type: 'missing_team',
+          difficulty_label: 'Difficulty',
+          difficulty: [bucket({ value: 'EXTREME', sessions: 11, below_threshold: true, completion_pct: null })],
+        })])}
+        meta={META}
+      />,
+    );
+
+    expect(screen.getByText('— 11 sessions, needs 30')).toBeInTheDocument();
+  });
+
+  it('keeps unrecorded difficulty as a row rather than dropping it', () => {
+    // On Missing Team it is the biggest bucket there is. Dropped, the tiers
+    // would look like the whole game.
+    render(
+      <DifficultyOutcomes
+        data={response([row({
+          game_type: 'missing_team',
+          difficulty_label: 'Difficulty',
+          difficulty: [bucket({ value: null, sessions: 905 }), bucket({ value: 'EASY', sessions: 476 })],
+        })])}
+        meta={META}
+      />,
+    );
+
+    expect(screen.getByText('Not recorded')).toBeInTheDocument();
+    expect(screen.getByText('905')).toBeInTheDocument();
+  });
+
+  it('flags a value the declared scale does not know about', () => {
+    render(
+      <DifficultyOutcomes
+        data={response([row({
+          game_type: 'missing_team',
+          difficulty_label: 'Difficulty',
+          difficulty: [bucket({ value: 'NIGHTMARE', off_scale: true })],
+        })])}
+        meta={META}
+      />,
+    );
+
+    expect(screen.getByText('off scale')).toBeInTheDocument();
+  });
+
+  it('names the axis the game actually records', () => {
+    // Grid HAS a column called difficulty and it is null on every session. The
+    // header says "Grid size" because that is what is on the axis.
+    render(
+      <DifficultyOutcomes
+        data={response([row({
+          game_type: 'grid',
+          difficulty_label: 'Grid size',
+          difficulty: [bucket({ value: '3x3' })],
+        })])}
+        meta={META}
+      />,
+    );
+
+    expect(screen.getByRole('columnheader', { name: 'Grid size' })).toBeInTheDocument();
+    expect(screen.getByText('by grid size')).toBeInTheDocument();
+  });
+});
+
+function attemptRow(over: Partial<AttemptRow> & Pick<AttemptRow, 'game_type'>): AttemptRow {
+  return {
+    sessions: 1000,
+    allowance_scope: 'session',
+    allowances: [5],
+    over_allowance: 127,
+    over_allowance_pct: 12.7,
+    bands: [
+      { from_attempts: 0, to_attempts: 0, count: 276, pct: 27.6 },
+      { from_attempts: 1, to_attempts: 2, count: 201, pct: 20.1 },
+      { from_attempts: 3, to_attempts: 5, count: 396, pct: 39.6 },
+      { from_attempts: 6, to_attempts: 10, count: 127, pct: 12.7 },
+      { from_attempts: 11, to_attempts: null, count: 0, pct: 0 },
+    ],
+    ...over,
+  };
+}
+
+describe('attemptSpread', () => {
+  it('reports overruns where the allowance is per session', () => {
+    render(
+      <AttemptSpread
+        data={{ rows: [attemptRow({ game_type: 'tenable' })] } as unknown as AttemptsResponse}
+        meta={META}
+      />,
+    );
+
+    expect(screen.getByText('12.7%')).toBeInTheDocument();
+    expect(screen.getByText('per session')).toBeInTheDocument();
+  });
+
+  it('refuses to compare a per-step allowance with a session total', () => {
+    // Missing11 allows 7 per lineup SLOT. A session's 38 guesses read against 7
+    // would report every player as having overrun fourfold.
+    render(
+      <AttemptSpread
+        data={{
+          rows: [attemptRow({
+            game_type: 'missing11',
+            allowance_scope: 'step',
+            allowances: [7],
+            over_allowance: null,
+            over_allowance_pct: null,
+          })],
+        } as unknown as AttemptsResponse}
+        meta={META}
+      />,
+    );
+
+    expect(screen.getByText('n/a')).toBeInTheDocument();
+    expect(screen.getByText('per step')).toBeInTheDocument();
+  });
+
+  it('labels the open-ended top band as open-ended', () => {
+    // "11–null" or a silent ceiling both read as a bound the data does not have.
+    render(
+      <AttemptSpread
+        data={{ rows: [attemptRow({ game_type: 'tenable' })] } as unknown as AttemptsResponse}
+        meta={META}
+      />,
+    );
+
+    expect(screen.getByText(/11\+/)).toBeInTheDocument();
+  });
+});

--- a/components/reports/panels/AttemptSpread.tsx
+++ b/components/reports/panels/AttemptSpread.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import type { Band } from '@/components/reports/primitives/Distribution';
+import type { GameMetaMap } from '@/hooks/use-game-meta';
+import type { AttemptBand, AttemptsResponse } from '@/types/reports';
+import { Distribution } from '@/components/reports/primitives/Distribution';
+import { EmptyState } from '@/components/reports/primitives/EmptyState';
+import { GameBadge } from '@/components/reports/primitives/GameBadge';
+import { MetricInfo } from '@/components/reports/primitives/MetricInfo';
+import { ReportHead, ReportRow, ReportTable, Td, Th } from '@/components/reports/primitives/ReportTable';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { useGameColor } from '@/hooks/use-game-meta';
+
+/**
+ * How often players got it wrong, against what the game says they may.
+ *
+ * Two games declare an allowance and nine do not, which is why this is a panel
+ * of two rows rather than a column on the difficulty table with nine nulls in it.
+ */
+
+function bandLabel(band: AttemptBand): string {
+  if (band.to_attempts === null) {
+    return `${band.from_attempts}+`;
+  }
+  if (band.from_attempts === band.to_attempts) {
+    return String(band.from_attempts);
+  }
+  return `${band.from_attempts}–${band.to_attempts}`;
+}
+
+function toBands(bands: AttemptBand[]): Band[] {
+  return bands.map(band => ({ label: bandLabel(band), count: band.count, pct: band.pct }));
+}
+
+export function AttemptSpread({ data, meta }: { data: AttemptsResponse; meta: GameMetaMap }) {
+  const colourFor = useGameColor();
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          How often players get it wrong
+          <MetricInfo metric="wrong_attempts" />
+        </CardTitle>
+        <CardDescription>
+          Wrong attempts per session, for the games that declare an allowance. The
+          allowance is what the game says, not what it enforces — on this data
+          those differ.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="overflow-x-auto">
+        {data.rows.length === 0
+          ? (
+              <EmptyState hint="Try a wider date range.">
+                No sessions with a declared allowance in this window.
+              </EmptyState>
+            )
+          : (
+              <ReportTable>
+                <ReportHead>
+                  <Th>Game</Th>
+                  <Th align="right">Sessions</Th>
+                  <Th align="right">Allowed</Th>
+                  <Th align="right" title="Sessions recording more wrong attempts than the game allows">Over it</Th>
+                  <Th>Wrong attempts per session</Th>
+                </ReportHead>
+                <tbody>
+                  {data.rows.map(row => (
+                    <ReportRow key={row.game_type}>
+                      <Td strong>
+                        <GameBadge gameKey={row.game_type} meta={meta} href={`/reports/games/${row.game_type}`} />
+                      </Td>
+                      <Td align="right">{row.sessions.toLocaleString()}</Td>
+                      <Td align="right">
+                        {row.allowances.join(', ') || '—'}
+                        <span className="mt-0.5 block text-xs font-normal text-muted-foreground">
+                          {row.allowance_scope === 'step' ? 'per step' : 'per session'}
+                        </span>
+                      </Td>
+                      <Td align="right">
+                        {/* A per-step allowance has nothing to compare a session
+                            total with. Missing11 allows 7 per lineup slot, so
+                            "38 against 7" would report every player as having
+                            overrun fourfold. */}
+                        {row.over_allowance_pct === null
+                          ? (
+                              <span
+                                className="text-muted-foreground/70"
+                                title="The allowance is per step here, so a session total is not the thing to measure against it"
+                              >
+                                n/a
+                              </span>
+                            )
+                          : (
+                              <>
+                                {`${row.over_allowance_pct}%`}
+                                <span className="mt-0.5 block text-xs font-normal text-muted-foreground">
+                                  {`${(row.over_allowance ?? 0).toLocaleString()} sessions`}
+                                </span>
+                              </>
+                            )}
+                      </Td>
+                      <Td>
+                        <Distribution bands={toBands(row.bands)} colour={colourFor(meta, row.game_type)} />
+                      </Td>
+                    </ReportRow>
+                  ))}
+                </tbody>
+              </ReportTable>
+            )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/reports/panels/AttemptSpread.tsx
+++ b/components/reports/panels/AttemptSpread.tsx
@@ -94,8 +94,15 @@ export function AttemptSpread({ data, meta }: { data: AttemptsResponse; meta: Ga
                           : (
                               <>
                                 {`${row.over_allowance_pct}%`}
+                                {/* A missing count is shown as missing, not as
+                                    zero: coercing it renders "0 sessions"
+                                    beside a non-zero percentage, which reads as
+                                    data rather than as the payload
+                                    inconsistency it is (Copilot on #121). */}
                                 <span className="mt-0.5 block text-xs font-normal text-muted-foreground">
-                                  {`${(row.over_allowance ?? 0).toLocaleString()} sessions`}
+                                  {row.over_allowance === null
+                                    ? '— sessions'
+                                    : `${row.over_allowance.toLocaleString()} sessions`}
                                 </span>
                               </>
                             )}

--- a/components/reports/panels/DifficultyOutcomes.tsx
+++ b/components/reports/panels/DifficultyOutcomes.tsx
@@ -117,11 +117,16 @@ export function DifficultyOutcomes({ data, meta }: { data: DifficultyResponse; m
               </ReportTable>
             )}
 
-        {rows.filter(row => row.difficulty.length > 0).map(row => (
+        {/* A non-null LABEL is required, not just rows: the section header and the
+            column heading both print it, and `by ${undefined?.toLowerCase()}`
+            rendered literally as "by undefined" with a blank header beside it
+            (Copilot on #121). A game with buckets and no label is a payload
+            fault, and showing nothing beats showing that. */}
+        {rows.filter(row => row.difficulty.length > 0 && row.difficulty_label).map(row => (
           <div key={row.game_type} className="space-y-2 border-t pt-4">
             <p className="flex items-center gap-2 text-sm font-medium">
               <GameBadge gameKey={row.game_type} meta={meta} href={`/reports/games/${row.game_type}`} />
-              <span className="text-muted-foreground">{`by ${row.difficulty_label?.toLowerCase()}`}</span>
+              <span className="text-muted-foreground">{`by ${row.difficulty_label!.toLowerCase()}`}</span>
             </p>
             <ReportTable>
               <ReportHead>

--- a/components/reports/panels/DifficultyOutcomes.tsx
+++ b/components/reports/panels/DifficultyOutcomes.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import type { GameMetaMap } from '@/hooks/use-game-meta';
+import type { DifficultyResponse, DifficultyRow } from '@/types/reports';
+import { EmptyState } from '@/components/reports/primitives/EmptyState';
+import { GameBadge } from '@/components/reports/primitives/GameBadge';
+import { MetricInfo } from '@/components/reports/primitives/MetricInfo';
+import { ReportHead, ReportRow, ReportTable, Td, Th } from '@/components/reports/primitives/ReportTable';
+import { SmallSampleNotice } from '@/components/reports/primitives/SmallSampleNotice';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+/**
+ * How hard each game is, on the axis it actually records.
+ *
+ * The platform has been reading completion as difficulty. Conquest reads 99%
+ * complete, of which three fifths is a 24-hour timer writing LOSS on sessions
+ * the player walked away from — so this panel puts the correction in a column
+ * rather than in a footnote, and says how much of the data each win rate is
+ * drawn from.
+ */
+
+/** Under this, a win rate describes multiplayer rather than the game. */
+const THIN_COVERAGE_PCT = 25;
+
+function Rate({ value, suffix = '%' }: { value: number | null; suffix?: string }) {
+  if (value === null) {
+    return <span className="text-muted-foreground/70">—</span>;
+  }
+  return <>{`${value}${suffix}`}</>;
+}
+
+function WinRate({ row }: { row: DifficultyRow }) {
+  if (!row.has_verdict) {
+    // Not 0%. A game with no result column would rank as the hardest on the
+    // platform, and the reason it has none is that it has no win to record.
+    return (
+      <span className="text-muted-foreground/70" title="This game records no win or loss — only whether a session ended">
+        no verdict
+      </span>
+    );
+  }
+
+  const thin = row.verdict_coverage_pct !== null && row.verdict_coverage_pct < THIN_COVERAGE_PCT;
+  return (
+    <>
+      <Rate value={row.win_rate_pct} />
+      {row.verdict_coverage_pct !== null && (
+        <span
+          className={thin ? 'mt-0.5 block text-xs font-normal text-amber-600 dark:text-amber-500' : 'mt-0.5 block text-xs font-normal text-muted-foreground'}
+          title={
+            thin
+              ? 'This game writes its result for multiplayer rounds only, so the rate describes multiplayer rather than the game'
+              : 'The share of sessions this rate is computed from'
+          }
+        >
+          {`from ${row.verdict_coverage_pct}% of sessions`}
+        </span>
+      )}
+    </>
+  );
+}
+
+export function DifficultyOutcomes({ data, meta }: { data: DifficultyResponse; meta: GameMetaMap }) {
+  const rows = data.rows.filter(row => row.sessions > 0);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          How hard each game is
+          <MetricInfo metric="win_rate" />
+        </CardTitle>
+        <CardDescription>
+          Completion is not difficulty. Sessions a sweeper closed are excluded from
+          both rates and counted separately — a timer ending a session is not a
+          player finishing one.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6 overflow-x-auto">
+        {rows.length === 0
+          ? (
+              <EmptyState hint="Try a wider date range.">
+                Nothing was played in this window.
+              </EmptyState>
+            )
+          : (
+              <ReportTable>
+                <ReportHead>
+                  <Th>Game</Th>
+                  <Th align="right">Sessions</Th>
+                  <Th align="right" title="Sessions the player finished — swept ones excluded">Completed</Th>
+                  <Th align="right" title="Closed by the game's idle timer, not by the player">Closed by timer</Th>
+                  <Th align="right" title="Of sessions that reached a verdict a player produced">Won</Th>
+                </ReportHead>
+                <tbody>
+                  {rows.map(row => (
+                    <ReportRow key={row.game_type}>
+                      <Td strong>
+                        <GameBadge gameKey={row.game_type} meta={meta} href={`/reports/games/${row.game_type}`} />
+                      </Td>
+                      <Td align="right">{row.sessions.toLocaleString()}</Td>
+                      <Td align="right" strong><Rate value={row.completion_pct} /></Td>
+                      <Td align="right" className="text-muted-foreground">
+                        {row.sweeper_hours === null
+                          ? <span className="text-muted-foreground/70" title="This game has no sweeper">—</span>
+                          : (
+                              <>
+                                {row.swept.toLocaleString()}
+                                <span className="mt-0.5 block text-xs">{`after ${row.sweeper_hours}h idle`}</span>
+                              </>
+                            )}
+                      </Td>
+                      <Td align="right"><WinRate row={row} /></Td>
+                    </ReportRow>
+                  ))}
+                </tbody>
+              </ReportTable>
+            )}
+
+        {rows.filter(row => row.difficulty.length > 0).map(row => (
+          <div key={row.game_type} className="space-y-2 border-t pt-4">
+            <p className="flex items-center gap-2 text-sm font-medium">
+              <GameBadge gameKey={row.game_type} meta={meta} href={`/reports/games/${row.game_type}`} />
+              <span className="text-muted-foreground">{`by ${row.difficulty_label?.toLowerCase()}`}</span>
+            </p>
+            <ReportTable>
+              <ReportHead>
+                <Th>{row.difficulty_label}</Th>
+                <Th align="right">Sessions</Th>
+                <Th align="right">Completed</Th>
+                {row.has_verdict && <Th align="right">Won</Th>}
+              </ReportHead>
+              <tbody>
+                {row.difficulty.map(bucket => (
+                  <ReportRow key={String(bucket.value)}>
+                    <Td strong>
+                      {/* Not recorded is a value, not a gap: on Missing Team it
+                          is the biggest bucket there is, and dropping it would
+                          make the tiers look like the whole game. */}
+                      {bucket.value ?? <span className="text-muted-foreground">Not recorded</span>}
+                      {bucket.off_scale && (
+                        <span
+                          className="ml-1.5 text-xs font-normal text-amber-600 dark:text-amber-500"
+                          title="Not in the scale this game declares — a new difficulty nobody wired up, or a typo"
+                        >
+                          off scale
+                        </span>
+                      )}
+                    </Td>
+                    <Td align="right">{bucket.sessions.toLocaleString()}</Td>
+                    <Td align="right">
+                      {bucket.below_threshold
+                        ? <SmallSampleNotice have={bucket.sessions} need={data.min_sessions} unit="sessions" />
+                        : <Rate value={bucket.completion_pct} />}
+                    </Td>
+                    {row.has_verdict && (
+                      <Td align="right"><Rate value={bucket.win_rate_pct} /></Td>
+                    )}
+                  </ReportRow>
+                ))}
+              </tbody>
+            </ReportTable>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/lib/__tests__/response-fields-used.test.ts
+++ b/lib/__tests__/response-fields-used.test.ts
@@ -26,6 +26,7 @@ const ROOT = process.cwd();
 const NOT_RENDERED: Record<string, string> = {
   grain: 'A reminder in the payload that multiplayer counts rooms; the card description says it in prose.',
   games_without_duration: 'Derived per row as `supported`, which DurationTable already groups by.',
+  games_with_difficulty: 'Derived per row as `difficulty_label`, which DifficultyOutcomes already keys its per-game breakdowns off.',
   games_without_progress: 'Derived per row as `supported`, which ProgressDropOff already lists with each reason.',
   total_abandoned: 'The games table above it carries abandonment per game and in total; a second total on the same page would be the same number twice.',
   long_lived_session_games: 'Derived per row as `single_sitting`, which DurationTable already groups by.',

--- a/lib/reports-api.ts
+++ b/lib/reports-api.ts
@@ -1,6 +1,8 @@
 import type {
   ActivityResponse,
   AnomaliesResponse,
+  AttemptsResponse,
+  DifficultyResponse,
   DurationResponse,
   FirstSessionResponse,
   GamesResponse,
@@ -109,6 +111,16 @@ export class ReportsAPI {
    */
   static async getFirstSession(params?: ReportParams): Promise<FirstSessionResponse> {
     return apiFetcher<FirstSessionResponse>(`core/reporting/first-session/${buildQuery(params)}`);
+  }
+
+  /** GET /core/reporting/difficulty/ — completion and win rate by difficulty. */
+  static async getDifficulty(params?: ReportParams): Promise<DifficultyResponse> {
+    return apiFetcher<DifficultyResponse>(`core/reporting/difficulty/${buildQuery(params)}`);
+  }
+
+  /** GET /core/reporting/attempts/ — wrong attempts per session, banded. */
+  static async getAttempts(params?: ReportParams): Promise<AttemptsResponse> {
+    return apiFetcher<AttemptsResponse>(`core/reporting/attempts/${buildQuery(params)}`);
   }
 
   /** GET /core/reporting/progress/ — how far into a session players got. */

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -644,3 +644,87 @@ export type ProgressResponse = {
   games_without_progress: string[];
   total_abandoned: number;
 } & ResolvedRange;
+
+/** One value of a game's difficulty axis, with its outcomes. */
+export type DifficultyBucket = {
+  value: string | null;
+  /**
+   * The value is not in the scale this game declared — a new difficulty nobody
+   * wired up, or a typo. Flagged rather than dropped, since both are worth seeing.
+   */
+  off_scale: boolean;
+  /** Too few sessions to state a rate. The count is still shown. */
+  below_threshold: boolean;
+  sessions: number;
+  finished: number;
+  swept: number;
+  completion_pct: number | null;
+  wins: number | null;
+  decided: number | null;
+  win_rate_pct: number | null;
+};
+
+/**
+ * How hard one game is, on the axis it actually records.
+ *
+ * `swept` is the correction that makes the rest readable: Conquest writes LOSS
+ * on anything idle for 24 hours, and 1,283 of its 2,122 losses still had lives
+ * in hand. Both rates here exclude them, and the count is present so the
+ * correction can be seen rather than taken on trust.
+ */
+export type DifficultyRow = {
+  game_type: string;
+  sessions: number;
+  finished: number;
+  swept: number;
+  /** Hours of idleness after which this game's sweeper closes a session. */
+  sweeper_hours: number | null;
+  completion_pct: number | null;
+  /** Whether this game records WIN/LOSS at all. Without it there is no win rate. */
+  has_verdict: boolean;
+  decided: number | null;
+  /**
+   * The share of sessions the win rate is computed from. Under 12% on four
+   * games, where `result` is written for multiplayer rounds only.
+   */
+  verdict_coverage_pct: number | null;
+  win_rate_pct: number | null;
+  /** What the axis IS — 'Grid size' where that differs from 'Difficulty'. */
+  difficulty_label: string | null;
+  difficulty: DifficultyBucket[];
+};
+
+export type DifficultyResponse = {
+  rows: DifficultyRow[];
+  games_with_difficulty: string[];
+  min_sessions: number;
+} & ResolvedRange;
+
+/** One band of wrong attempts per session. `to_attempts` is null on the last. */
+export type AttemptBand = {
+  from_attempts: number;
+  to_attempts: number | null;
+  count: number;
+  pct: number;
+};
+
+export type AttemptRow = {
+  game_type: string;
+  sessions: number;
+  /** 'session' or 'step' — what the allowance is per. */
+  allowance_scope: string;
+  /** Every distinct declared allowance seen in the window. */
+  allowances: number[];
+  /**
+   * Sessions recording more wrong attempts than declared — only meaningful
+   * where the allowance is per session. `null` on a per-step allowance, which
+   * a session total cannot be compared with.
+   */
+  over_allowance: number | null;
+  over_allowance_pct: number | null;
+  bands: AttemptBand[];
+};
+
+export type AttemptsResponse = {
+  rows: AttemptRow[];
+} & ResolvedRange;


### PR DESCRIPTION
FE half of **R5** (backend: FootballExtraTime/App#1479). Stacked on #120 — the base retargets as the stack merges.

Two panels under the games table, **before** the drop-off panel: "is this game hard" comes before "where do people give up on it" — and because one of the numbers the table above carries is wrong until this corrects it. Conquest reads 99% complete there and **44%** here; the difference is a 24-hour timer writing `LOSS` on sessions the player walked away from.

## Six things the panels state rather than assume

All six mutation-tested by removing them and watching a test fail.

**The swept count sits beside the corrected rate**, with the timeout that produced it. In a footnote, the corrected figure looks like an unexplained drop rather than the correction it is.

**A game without a verdict says so** instead of reporting 0% won. Zero would rank Grid as the hardest game on the platform, when the reason it has no win rate is that it records no win.

**Every win rate carries its coverage**, in amber under 25%. Four games write `result` for multiplayer rounds only — 3.6% printed beside 100% invites a comparison that isn't one.

**"Not recorded" is a row, not a gap.** On Missing Team it's the biggest bucket there is; dropped, the tiers would look like the whole game.

**Thin buckets withhold the rate and keep the count** — "nobody plays EXTREME" is itself the answer to whether its difficulty needs tuning.

**A per-step allowance is not compared with a session total.** Missing11 allows 7 per lineup *slot*; a session's 38 guesses against 7 would report every player as having overrun fourfold. It reads `n/a` with the reason on hover.

## Naming

The axis is labelled as the game records it, so Grid's header reads **"Grid size"** — its `difficulty` column exists and is null on all 6,790 sessions.

Third and fourth callers for R9's `Distribution` and `SmallSampleNotice`; neither panel hand-rolls one.

537 tests, lint clean, types OK, build compiling. The `response-fields-used` guard fired again on a payload field with no renderer — documented with its reason rather than rendered, since the panel derives the same list per row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)