### PR TITLE
Put churn below the line

### DIFF
--- a/app/reports/page.tsx
+++ b/app/reports/page.tsx
@@ -3,6 +3,7 @@
 import type { GameTotals, Granularity } from '@/types/reports';
 import { useMemo, useState } from 'react';
 import { ActivityChart } from '@/components/reports/charts/ActivityChart';
+import { GrowthFlow } from '@/components/reports/charts/GrowthFlow';
 import { NewVsReturning } from '@/components/reports/charts/NewVsReturning';
 import { FilterBar } from '@/components/reports/filters/FilterBar';
 import { MetricToggle } from '@/components/reports/filters/MetricToggle';
@@ -68,6 +69,10 @@ export default function ReportsPage() {
   // still saying otherwise. Everything else on the page follows the selection;
   // this is the one panel whose meaning changes if it does.
   const patterns = useReport(ReportsAPI.getPatterns, allGamesParams, enabled, 'The patterns reporting endpoint');
+  // Growth DOES follow the selection: its bands are per-player and a per-game
+  // reading of them is a real question ("who did this game gain and lose"),
+  // which is not true of the panel above.
+  const growth = useReport(ReportsAPI.getGrowth, params, enabled, 'The growth reporting endpoint');
   // Unfiltered on purpose: "what needs attention" must surface a game you
   // haven't selected, which is exactly the one you'd otherwise miss.
 
@@ -147,6 +152,16 @@ export default function ReportsPage() {
             description={`${data.totals.games_started.toLocaleString()} played, ${data.totals.games_finished.toLocaleString()} finished, ${data.totals.distinct_players.toLocaleString()} distinct players.`}
           />
         )}
+      </ReportPanel>
+
+      {/* Above new-vs-returning, which answers a narrower version of the same
+          question: that chart splits a DAY into two bands by registration date,
+          this splits a WEEK into four by what the player actually did. Where
+          they disagree, this one is the one to trust — "new" there means the
+          account was made that day, which counts a three-month absence as
+          growth. */}
+      <ReportPanel state={growth} skeletonClassName="h-96 w-full">
+        {data => <GrowthFlow data={data} />}
       </ReportPanel>
 
       <ReportPanel state={patterns} skeletonClassName="h-72 w-full">

--- a/components/reports/__tests__/GrowthFlow.test.tsx
+++ b/components/reports/__tests__/GrowthFlow.test.tsx
@@ -1,0 +1,128 @@
+import type { GrowthResponse, GrowthRow } from '@/types/reports';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { GrowthFlow } from '@/components/reports/charts/GrowthFlow';
+import { toChartRow } from '@/lib/growth-flow';
+
+// recharts measures its container, which jsdom reports as zero, so the SVG never
+// renders. The stacking claim is therefore asserted against `toChartRow` — the
+// data the chart is handed — rather than against paths. That is the honest test
+// anyway: the claim is "churn goes below the line", not "recharts drew a rect".
+vi.mock('recharts', async () => {
+  const actual = await vi.importActual<typeof import('recharts')>('recharts');
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+      <div style={{ width: 800, height: 300 }}>{children}</div>
+    ),
+  };
+});
+
+function row(over: Partial<GrowthRow> & Pick<GrowthRow, 'week'>): GrowthRow {
+  return {
+    new: 40,
+    resurrected: 10,
+    retained: 80,
+    churned: 30,
+    active: 130,
+    previous_active: 110,
+    net: 20,
+    quick_ratio: 1.67,
+    provisional: false,
+    week_covered: true,
+    ...over,
+  };
+}
+
+function response(rows: GrowthRow[], over: Partial<GrowthResponse['summary']> = {}): GrowthResponse {
+  const settled = rows.filter(r => !r.provisional);
+  return {
+    rows,
+    bands: ['new', 'resurrected', 'retained', 'churned'],
+    weeks_covered: settled.length,
+    summary: {
+      new: settled.reduce((sum, r) => sum + r.new, 0),
+      resurrected: settled.reduce((sum, r) => sum + r.resurrected, 0),
+      churned: settled.reduce((sum, r) => sum + r.churned, 0),
+      quick_ratio: 1.06,
+      ...over,
+    },
+  } as unknown as GrowthResponse;
+}
+
+describe('growthFlow', () => {
+  it('leads with the quick ratio, which is the number that says which way it is going', () => {
+    render(<GrowthFlow data={response([row({ week: '2026-06-01' })])} />);
+
+    expect(screen.getByText('Quick ratio')).toBeInTheDocument();
+    expect(screen.getByText('1.06')).toBeInTheDocument();
+  });
+
+  it('shows a dash rather than a number when nothing churned', () => {
+    // Not infinity, and not zero. A week that lost nobody has no ratio, and
+    // rendering that as a spike makes the best week on record read as an
+    // anomaly.
+    render(<GrowthFlow data={response([row({ week: '2026-06-01' })], { quick_ratio: null })} />);
+
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+
+  it('says how many settled weeks the totals cover', () => {
+    // The running week is excluded from them, so a reader comparing this with
+    // the date picker would otherwise find the totals short and assume a bug.
+    render(
+      <GrowthFlow
+        data={response([
+          row({ week: '2026-06-01' }),
+          row({ week: '2026-06-08' }),
+          row({ week: '2026-06-15', provisional: true }),
+        ])}
+      />,
+    );
+
+    expect(screen.getByText('Totals cover 2 settled weeks.')).toBeInTheDocument();
+  });
+
+  it('warns that the running week understates what it will keep', () => {
+    // Its churn cannot be counted until the following week ends. Unmarked, the
+    // last bar on every run of this report looks like a collapse.
+    render(
+      <GrowthFlow
+        data={response([row({ week: '2026-06-01' }), row({ week: '2026-06-08', provisional: true })])}
+      />,
+    );
+
+    expect(screen.getByText(/Week of 2026-06-08 is still running/)).toBeInTheDocument();
+  });
+
+  it('says nothing about a running week when every week has settled', () => {
+    render(<GrowthFlow data={response([row({ week: '2026-06-01' })])} />);
+
+    expect(screen.queryByText(/is still running/)).not.toBeInTheDocument();
+  });
+
+  it('has an empty state rather than an axis with nothing on it', () => {
+    render(<GrowthFlow data={response([])} />);
+
+    expect(screen.getByText('No player activity in this window.')).toBeInTheDocument();
+  });
+});
+
+describe('toChartRow', () => {
+  it('turns churn negative so it stacks below the line', () => {
+    // The API sends it positive on purpose, so a client that does not know to
+    // invert it never finds a negative in a chart that cannot handle one. This
+    // component is the one that decides.
+    expect(toChartRow(row({ week: '2026-06-01', churned: 30 })).churned).toBe(-30);
+  });
+
+  it('leaves the three gaining bands alone', () => {
+    const chart = toChartRow(row({ week: '2026-06-01', new: 40, resurrected: 10, retained: 80 }));
+
+    expect([chart.new, chart.resurrected, chart.retained]).toEqual([40, 10, 80]);
+  });
+
+  it('drops the year from the label, since every bar carries the same one', () => {
+    expect(toChartRow(row({ week: '2026-06-01' })).week).toBe('06-01');
+  });
+});

--- a/components/reports/__tests__/GrowthFlow.test.tsx
+++ b/components/reports/__tests__/GrowthFlow.test.tsx
@@ -122,7 +122,14 @@ describe('toChartRow', () => {
     expect([chart.new, chart.resurrected, chart.retained]).toEqual([40, 10, 80]);
   });
 
-  it('drops the year from the label, since every bar carries the same one', () => {
-    expect(toChartRow(row({ week: '2026-06-01' })).week).toBe('06-01');
+  it('keeps the full date as the key and shortens only the label', () => {
+    // The range picker allows arbitrary custom spans, so across a multi-year
+    // selection MM-DD repeats and a categorical axis collapses two different
+    // weeks onto one bar (Copilot on #122). The key stays unambiguous; the
+    // label is what gets shortened.
+    const chart = toChartRow(row({ week: '2026-06-01' }));
+
+    expect(chart.week).toBe('2026-06-01');
+    expect(chart.label).toBe('06-01');
   });
 });

--- a/components/reports/charts/GrowthFlow.tsx
+++ b/components/reports/charts/GrowthFlow.tsx
@@ -66,15 +66,18 @@ export function GrowthFlow({ data }: { data: GrowthResponse }) {
         <MetricRow
           columns={4}
           metrics={[
-            { label: 'New players', value: data.summary.new.toLocaleString(), metric: 'new_players_weekly' },
-            { label: 'Came back', value: data.summary.resurrected.toLocaleString(), metric: 'resurrected_players' },
-            { label: 'Churned', value: data.summary.churned.toLocaleString(), metric: 'churned_players' },
             {
+              // FIRST, because this PR claims it leads and it was last — the
+              // one figure that says which way the period went should be the
+              // one read first (Copilot on #122). Gained over lost: above 1 the
+              // period added more than it lost.
               label: 'Quick ratio',
-              // Gained over lost. Above 1 the period added more than it lost.
               value: data.summary.quick_ratio === null ? '—' : String(data.summary.quick_ratio),
               metric: 'quick_ratio',
             },
+            { label: 'New players', value: data.summary.new.toLocaleString(), metric: 'new_players_weekly' },
+            { label: 'Came back', value: data.summary.resurrected.toLocaleString(), metric: 'resurrected_players' },
+            { label: 'Churned', value: data.summary.churned.toLocaleString(), metric: 'churned_players' },
           ]}
         />
         <p className="text-xs text-muted-foreground">
@@ -88,7 +91,7 @@ export function GrowthFlow({ data }: { data: GrowthResponse }) {
                 <ResponsiveContainer width="100%" height="100%">
                   <BarChart data={rows} margin={{ top: 8, right: 8, bottom: 8, left: -12 }} stackOffset="sign">
                     <CartesianGrid strokeDasharray="3 3" stroke={theme.grid.stroke} />
-                    <XAxis dataKey="week" tick={theme.tick} interval="preserveStartEnd" minTickGap={16} />
+                    <XAxis dataKey="label" tick={theme.tick} interval="preserveStartEnd" minTickGap={16} />
                     <YAxis tick={theme.tick} allowDecimals={false} width={44} />
                     <Tooltip content={<ChartTooltip />} cursor={theme.tooltip.cursor} />
                     {/* The line the shape is read against. Without it, a week
@@ -112,7 +115,7 @@ export function GrowthFlow({ data }: { data: GrowthResponse }) {
 
         {provisional && (
           <p className="text-xs text-muted-foreground">
-            {`Week of ${provisional.week} is still running — its churn cannot be counted until the following week ends, so the faint bar understates what it will keep.`}
+            {`Week of ${provisional.week} is still running — its churn cannot be known until the week ends, so the faint bar understates what it will keep.`}
           </p>
         )}
       </CardContent>

--- a/components/reports/charts/GrowthFlow.tsx
+++ b/components/reports/charts/GrowthFlow.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import type { GrowthResponse } from '@/types/reports';
+import { useTheme } from 'next-themes';
+import { Bar, BarChart, CartesianGrid, Cell, ReferenceLine, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { ChartTooltip } from '@/components/reports/charts/ChartTooltip';
+import { EmptyState } from '@/components/reports/primitives/EmptyState';
+import { MetricRow } from '@/components/reports/primitives/MetricRow';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { chartTheme } from '@/lib/chart-theme';
+import { toChartRow } from '@/lib/growth-flow';
+
+/**
+ * Where each week's players came from, and where last week's went.
+ *
+ * The totals view says "sessions were up 12%", which cannot be acted on — 500
+ * sessions is 50 loyal players or 200 tourists. Four bands say which.
+ *
+ * Stacked with churn BELOW the axis, because that is what makes the shape
+ * readable at a glance: the bar above the line is what the week gained and kept,
+ * the bar below is what it lost, and a week where the two are level is a week
+ * that stood still however good the total looked.
+ *
+ * The quick ratio deliberately does NOT go on this chart. It is a ratio around
+ * 1 against player counts in the hundreds, so it needs its own scale — and a
+ * second y-axis is the one chart decision that reliably misleads. It sits above
+ * as a figure instead.
+ */
+
+const BAND_NAMES = {
+  retained: 'Stayed',
+  resurrected: 'Came back',
+  new: 'New',
+  churned: 'Churned',
+} as const;
+
+export function GrowthFlow({ data }: { data: GrowthResponse }) {
+  const { resolvedTheme } = useTheme();
+  const theme = chartTheme(resolvedTheme === 'dark');
+  const rows = data.rows.map(toChartRow);
+  const provisional = data.rows.find(row => row.provisional);
+
+  // Semantic, not the categorical order: green is what arrived, rose is what
+  // left, and the two calm hues in between are the players who were already
+  // here. Reading gain and loss off hue is the whole point of the shape.
+  const colours = {
+    retained: theme.series[1],
+    resurrected: theme.series[2],
+    new: theme.series[0],
+    churned: theme.series[4],
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Where the week's players came from</CardTitle>
+        <CardDescription>
+          Above the line is what the week gained and kept; below it is what it lost.
+          A week where the two are level stood still, however good the total looked.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Named, because the totals above do NOT cover the whole selection —
+            the running week is left out of them, and a reader comparing this
+            figure with the date picker would otherwise find it short. */}
+        <MetricRow
+          columns={4}
+          metrics={[
+            { label: 'New players', value: data.summary.new.toLocaleString(), metric: 'new_players_weekly' },
+            { label: 'Came back', value: data.summary.resurrected.toLocaleString(), metric: 'resurrected_players' },
+            { label: 'Churned', value: data.summary.churned.toLocaleString(), metric: 'churned_players' },
+            {
+              label: 'Quick ratio',
+              // Gained over lost. Above 1 the period added more than it lost.
+              value: data.summary.quick_ratio === null ? '—' : String(data.summary.quick_ratio),
+              metric: 'quick_ratio',
+            },
+          ]}
+        />
+        <p className="text-xs text-muted-foreground">
+          {`Totals cover ${data.weeks_covered} settled ${data.weeks_covered === 1 ? 'week' : 'weeks'}.`}
+        </p>
+
+        <div className="h-64 sm:h-72">
+          {rows.length === 0
+            ? <EmptyState hint="Try a wider date range.">No player activity in this window.</EmptyState>
+            : (
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={rows} margin={{ top: 8, right: 8, bottom: 8, left: -12 }} stackOffset="sign">
+                    <CartesianGrid strokeDasharray="3 3" stroke={theme.grid.stroke} />
+                    <XAxis dataKey="week" tick={theme.tick} interval="preserveStartEnd" minTickGap={16} />
+                    <YAxis tick={theme.tick} allowDecimals={false} width={44} />
+                    <Tooltip content={<ChartTooltip />} cursor={theme.tooltip.cursor} />
+                    {/* The line the shape is read against. Without it, a week
+                        that lost more than it gained still looks like a bar. */}
+                    <ReferenceLine y={0} stroke={theme.axisLine.stroke} />
+                    {(['retained', 'resurrected', 'new', 'churned'] as const).map(band => (
+                      <Bar key={band} dataKey={band} name={BAND_NAMES[band]} stackId="players" fill={colours[band]}>
+                        {rows.map(row => (
+                          // The provisional week is drawn faint rather than
+                          // dropped: its churn cannot be known yet, and hiding
+                          // the most recent bar on a report about what is
+                          // happening now is worse than marking it.
+                          <Cell key={row.week} fillOpacity={row.provisional ? 0.35 : 0.9} />
+                        ))}
+                      </Bar>
+                    ))}
+                  </BarChart>
+                </ResponsiveContainer>
+              )}
+        </div>
+
+        {provisional && (
+          <p className="text-xs text-muted-foreground">
+            {`Week of ${provisional.week} is still running — its churn cannot be counted until the following week ends, so the faint bar understates what it will keep.`}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/lib/growth-flow.ts
+++ b/lib/growth-flow.ts
@@ -11,9 +11,13 @@ import type { GrowthRow } from '@/types/reports';
  */
 export function toChartRow(row: GrowthRow) {
   return {
-    // The year is dropped: every bar in a window carries the same one, and the
-    // axis has room for about eight labels.
-    week: row.week.slice(5),
+    // The full date is the KEY, because the range picker allows arbitrary
+    // custom spans: across a multi-year selection, MM-DD repeats and a
+    // categorical axis collapses two different weeks onto one bar (Copilot on
+    // #122). The short form is a separate field the axis formats with, so the
+    // label stays readable without the key becoming ambiguous.
+    week: row.week,
+    label: row.week.slice(5),
     retained: row.retained,
     resurrected: row.resurrected,
     new: row.new,

--- a/lib/growth-flow.ts
+++ b/lib/growth-flow.ts
@@ -1,0 +1,26 @@
+import type { GrowthRow } from '@/types/reports';
+
+/**
+ * One growth week, shaped for a stacked bar chart.
+ *
+ * Its own module rather than an export from the chart, so the one decision worth
+ * testing here is testable: jsdom reports a zero-size container and recharts
+ * draws nothing, so asserting "churn goes below the line" against rendered paths
+ * is not possible. Asserting it against the data the chart is handed is both
+ * possible and the more honest check.
+ */
+export function toChartRow(row: GrowthRow) {
+  return {
+    // The year is dropped: every bar in a window carries the same one, and the
+    // axis has room for about eight labels.
+    week: row.week.slice(5),
+    retained: row.retained,
+    resurrected: row.resurrected,
+    new: row.new,
+    // The API sends churn POSITIVE, on purpose — so a client that does not know
+    // to stack it downward never finds a negative in a chart that cannot handle
+    // one. Turning it negative is the chart's decision, made here.
+    churned: -row.churned,
+    provisional: row.provisional,
+  };
+}

--- a/lib/reports-api.ts
+++ b/lib/reports-api.ts
@@ -7,6 +7,7 @@ import type {
   FirstSessionResponse,
   GamesResponse,
   GlossaryResponse,
+  GrowthResponse,
   MultiplayerResponse,
   PatternsResponse,
   PlayerDetailResponse,
@@ -111,6 +112,11 @@ export class ReportsAPI {
    */
   static async getFirstSession(params?: ReportParams): Promise<FirstSessionResponse> {
     return apiFetcher<FirstSessionResponse>(`core/reporting/first-session/${buildQuery(params)}`);
+  }
+
+  /** GET /core/reporting/growth/ — weekly new / resurrected / retained / churned. */
+  static async getGrowth(params?: ReportParams): Promise<GrowthResponse> {
+    return apiFetcher<GrowthResponse>(`core/reporting/growth/${buildQuery(params)}`);
   }
 
   /** GET /core/reporting/difficulty/ — completion and win rate by difficulty. */

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -728,3 +728,42 @@ export type AttemptRow = {
 export type AttemptsResponse = {
   rows: AttemptRow[];
 } & ResolvedRange;
+
+/**
+ * One week of growth accounting.
+ *
+ * The four bands are exhaustive and do not overlap, which is what makes the flow
+ * add up: `active - previous_active === new + resurrected - churned` on every
+ * row. `churned` is POSITIVE — stacking it downward is the client's decision, so
+ * a chart that does not expect a negative never finds one.
+ */
+export type GrowthRow = {
+  /** Monday of the week, YYYY-MM-DD. */
+  week: string;
+  /** First session ever, not first in the window. */
+  new: number;
+  /** Active this week, not last week, but has played before. */
+  resurrected: number;
+  retained: number;
+  churned: number;
+  active: number;
+  previous_active: number;
+  net: number;
+  /** Gained over lost. `null` where nothing churned — not infinity. */
+  quick_ratio: number | null;
+  /** The week is still running, so its churn cannot be known yet. */
+  provisional: boolean;
+  week_covered: boolean;
+};
+
+export type GrowthResponse = {
+  rows: GrowthRow[];
+  bands: string[];
+  weeks_covered: number;
+  summary: {
+    new: number;
+    resurrected: number;
+    churned: number;
+    quick_ratio: number | null;
+  };
+} & ResolvedRange;


### PR DESCRIPTION
FE half of **R6** (backend: FootballExtraTime/App#1480). Stacked on #121 — the base retargets as the stack merges.

A stacked weekly flow on the overview. **Above the axis is what the week gained and kept; below it is what it lost.** A week where the two are level stood still, however good the total looked.

Placed above new-vs-returning, which answers a narrower version of the same question: that chart splits a **day** into two bands by registration date, this splits a **week** into four by what the player actually did. Where they disagree, this is the one to trust — "new" there means the account was made that day, which counts a three-month absence as growth.

## Four decisions, each mutation-tested

**Churn is negated here, not by the API.** The payload sends it positive so a client that doesn't know to stack it downward never finds a negative in a chart that can't handle one. The negation lives in `lib/growth-flow.ts` so the decision is testable — jsdom reports a zero-size container and recharts draws nothing, so asserting it against rendered paths isn't possible; asserting it against the data the chart is handed is both possible and the more honest check.

**A null quick ratio renders as a dash**, not zero. A week that lost nobody has no ratio, and zero is the value that means the opposite.

**The running week is drawn faint with a note**, not dropped. Its churn can't be counted until the following week ends, and hiding the most recent bar on a report about what's happening *now* is worse than marking it.

**The totals say how many weeks they cover**, because the running week is left out of them and a reader comparing against the date picker would otherwise find them short and assume a bug.

## What is deliberately not on the chart

The quick ratio. It's a ratio around 1 against player counts in the hundreds, so plotting it needs a second y-axis — the one chart decision that reliably misleads. It leads as a figure above the chart instead, which is where someone reads it anyway.

Fifth caller for R9's `MetricRow`.

546 tests, lint clean, types OK, build compiling. Two lint rules fired on the first pass and both were right: exporting a helper from a component file breaks fast refresh (moved to `lib/`), and `BAND_NAMES` was used above its definition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)