### PR TITLE
Say whether there is anything left to play

### DIFF
--- a/app/reports/games/page.tsx
+++ b/app/reports/games/page.tsx
@@ -10,6 +10,7 @@ import { FilterBar } from '@/components/reports/filters/FilterBar';
 import { RangePicker } from '@/components/reports/filters/RangePicker';
 import { AbandonedPanel } from '@/components/reports/panels/AbandonedPanel';
 import { AttemptSpread } from '@/components/reports/panels/AttemptSpread';
+import { ContentHealth, FormatFallbacks } from '@/components/reports/panels/ContentHealth';
 import { DifficultyOutcomes } from '@/components/reports/panels/DifficultyOutcomes';
 import { DurationTable } from '@/components/reports/panels/DurationTable';
 import { ProgressDropOff } from '@/components/reports/panels/ProgressDropOff';
@@ -82,6 +83,15 @@ export default function GamesIndexPage() {
   // ranged page because the question ("what is lying around for this game") is a
   // per-game one; the panel says so itself rather than inheriting the filter.
   const unfinishedParams = useMemo(() => ({ include_bots: includeBots }), [includeBots]);
+  // The content endpoint takes no range: "how many lineups are staged" is a
+  // snapshot, and a window on it would produce a number that means nothing.
+  const content = useReport(ReportsAPI.getContent, {}, enabled, 'The content reporting endpoint');
+  const fallbacks = useReport(
+    ReportsAPI.getFallbacks,
+    params,
+    enabled,
+    'The answer-format fallback endpoint',
+  );
   const difficulty = useReport(
     ReportsAPI.getDifficulty,
     params,
@@ -294,6 +304,24 @@ export default function GamesIndexPage() {
 
       <ReportPanel state={progress} skeletonClassName="h-80 w-full">
         {data => <ProgressDropOff data={data} meta={meta} />}
+      </ReportPanel>
+
+      {/* After difficulty and drop-off, because those describe how the games
+          play and this describes whether there is anything left to play. It is
+          also the only panel here that can be acted on the same afternoon:
+          everything else asks for a design change, this asks someone to stage
+          more lineups. */}
+      <SectionHeader
+        title="Whether there is material left"
+        description="Two games schedule their content against a calendar. The rest draw from a pool."
+      />
+
+      <ReportPanel state={content} skeletonClassName="h-64 w-full">
+        {data => <ContentHealth data={data} meta={meta} />}
+      </ReportPanel>
+
+      <ReportPanel state={fallbacks} skeletonClassName="h-56 w-full">
+        {data => <FormatFallbacks data={data} />}
       </ReportPanel>
 
       <SectionHeader

--- a/components/reports/__tests__/ContentHealth.test.tsx
+++ b/components/reports/__tests__/ContentHealth.test.tsx
@@ -1,3 +1,4 @@
+import type { GameMetaMap } from '@/hooks/use-game-meta';
 import type { ContentResponse, ContentRow, FallbackRow, FallbacksResponse } from '@/types/reports';
 import { render, screen, within } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
@@ -7,7 +8,7 @@ const META = {
   missing11: { key: 'missing11', label: 'Missing11', display_name: 'Guess The Line Up', color: '#2563eb', color_dark: '#60a5fa' },
   grid: { key: 'grid', label: 'Grid', display_name: 'Grid', color: '#f97316', color_dark: '#fdba74' },
   quiz: { key: 'quiz', label: 'Quiz', display_name: 'Quiz', color: '#059669', color_dark: '#34d399' },
-} as never;
+} satisfies GameMetaMap;
 
 function row(over: Partial<ContentRow> & Pick<ContentRow, 'game_type'>): ContentRow {
   return {
@@ -143,7 +144,16 @@ function fallbacks(rows: FallbackRow[], unstamped = 0): FallbacksResponse {
     total_wanted_multiple_choice: rows.reduce((sum, r) => sum + r.wanted_multiple_choice, 0),
     total_fallbacks: rows.reduce((sum, r) => sum + r.fallbacks, 0),
     total_unstamped: unstamped,
-  } as unknown as FallbacksResponse;
+    // The range echo, filled in rather than cast past (Copilot on #123): a cast
+    // here hides the day the response shape changes, which is the day a test
+    // fixture is most worth having.
+    start: '2026-06-01',
+    end: '2026-06-30',
+    days: 30,
+    window: 30,
+    include_bots: false,
+    game_type: null,
+  } satisfies FallbacksResponse;
 }
 
 describe('formatFallbacks', () => {

--- a/components/reports/__tests__/ContentHealth.test.tsx
+++ b/components/reports/__tests__/ContentHealth.test.tsx
@@ -1,0 +1,176 @@
+import type { ContentResponse, ContentRow, FallbackRow, FallbacksResponse } from '@/types/reports';
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ContentHealth, FormatFallbacks } from '@/components/reports/panels/ContentHealth';
+
+const META = {
+  missing11: { key: 'missing11', label: 'Missing11', display_name: 'Guess The Line Up', color: '#2563eb', color_dark: '#60a5fa' },
+  grid: { key: 'grid', label: 'Grid', display_name: 'Grid', color: '#f97316', color_dark: '#fdba74' },
+  quiz: { key: 'quiz', label: 'Quiz', display_name: 'Quiz', color: '#059669', color_dark: '#34d399' },
+} as never;
+
+function row(over: Partial<ContentRow> & Pick<ContentRow, 'game_type'>): ContentRow {
+  return {
+    item: 'lineup',
+    scheduled: true,
+    total: 458,
+    unused: 0,
+    exhausted: 0,
+    usable: 458,
+    runway_days: 30,
+    staged_ahead: 30,
+    last_staged: '2026-09-14',
+    low: false,
+    dry: false,
+    topped_up_by_a_job: false,
+    ...over,
+  };
+}
+
+function response(rows: ContentRow[], warningDays = 14): ContentResponse {
+  return {
+    as_of: '2026-08-15',
+    rows,
+    warning_days: warningDays,
+    games_running_low: rows.filter(r => r.low).map(r => r.game_type),
+  };
+}
+
+describe('contentHealth', () => {
+  it('says a game is dry, and for how long', () => {
+    // Not "0 days". The distinction between running out today and having run
+    // out three weeks ago is what decides how urgent this is.
+    render(
+      <ContentHealth
+        data={response([row({
+          game_type: 'missing11',
+          runway_days: -20,
+          staged_ahead: 0,
+          dry: true,
+          low: true,
+          last_staged: '2026-07-26',
+        })])}
+        meta={META}
+      />,
+    );
+
+    expect(screen.getByText('Dry 20d')).toBeInTheDocument();
+    expect(screen.getByText(/2026-07-26/)).toBeInTheDocument();
+  });
+
+  it('does not treat a full catalogue as health', () => {
+    // 458 lineups, every one served. A coverage bar draws that as full on the
+    // day the game runs out of anything to show.
+    render(
+      <ContentHealth
+        data={response([row({
+          game_type: 'missing11',
+          total: 458,
+          unused: 0,
+          runway_days: -20,
+          dry: true,
+          low: true,
+        })])}
+        meta={META}
+      />,
+    );
+    const cells = within(screen.getAllByRole('row')[1]).getAllByRole('cell');
+
+    expect(cells[1]).toHaveTextContent('Dry 20d');
+    expect(cells[2]).toHaveTextContent('458');
+  });
+
+  it('says a pooled game has no schedule rather than no runway', () => {
+    // A zero here reads as "out of content" for a game that simply has no
+    // calendar to be measured against.
+    render(
+      <ContentHealth
+        data={response([row({
+          game_type: 'quiz',
+          scheduled: false,
+          item: 'quiz',
+          runway_days: null,
+          staged_ahead: null,
+        })])}
+        meta={META}
+      />,
+    );
+
+    expect(screen.getByText('no schedule')).toBeInTheDocument();
+  });
+
+  it('marks a machine-filled pool, because a shrinking one is a broken job', () => {
+    // Different alert, different owner. Filed under "write more content" it
+    // wastes a week before anyone checks the scheduler.
+    render(
+      <ContentHealth
+        data={response([row({
+          game_type: 'grid',
+          scheduled: false,
+          item: 'grid',
+          runway_days: null,
+          topped_up_by_a_job: true,
+        })])}
+        meta={META}
+      />,
+    );
+
+    expect(screen.getByText('machine-filled')).toBeInTheDocument();
+  });
+
+  it('states the threshold it is colouring against', () => {
+    render(<ContentHealth data={response([row({ game_type: 'missing11' })], 14)} meta={META} />);
+
+    expect(screen.getByText(/Amber under 14 days/)).toBeInTheDocument();
+  });
+});
+
+function fallbackRow(over: Partial<FallbackRow> & Pick<FallbackRow, 'challenge_type'>): FallbackRow {
+  return {
+    challenges: 100,
+    multiple_choice: 82,
+    fallbacks: 18,
+    wanted_multiple_choice: 100,
+    fallback_pct: 18,
+    unstamped: 0,
+    ...over,
+  };
+}
+
+function fallbacks(rows: FallbackRow[], unstamped = 0): FallbacksResponse {
+  return {
+    rows,
+    total_wanted_multiple_choice: rows.reduce((sum, r) => sum + r.wanted_multiple_choice, 0),
+    total_fallbacks: rows.reduce((sum, r) => sum + r.fallbacks, 0),
+    total_unstamped: unstamped,
+  } as unknown as FallbacksResponse;
+}
+
+describe('formatFallbacks', () => {
+  it('shows the rate against what wanted a grid, not against everything', () => {
+    render(<FormatFallbacks data={fallbacks([fallbackRow({ challenge_type: 'CLUB_CONNECTION' })])} />);
+    const cells = within(screen.getAllByRole('row')[1]).getAllByRole('cell');
+
+    expect(cells[1]).toHaveTextContent('100');
+    expect(cells[3]).toHaveTextContent('18%');
+  });
+
+  it('says the rate is unknown, not zero, when nothing carries the flag', () => {
+    // Every challenge predating the flag reported as a clean 0% is the specific
+    // wrong answer here — it says the content is fine when nothing was measured.
+    render(<FormatFallbacks data={fallbacks([], 16651)} />);
+
+    expect(screen.getByText(/unknown rather than zero/)).toBeInTheDocument();
+    expect(screen.queryByText('0%')).not.toBeInTheDocument();
+  });
+
+  it('says how many rows were left out of the rates', () => {
+    render(
+      <FormatFallbacks
+        data={fallbacks([fallbackRow({ challenge_type: 'CLUB_CONNECTION' })], 400)}
+      />,
+    );
+
+    expect(screen.getByText(/400 challenges in this window predate the flag/)).toBeInTheDocument();
+  });
+});

--- a/components/reports/panels/ContentHealth.tsx
+++ b/components/reports/panels/ContentHealth.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import type { GameMetaMap } from '@/hooks/use-game-meta';
+import type { ContentResponse, ContentRow, FallbacksResponse } from '@/types/reports';
+import { EmptyState } from '@/components/reports/primitives/EmptyState';
+import { GameBadge } from '@/components/reports/primitives/GameBadge';
+import { MetricInfo } from '@/components/reports/primitives/MetricInfo';
+import { ReportHead, ReportRow, ReportTable, Td, Th } from '@/components/reports/primitives/ReportTable';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+/**
+ * Whether a game is running out of material people have not seen.
+ *
+ * Runway rather than coverage, and the panel has to make that legible: Missing11
+ * has 458 lineups and has served every one of them, which a coverage bar would
+ * draw as full on the day the game runs dry.
+ */
+
+function Runway({ row }: { row: ContentRow }) {
+  if (!row.scheduled) {
+    // A pooled game has no calendar to have a runway against. A dash here
+    // rather than a zero, which would read as "out of content".
+    return (
+      <span className="text-muted-foreground/70" title="This game draws from a pool with no schedule, so it has no runway — read its unused count instead">
+        no schedule
+      </span>
+    );
+  }
+
+  if (row.dry) {
+    const days = row.runway_days === null ? null : Math.abs(row.runway_days);
+    return (
+      <span className="font-medium text-rose-600 dark:text-rose-400">
+        {days === null ? 'Nothing staged' : `Dry ${days}d`}
+        <span className="mt-0.5 block text-xs font-normal text-muted-foreground">
+          nothing new since
+          {' '}
+          {row.last_staged ?? 'ever'}
+        </span>
+      </span>
+    );
+  }
+
+  // `row.low` rather than comparing against the threshold here: the server owns
+  // where the line sits, and a client that re-derives it drifts the first time
+  // that changes.
+  return (
+    <span className={row.low ? 'font-medium text-amber-600 dark:text-amber-500' : undefined}>
+      {`${row.runway_days}d`}
+      <span className="mt-0.5 block text-xs font-normal text-muted-foreground">
+        {`${(row.staged_ahead ?? 0).toLocaleString()} staged`}
+      </span>
+    </span>
+  );
+}
+
+export function ContentHealth({ data, meta }: { data: ContentResponse; meta: GameMetaMap }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          Are we running out of material
+          <MetricInfo metric="content_runway" />
+        </CardTitle>
+        <CardDescription>
+          {`Days of staged content, not the share of the catalogue used — a game that has served every item it owns is out of material, not fully covered. Amber under ${data.warning_days} days.`}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3 overflow-x-auto">
+        {/* The answer before the table. Someone opening this panel is asking
+            "is anything about to run out", and a five-row table makes them
+            work it out. */}
+        <p className="text-sm">
+          {data.games_running_low.length === 0
+            ? 'Every game has material staged or in the pool.'
+            : `${data.games_running_low.length === 1 ? '1 game is' : `${data.games_running_low.length} games are`} running low.`}
+        </p>
+
+        {data.rows.length === 0
+          ? <EmptyState>No game declares a content pool.</EmptyState>
+          : (
+              <ReportTable>
+                <ReportHead>
+                  <Th>Game</Th>
+                  <Th align="right" title="Days until the last staged item goes live">Runway</Th>
+                  <Th align="right">In the catalogue</Th>
+                  <Th align="right" title="Never served to anyone">Unused</Th>
+                  <Th align="right" title="At their run cap and unusable">Used up</Th>
+                </ReportHead>
+                <tbody>
+                  {data.rows.map(row => (
+                    <ReportRow key={row.game_type}>
+                      <Td strong>
+                        <GameBadge gameKey={row.game_type} meta={meta} href={`/reports/games/${row.game_type}`} />
+                        {row.topped_up_by_a_job && (
+                          // A shrinking pool here is a broken job, not a content
+                          // shortage — a different alert with a different owner,
+                          // and filing it under "write more content" wastes a
+                          // week before anyone checks the scheduler.
+                          <span
+                            className="mt-0.5 block text-xs font-normal text-muted-foreground"
+                            title="This pool is refilled automatically every few minutes — if it shrinks, check the job before writing more content"
+                          >
+                            machine-filled
+                          </span>
+                        )}
+                      </Td>
+                      <Td align="right"><Runway row={row} /></Td>
+                      <Td align="right">
+                        {row.total.toLocaleString()}
+                        <span className="mt-0.5 block text-xs font-normal text-muted-foreground">
+                          {`${row.item}s`}
+                        </span>
+                      </Td>
+                      <Td align="right">{row.unused.toLocaleString()}</Td>
+                      <Td align="right" className="text-muted-foreground">
+                        {row.exhausted.toLocaleString()}
+                      </Td>
+                    </ReportRow>
+                  ))}
+                </tbody>
+              </ReportTable>
+            )}
+      </CardContent>
+    </Card>
+  );
+}
+
+/**
+ * Material that exists but cannot be used.
+ *
+ * The sharpest form of content exhaustion: a challenge that cannot produce four
+ * plausible options is served as something harder than what was configured, and
+ * until now the only trace was a log line.
+ */
+export function FormatFallbacks({ data }: { data: FallbacksResponse }) {
+  const measurable = data.rows.filter(row => row.wanted_multiple_choice > 0);
+  const unstamped = data.total_unstamped;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          When the content could not fill a grid
+          <MetricInfo metric="format_fallback_rate" />
+        </CardTitle>
+        <CardDescription>
+          Of the Conquest challenges that asked for a multiple-choice grid, the share
+          that could not build a fair one and served autocomplete instead.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3 overflow-x-auto">
+        {data.total_wanted_multiple_choice > 0 && (
+          <p className="text-sm">
+            {`${data.total_fallbacks.toLocaleString()} of ${data.total_wanted_multiple_choice.toLocaleString()} challenges that wanted a grid could not build one.`}
+          </p>
+        )}
+
+        {measurable.length === 0
+          ? (
+              <EmptyState hint={unstamped > 0 ? undefined : 'Try a wider date range.'}>
+                {unstamped > 0
+                  // Not "no fallbacks". Every challenge here predates the flag, and
+                  // reporting that as a clean 0% is the specific wrong answer.
+                  ? `No challenge in this window records its format. All ${unstamped.toLocaleString()} predate the flag, so the rate is unknown rather than zero.`
+                  : 'No challenges asked for a multiple-choice grid in this window.'}
+              </EmptyState>
+            )
+          : (
+              <ReportTable>
+                <ReportHead>
+                  <Th>Challenge type</Th>
+                  <Th align="right" title="Built a grid, plus fell back — never all challenges">Wanted a grid</Th>
+                  <Th align="right">Fell back</Th>
+                  <Th align="right">Rate</Th>
+                </ReportHead>
+                <tbody>
+                  {measurable.map(row => (
+                    <ReportRow key={row.challenge_type}>
+                      <Td strong>{row.challenge_type.replaceAll('_', ' ').toLowerCase()}</Td>
+                      <Td align="right">{row.wanted_multiple_choice.toLocaleString()}</Td>
+                      <Td align="right">{row.fallbacks.toLocaleString()}</Td>
+                      <Td align="right" strong>
+                        {row.fallback_pct === null ? '—' : `${row.fallback_pct}%`}
+                      </Td>
+                    </ReportRow>
+                  ))}
+                </tbody>
+              </ReportTable>
+            )}
+
+        {measurable.length > 0 && unstamped > 0 && (
+          <p className="text-xs text-muted-foreground">
+            {`${unstamped.toLocaleString()} challenges in this window predate the flag and are left out of every rate above, rather than counted as successes.`}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/reports/panels/ContentHealth.tsx
+++ b/components/reports/panels/ContentHealth.tsx
@@ -16,6 +16,25 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
  * draw as full on the day the game runs dry.
  */
 
+/**
+ * Plural forms for the item names the registry declares.
+ *
+ * Appending "s" turned `quiz` into "quizs" (Copilot on #123). A map rather than
+ * a rule: English pluralisation is not a rule, and the set of item names is
+ * small, closed and declared on the backend — so an unknown one falling back to
+ * "+s" is a reminder to add it here, not a silent wrong answer in the UI.
+ */
+const ITEM_PLURALS: Record<string, string> = {
+  lineup: 'lineups',
+  challenge: 'challenges',
+  quiz: 'quizzes',
+  grid: 'grids',
+};
+
+function plural(item: string): string {
+  return ITEM_PLURALS[item] ?? `${item}s`;
+}
+
 function Runway({ row }: { row: ContentRow }) {
   if (!row.scheduled) {
     // A pooled game has no calendar to have a runway against. A dash here
@@ -109,7 +128,7 @@ export function ContentHealth({ data, meta }: { data: ContentResponse; meta: Gam
                       <Td align="right">
                         {row.total.toLocaleString()}
                         <span className="mt-0.5 block text-xs font-normal text-muted-foreground">
-                          {`${row.item}s`}
+                          {plural(row.item)}
                         </span>
                       </Td>
                       <Td align="right">{row.unused.toLocaleString()}</Td>

--- a/lib/reports-api.ts
+++ b/lib/reports-api.ts
@@ -2,8 +2,10 @@ import type {
   ActivityResponse,
   AnomaliesResponse,
   AttemptsResponse,
+  ContentResponse,
   DifficultyResponse,
   DurationResponse,
+  FallbacksResponse,
   FirstSessionResponse,
   GamesResponse,
   GlossaryResponse,
@@ -112,6 +114,16 @@ export class ReportsAPI {
    */
   static async getFirstSession(params?: ReportParams): Promise<FirstSessionResponse> {
     return apiFetcher<FirstSessionResponse>(`core/reporting/first-session/${buildQuery(params)}`);
+  }
+
+  /** GET /core/reporting/content/ — content runway and pool depth. A snapshot. */
+  static async getContent(): Promise<ContentResponse> {
+    return apiFetcher<ContentResponse>('core/reporting/content/');
+  }
+
+  /** GET /core/reporting/fallbacks/ — Conquest answer-format fallback rate. */
+  static async getFallbacks(params?: ReportParams): Promise<FallbacksResponse> {
+    return apiFetcher<FallbacksResponse>(`core/reporting/fallbacks/${buildQuery(params)}`);
   }
 
   /** GET /core/reporting/growth/ — weekly new / resurrected / retained / churned. */

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -767,3 +767,64 @@ export type GrowthResponse = {
     quick_ratio: number | null;
   };
 } & ResolvedRange;
+
+/**
+ * One game's content supply.
+ *
+ * Two shapes in one row, distinguished by `scheduled`. Scheduled games stage
+ * material against a calendar and report `runway_days`; pooled games have no
+ * calendar and report depth. Reading a pooled game's blank runway as "no runway"
+ * would be wrong — it has no calendar to have one against.
+ */
+export type ContentRow = {
+  game_type: string;
+  /** One item, singular: 'lineup', 'quiz', 'grid'. */
+  item: string;
+  scheduled: boolean;
+  total: number;
+  unused: number;
+  /** At their run cap and unusable. A cap of 0 means unlimited, not exhausted. */
+  exhausted: number;
+  usable: number;
+  /**
+   * Days until the last staged item goes live. NEGATIVE means the well ran dry
+   * that many days ago — not clamped, because "ran out today" and "ran out three
+   * weeks ago" decide different urgencies. `null` on pooled games.
+   */
+  runway_days: number | null;
+  staged_ahead: number | null;
+  last_staged: string | null;
+  /** Below the warning threshold, or dry. */
+  low: boolean;
+  /** Already out of staged content. Branch on this, not on the sign. */
+  dry: boolean;
+  /** A shrinking pool here is a broken job, not a content shortage. */
+  topped_up_by_a_job: boolean;
+};
+
+export type ContentResponse = {
+  as_of: string;
+  rows: ContentRow[];
+  warning_days: number;
+  games_running_low: string[];
+};
+
+/** One Conquest challenge type's answer-format fallbacks. */
+export type FallbackRow = {
+  challenge_type: string;
+  challenges: number;
+  multiple_choice: number;
+  fallbacks: number;
+  /** The denominator: succeeded plus fell back. Never all challenges. */
+  wanted_multiple_choice: number;
+  fallback_pct: number | null;
+  /** Written before the flag existed. Counted, never assumed non-fallback. */
+  unstamped: number;
+};
+
+export type FallbacksResponse = {
+  rows: FallbackRow[];
+  total_wanted_multiple_choice: number;
+  total_fallbacks: number;
+  total_unstamped: number;
+} & ResolvedRange;


### PR DESCRIPTION
FE half of **R7** (backend: FootballExtraTime/App#1481). Stacked on #122 — the base retargets as the stack merges.

Two panels on the games page, after difficulty and drop-off: those describe *how the games play*, this describes *whether there is anything left to play*. It's also the only panel there that can be acted on the same afternoon — everything else asks for a design change, this asks someone to stage more lineups.

## Five things it refuses to draw

Each mutation-tested by removing it and watching a test fail.

**A dry game shows how long it has been dry**, not `0 days`. Twenty days without new material is a different conversation from running out this morning.

**A pooled game reads "no schedule"**, not a runway of zero. It has no calendar to have a runway against, and a zero there says it's out of content.

**A full catalogue is not health.** Missing11's 458 lineups sit in the row right beside "Dry 20d" — because a coverage bar would draw that game as *full* on the day it stops having anything to show. That's the whole reason this panel measures runway.

**A machine-filled pool says so.** A shrinking Grid pool is a broken job, not a content shortage — different alert, different owner. Filed under "write more content" it wastes a week before anyone checks the scheduler.

**A window where nothing carries the flag reads "unknown"**, not 0%. Every challenge predating the stamp reported as a clean zero is the specific wrong answer here: it says the content is fine when nothing was measured.

## Leading with the answer

Both panels open with the conclusion — "2 games are running low", "18 of 100 challenges that wanted a grid could not build one" — because someone opening them is asking exactly one question, and a five-row table makes them work it out.

## One correction to my own first pass

The threshold colouring now reads `row.low` from the payload instead of comparing against `warning_days` in the component. The server owns where that line sits, and a client that re-derives it drifts the first time it moves. (Caught because the `response-fields-used` guard flagged three payload fields with no renderer — all three turned out to be worth rendering rather than exempting.)

554 tests, lint clean, types OK, build compiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)