### PR TITLE
Lead with the week, and say what the bar was

### DIFF
--- a/app/reports/page.tsx
+++ b/app/reports/page.tsx
@@ -115,7 +115,11 @@ export default function ReportsPage() {
                 first should be the one that is mostly signal. The daily pulse
                 stays underneath rather than going: "what happened today" is a
                 real question, just not the one to open with. */}
-            <WeeklyPulseTiles pulse={data.weekly_pulse} />
+            {/* Guarded: the backend sending this may not be deployed yet, and
+                the two repositories ship independently. Absent, the page shows
+                the daily pulse alone rather than crashing on `pulse.metrics`
+                (Copilot on #124). */}
+            {data.weekly_pulse && <WeeklyPulseTiles pulse={data.weekly_pulse} />}
 
             {/* The daily pulse always describes TODAY, whatever range is
                     selected — the BE sends pulse_applies to say so. Rendering it

--- a/app/reports/page.tsx
+++ b/app/reports/page.tsx
@@ -11,6 +11,7 @@ import { RangePicker } from '@/components/reports/filters/RangePicker';
 import { GameLeaderboard } from '@/components/reports/panels/GameLeaderboard';
 import { PulseTiles } from '@/components/reports/panels/PulseTiles';
 import { RollupHealthBanner } from '@/components/reports/panels/RollupHealthBanner';
+import { WeeklyPulseTiles } from '@/components/reports/panels/WeeklyPulseTiles';
 import { ExportButton } from '@/components/reports/primitives/ExportButton';
 import { GameBadge } from '@/components/reports/primitives/GameBadge';
 import { ReportPanel } from '@/components/reports/primitives/ReportPanel';
@@ -108,10 +109,18 @@ export default function ReportsPage() {
       <ReportPanel state={summary} skeletonClassName="h-32 w-full">
         {data => (
           <>
-            {/* The pulse always describes TODAY, whatever range is selected —
-                    the BE sends pulse_applies to say so. Rendering it beside
-                    comparison tiles that DO follow the range invites reading
-                    today's numbers as the selected period's. */}
+            {/* Weekly first (#1474 R8). A day is not a meaningful sample at
+                this volume — 36 players on a game means one day moves by four
+                people and reads as a 30% swing — so the figure someone sees
+                first should be the one that is mostly signal. The daily pulse
+                stays underneath rather than going: "what happened today" is a
+                real question, just not the one to open with. */}
+            <WeeklyPulseTiles pulse={data.weekly_pulse} />
+
+            {/* The daily pulse always describes TODAY, whatever range is
+                    selected — the BE sends pulse_applies to say so. Rendering it
+                    beside comparison tiles that DO follow the range invites
+                    reading today's numbers as the selected period's. */}
             {data.pulse_applies
               ? (
                   <>

--- a/components/reports/__tests__/AnomalyPanel.test.tsx
+++ b/components/reports/__tests__/AnomalyPanel.test.tsx
@@ -1,4 +1,4 @@
-import type { AnomaliesResponse } from '@/types/reports';
+import type { AnomaliesResponse, AnomalyFinding } from '@/types/reports';
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { AnomalyPanel } from '@/components/reports/panels/AnomalyPanel';
@@ -15,9 +15,26 @@ function build(overrides: Partial<AnomaliesResponse> = {}): AnomaliesResponse {
     include_bots: false,
     window_days: 14,
     compared_with: { start: '2026-07-18', end: '2026-07-31' },
-    thresholds: { min_volume: 30, min_change_pct: 25, severe_change_pct: 50 },
+    thresholds: { min_volume: 30, min_change_pct: 25, severe_change_pct: 50, sigma: 3 },
     coverage: { complete: true, missing_days: [] },
     findings: [],
+    ...overrides,
+  };
+}
+
+function finding(overrides: Partial<AnomalyFinding> = {}): AnomalyFinding {
+  return {
+    scope: 'game',
+    game_type: 'grid',
+    metric: 'games_started',
+    change_pct: -47,
+    current: 637,
+    previous: 1203,
+    z_score: -12.9,
+    required_pct: 20,
+    severity: 'high',
+    headline: 'grid down 47%',
+    detail: '637 games against 1,203 in the previous 14 days.',
     ...overrides,
   };
 }
@@ -55,6 +72,8 @@ describe('anomalyPanel', () => {
             change_pct: -47,
             current: 637,
             previous: 1203,
+            z_score: 3.4,
+            required_pct: 20,
             severity: 'medium',
             headline: 'Grid down 47.0%',
             detail: '637 games started, down from 1,203.',
@@ -73,5 +92,18 @@ describe('anomalyPanel', () => {
     // Without these numbers, "nothing unusual" is an unfalsifiable claim.
     expect(screen.getByText(/25%/)).toBeInTheDocument();
     expect(screen.getByText(/30 sessions/)).toBeInTheDocument();
+    // And the sigma bar, which is the part that actually decides now (#1474 R8).
+    // The percentage alone reads as a flat rule and is why someone would ask
+    // why a +28% game is missing.
+    expect(screen.getByText(/3 standard deviations/)).toBeInTheDocument();
+  });
+
+  it('says what the bar was at that volume, beside the finding', () => {
+    // The panel has to be able to explain an OMISSION. Seeing +28% absent
+    // without this, a reader concludes the panel is broken rather than that 28%
+    // is what a game that size does on a quiet week.
+    render(<AnomalyPanel data={build({ findings: [finding()] })} meta={META} />);
+
+    expect(screen.getByText(/a move of 20% would have been the bar/)).toBeInTheDocument();
   });
 });

--- a/components/reports/__tests__/WeeklyPulseTiles.test.tsx
+++ b/components/reports/__tests__/WeeklyPulseTiles.test.tsx
@@ -74,3 +74,37 @@ describe('weeklyPulseTiles', () => {
     expect(screen.getByText(/mean of the 4 weeks before/)).toBeInTheDocument();
   });
 });
+
+describe('weeklyPulseTiles ordering', () => {
+  it('renders the tiles in a fixed order, not the API\'s key order', () => {
+    // Iterating Object.entries meant a backend key reordering silently
+    // reordered the UI (Copilot on #124). PulseTiles already used a fixed list.
+    render(
+      <WeeklyPulseTiles
+        pulse={pulse({
+          metrics: {
+            mp_player_sessions: { current: 4, baseline: 4, delta_pct: 0 },
+            games_started: { current: 1, baseline: 1, delta_pct: 0 },
+            distinct_players: { current: 3, baseline: 3, delta_pct: 0 },
+            games_finished: { current: 2, baseline: 2, delta_pct: 0 },
+          },
+        })}
+      />,
+    );
+    const labels = screen.getAllByText(/Games started|Games finished|Players|Multiplayer sessions/)
+      .map(node => node.textContent?.trim());
+
+    expect(labels).toEqual(['Games started', 'Games finished', 'Players', 'Multiplayer sessions']);
+  });
+
+  it('skips a metric the payload does not carry rather than rendering an empty tile', () => {
+    render(
+      <WeeklyPulseTiles
+        pulse={pulse({ metrics: { games_started: { current: 1, baseline: 1, delta_pct: 0 } } })}
+      />,
+    );
+
+    expect(screen.getByText('Games started')).toBeInTheDocument();
+    expect(screen.queryByText('Multiplayer sessions')).not.toBeInTheDocument();
+  });
+});

--- a/components/reports/__tests__/WeeklyPulseTiles.test.tsx
+++ b/components/reports/__tests__/WeeklyPulseTiles.test.tsx
@@ -1,0 +1,76 @@
+import type { WeeklyPulse } from '@/types/reports';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { WeeklyPulseTiles } from '@/components/reports/panels/WeeklyPulseTiles';
+
+function pulse(over: Partial<WeeklyPulse> = {}): WeeklyPulse {
+  return {
+    start: '2026-06-24',
+    end: '2026-06-30',
+    baseline_weeks: 4,
+    baseline_covered: true,
+    baseline_missing_days: [],
+    metrics: {
+      games_started: { current: 3250, baseline: 4359, delta_pct: -25.4 },
+      distinct_players: { current: 115, baseline: 341.8, delta_pct: -66.3 },
+    },
+    ...over,
+  };
+}
+
+describe('weeklyPulseTiles', () => {
+  it('shows the week against what a week usually looks like', () => {
+    render(<WeeklyPulseTiles pulse={pulse()} />);
+
+    expect(screen.getByText('3,250')).toBeInTheDocument();
+    expect(screen.getByText('-25.4%')).toBeInTheDocument();
+    expect(screen.getByText('vs 4,359 usual')).toBeInTheDocument();
+  });
+
+  it('says today is left out, because that is why the number can be trusted', () => {
+    // The daily pulse has to scale its baseline by how much of the day has
+    // elapsed. A window of finished days needs no such correction, and that is
+    // half the reason this leads.
+    render(<WeeklyPulseTiles pulse={pulse()} />);
+
+    expect(screen.getByText(/Today is deliberately left out/)).toBeInTheDocument();
+  });
+
+  it('withholds the comparison rather than averaging over uncomputed days', () => {
+    // Averaging over days the rollup never ran divides real activity by four and
+    // calls the result typical — it once produced "+100% vs usual" from nothing.
+    render(
+      <WeeklyPulseTiles
+        pulse={pulse({
+          baseline_covered: false,
+          baseline_missing_days: ['2026-06-10'],
+          metrics: {
+            games_started: { current: 3250, baseline: null, delta_pct: null },
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByText('no baseline')).toBeInTheDocument();
+    expect(screen.getByText(/withheld rather than averaged over gaps/)).toBeInTheDocument();
+  });
+
+  it('says "level" rather than 0%, which reads as a measurement of nothing', () => {
+    render(
+      <WeeklyPulseTiles
+        pulse={pulse({
+          metrics: { games_started: { current: 3250, baseline: 3250, delta_pct: 0 } },
+        })}
+      />,
+    );
+
+    expect(screen.getByText('level')).toBeInTheDocument();
+  });
+
+  it('names the window it covers and how far back it compares', () => {
+    render(<WeeklyPulseTiles pulse={pulse()} />);
+
+    expect(screen.getByText(/2026-06-24 to 2026-06-30/)).toBeInTheDocument();
+    expect(screen.getByText(/mean of the 4 weeks before/)).toBeInTheDocument();
+  });
+});

--- a/components/reports/panels/AnomalyPanel.tsx
+++ b/components/reports/panels/AnomalyPanel.tsx
@@ -33,7 +33,7 @@ export function AnomalyPanel({ data, meta }: { data: AnomaliesResponse; meta: Ga
             </p>
             <p className="text-sm text-muted-foreground">
               {coverage.complete
-                ? `No game moved more than ${thresholds.min_change_pct}% against the previous ${data.window_days} days, above ${thresholds.min_volume} sessions.`
+                ? `Nothing moved further than these metrics move on their own, against the previous ${data.window_days} days. The bar is ${thresholds.sigma} standard deviations and at least ${thresholds.min_change_pct}%, on at least ${thresholds.min_volume} sessions — so it rises as a game gets smaller, because a small game's numbers wander further by themselves.`
                 : `${coverage.missing_days.length} day(s) in this comparison were never computed, so a quiet result here can't be trusted. Run the reporting backfill.`}
             </p>
           </div>
@@ -58,7 +58,7 @@ export function AnomalyPanel({ data, meta }: { data: AnomaliesResponse; meta: Ga
           {data.compared_with.start}
           {' → '}
           {data.compared_with.end}
-          {`. Only moves over ${thresholds.min_change_pct}% on at least ${thresholds.min_volume} sessions are listed — smaller swings are ordinary variation.`}
+          {`. A move is listed when it is at least ${thresholds.sigma} standard deviations outside ordinary variation AND over ${thresholds.min_change_pct}% — so the bar rises as a game gets smaller, because a small game's numbers wander further on their own.`}
           {!coverage.complete && ' Some days in this comparison were never computed, so this list may be incomplete.'}
         </CardDescription>
       </CardHeader>
@@ -89,6 +89,15 @@ export function AnomalyPanel({ data, meta }: { data: AnomaliesResponse; meta: Ga
               <div className="min-w-0 flex-1">
                 <p className="font-medium text-foreground">{finding.headline}</p>
                 <p className="text-sm text-muted-foreground">{finding.detail}</p>
+                {/* What the bar was, in the units the reader already has. The
+                    percentage alone cannot say why a +28% neighbour is absent,
+                    and a panel that cannot explain an omission gets read as
+                    broken. */}
+                {finding.required_pct !== null && (
+                  <p className="mt-0.5 text-xs text-muted-foreground/80">
+                    {`${finding.z_score}σ — a move of ${finding.required_pct}% would have been the bar at this volume`}
+                  </p>
+                )}
               </div>
               {finding.game_type && (
                 <div className="flex items-center gap-2">

--- a/components/reports/panels/AnomalyPanel.tsx
+++ b/components/reports/panels/AnomalyPanel.tsx
@@ -93,7 +93,10 @@ export function AnomalyPanel({ data, meta }: { data: AnomaliesResponse; meta: Ga
                     percentage alone cannot say why a +28% neighbour is absent,
                     and a panel that cannot explain an omission gets read as
                     broken. */}
-                {finding.required_pct !== null && (
+                {/* Both, not just the bar: `z_score` is null on rate findings,
+                    and gating on `required_pct` alone rendered "nullσ"
+                    (Copilot on #124). */}
+                {finding.required_pct !== null && finding.z_score !== null && (
                   <p className="mt-0.5 text-xs text-muted-foreground/80">
                     {`${finding.z_score}σ — a move of ${finding.required_pct}% would have been the bar at this volume`}
                   </p>

--- a/components/reports/panels/WeeklyPulseTiles.tsx
+++ b/components/reports/panels/WeeklyPulseTiles.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import type { WeeklyPulse } from '@/types/reports';
+import { MetricInfo } from '@/components/reports/primitives/MetricInfo';
+import { cn } from '@/lib/utils';
+
+/**
+ * The pulse at the scale the platform actually supports.
+ *
+ * Leads over the daily tiles because a day is not a meaningful sample here: at
+ * 36 players on a game, one day moves by four people and reads as a 30% swing.
+ * The daily pulse is still below — "what happened today" is a real question,
+ * just not the one to open with.
+ *
+ * Complete days only, which removes a doubt the daily figure cannot: that one
+ * has to scale its baseline by how much of today has elapsed, and every number
+ * on it is therefore partial until midnight.
+ */
+
+const LABELS: Record<string, string> = {
+  games_started: 'Games started',
+  games_finished: 'Games finished',
+  distinct_players: 'Players',
+  mp_player_sessions: 'Multiplayer sessions',
+};
+
+function Delta({ value }: { value: number | null }) {
+  if (value === null) {
+    return (
+      <span className="text-xs text-muted-foreground/70" title="Not every day in the baseline was computed, so there is nothing to compare against">
+        no baseline
+      </span>
+    );
+  }
+  const flat = Math.abs(value) < 0.05;
+  return (
+    <span
+      className={cn(
+        'text-xs font-medium',
+        flat
+          ? 'text-muted-foreground'
+          : value > 0
+            ? 'text-emerald-600 dark:text-emerald-400'
+            : 'text-red-600 dark:text-red-400',
+      )}
+    >
+      {flat ? 'level' : `${value > 0 ? '+' : ''}${value}%`}
+    </span>
+  );
+}
+
+export function WeeklyPulseTiles({ pulse }: { pulse: WeeklyPulse }) {
+  return (
+    <section aria-label="This week">
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+        {Object.entries(pulse.metrics).map(([metric, values]) => (
+          <div key={metric} className="rounded-lg border bg-card p-3">
+            <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              {LABELS[metric] ?? metric}
+              <MetricInfo metric={metric} />
+            </p>
+            <p className="mt-1 text-2xl font-semibold tabular-nums">
+              {values.current.toLocaleString()}
+            </p>
+            <p className="mt-0.5 flex items-baseline gap-1.5">
+              <Delta value={values.delta_pct} />
+              {values.baseline !== null && (
+                <span className="text-xs text-muted-foreground">
+                  {`vs ${values.baseline.toLocaleString()} usual`}
+                </span>
+              )}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      <p className="mt-2 text-center text-xs text-muted-foreground">
+        {`${pulse.start} to ${pulse.end} — seven finished days, against the mean of the ${pulse.baseline_weeks} weeks before. `}
+        {pulse.baseline_covered
+          ? 'Today is deliberately left out: it is not over.'
+          // Not a silent zero. Averaging over days the rollup never computed
+          // divides real activity by four and calls the result typical.
+          : 'Some days in the baseline were never computed, so the comparison is withheld rather than averaged over gaps.'}
+      </p>
+    </section>
+  );
+}

--- a/components/reports/panels/WeeklyPulseTiles.tsx
+++ b/components/reports/panels/WeeklyPulseTiles.tsx
@@ -17,12 +17,18 @@ import { cn } from '@/lib/utils';
  * on it is therefore partial until midnight.
  */
 
-const LABELS: Record<string, string> = {
-  games_started: 'Games started',
-  games_finished: 'Games finished',
-  distinct_players: 'Players',
-  mp_player_sessions: 'Multiplayer sessions',
-};
+/**
+ * The tiles, in the order they are read — not in whatever order the API happens
+ * to serialise its keys (Copilot on #124). `PulseTiles` already does this;
+ * iterating `Object.entries` here meant a backend key reordering silently
+ * reordered the UI.
+ */
+const TILES: { metric: string; label: string }[] = [
+  { metric: 'games_started', label: 'Games started' },
+  { metric: 'games_finished', label: 'Games finished' },
+  { metric: 'distinct_players', label: 'Players' },
+  { metric: 'mp_player_sessions', label: 'Multiplayer sessions' },
+];
 
 function Delta({ value }: { value: number | null }) {
   if (value === null) {
@@ -53,25 +59,28 @@ export function WeeklyPulseTiles({ pulse }: { pulse: WeeklyPulse }) {
   return (
     <section aria-label="This week">
       <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
-        {Object.entries(pulse.metrics).map(([metric, values]) => (
-          <div key={metric} className="rounded-lg border bg-card p-3">
-            <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
-              {LABELS[metric] ?? metric}
-              <MetricInfo metric={metric} />
-            </p>
-            <p className="mt-1 text-2xl font-semibold tabular-nums">
-              {values.current.toLocaleString()}
-            </p>
-            <p className="mt-0.5 flex items-baseline gap-1.5">
-              <Delta value={values.delta_pct} />
-              {values.baseline !== null && (
-                <span className="text-xs text-muted-foreground">
-                  {`vs ${values.baseline.toLocaleString()} usual`}
-                </span>
-              )}
-            </p>
-          </div>
-        ))}
+        {TILES.filter(tile => pulse.metrics[tile.metric]).map(({ metric, label }) => {
+          const values = pulse.metrics[metric];
+          return (
+            <div key={metric} className="rounded-lg border bg-card p-3">
+              <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                {label}
+                <MetricInfo metric={metric} />
+              </p>
+              <p className="mt-1 text-2xl font-semibold tabular-nums">
+                {values.current.toLocaleString()}
+              </p>
+              <p className="mt-0.5 flex items-baseline gap-1.5">
+                <Delta value={values.delta_pct} />
+                {values.baseline !== null && (
+                  <span className="text-xs text-muted-foreground">
+                    {`vs ${values.baseline.toLocaleString()} usual`}
+                  </span>
+                )}
+              </p>
+            </div>
+          );
+        })}
       </div>
 
       <p className="mt-2 text-center text-xs text-muted-foreground">

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -110,6 +110,8 @@ export type SummaryResponse = {
   pulse: Pulse;
   /** False when the range doesn't end today — the pulse describes today only. */
   pulse_applies: boolean;
+  /** The same question at the scale the platform supports. Leads over `pulse`. */
+  weekly_pulse: WeeklyPulse;
   comparison: PeriodComparison;
   window_totals: ActivityMetrics;
   by_game: GameTotals[];
@@ -579,6 +581,18 @@ export type AnomalyFinding = {
   severity: 'high' | 'medium';
   headline: string;
   detail: string;
+  /**
+   * How many standard deviations the move sits outside ordinary noise at this
+   * volume. `null` on rate findings, which have no Poisson difference to take.
+   */
+  z_score: number | null;
+  /**
+   * The smallest percentage move that would have been notable AT THIS VOLUME —
+   * 71% at 36 sessions, 9.5% at 2,000. Carried for the non-findings as much as
+   * the findings: without it, a reader seeing +28% missing from the panel
+   * concludes the panel is broken.
+   */
+  required_pct: number | null;
 };
 
 export type AnomaliesResponse = {
@@ -589,6 +603,8 @@ export type AnomaliesResponse = {
     min_volume: number;
     min_change_pct: number;
     severe_change_pct: number;
+    /** The test that actually decides. `min_change_pct` is only a floor. */
+    sigma: number;
   };
   /** Lets an empty list mean "nothing moved" rather than "we couldn't tell". */
   coverage: { complete: boolean; missing_days: string[] };
@@ -828,3 +844,23 @@ export type FallbacksResponse = {
   total_fallbacks: number;
   total_unstamped: number;
 } & ResolvedRange;
+
+/**
+ * The last seven complete days against the four weeks before them.
+ *
+ * Leads over the daily pulse because a day is not a meaningful sample at this
+ * volume. `baseline` is null when any day in the comparison was never computed —
+ * averaging over gaps divides real activity by four and calls it typical.
+ */
+export type WeeklyPulse = {
+  start: string;
+  end: string;
+  baseline_weeks: number;
+  baseline_covered: boolean;
+  baseline_missing_days: string[];
+  metrics: Record<string, {
+    current: number;
+    baseline: number | null;
+    delta_pct: number | null;
+  }>;
+};

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -110,8 +110,16 @@ export type SummaryResponse = {
   pulse: Pulse;
   /** False when the range doesn't end today — the pulse describes today only. */
   pulse_applies: boolean;
-  /** The same question at the scale the platform supports. Leads over `pulse`. */
-  weekly_pulse: WeeklyPulse;
+  /**
+   * The same question at the scale the platform supports. Leads over `pulse`.
+   *
+   * OPTIONAL because the backend that sends it may not be deployed yet
+   * (Copilot on #124). The two repositories ship independently, so for the
+   * window between them this field is simply absent — and a required type plus
+   * an unconditional render is a crash on the reports page, not a missing
+   * panel. Every field added since has been optional for the same reason.
+   */
+  weekly_pulse?: WeeklyPulse;
   comparison: PeriodComparison;
   window_totals: ActivityMetrics;
   by_game: GameTotals[];


### PR DESCRIPTION
FE half of **R8** (backend: FootballExtraTime/App#1482). Stacked on #123 — the base retargets as the stack merges.

## Weekly tiles lead the overview

A day isn't a meaningful sample here: 36 players on a game means one day moves by four people and reads as a 30% swing. The daily pulse stays directly underneath rather than going — "what happened today" is a real question, just not the one to open with.

The weekly tiles cover seven **finished** days, and the caption says so. That's half the reason they lead: the daily pulse has to scale its baseline by how much of today has elapsed, so every number on it is partial until midnight. This one needs no such correction.

## The anomaly panel now explains its omissions

Each finding carries its sigma and the move that *would* have been the bar at that volume — "3.4σ, a move of 20% would have been the bar here".

That line exists for the findings that are **absent** more than the ones present. Seeing +28% missing from the panel without it, a reader concludes the panel is broken rather than that 28% is what a game that size does on a quiet week. The empty state and description name the sigma bar alongside the percentage floor for the same reason.

## Three things the tiles refuse to draw

Each mutation-tested.

**A withheld baseline reads "no baseline", not 0%.** Averaging over days the rollup never computed divides real activity by four and calls the result typical; a zero delta claims it was measured and found equal.

**An unchanged week reads "level", not 0%.** A bare 0% reads as a measurement of nothing rather than a week that held steady.

**The uncomputed-days note stays** when the baseline is short, so a missing comparison is never mistaken for a quiet week.

## One existing test extended, not replaced

The panel still has to name what it filtered — "nothing unusual" is unfalsifiable otherwise — and now names the sigma bar too, since the percentage alone reads as exactly the flat rule this change removes.

560 tests, lint clean, types OK, build compiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)