### PR TITLE
Keep the platform panel showing the platform

### DIFF
--- a/app/reports/page.tsx
+++ b/app/reports/page.tsx
@@ -62,7 +62,12 @@ export default function ReportsPage() {
   const activity = useReport(ReportsAPI.getActivity, activityParams, enabled, 'The reporting activity endpoint');
   // Only for the new-vs-returning panel, lifted here when the Patterns page was
   // removed. Its own panel, so a slow patterns request cannot blank the pulse.
-  const patterns = useReport(ReportsAPI.getPatterns, params, enabled, 'The patterns reporting endpoint');
+  // UNFILTERED on purpose (Copilot on #117). The panel's own copy makes a
+  // platform claim — "all returning means growth has stalled" — and narrowing it
+  // to one game silently turns that into a claim about that game, with the copy
+  // still saying otherwise. Everything else on the page follows the selection;
+  // this is the one panel whose meaning changes if it does.
+  const patterns = useReport(ReportsAPI.getPatterns, allGamesParams, enabled, 'The patterns reporting endpoint');
   // Unfiltered on purpose: "what needs attention" must surface a game you
   // haven't selected, which is exactly the one you'd otherwise miss.
 

--- a/components/reports/__tests__/NewVsReturning.test.tsx
+++ b/components/reports/__tests__/NewVsReturning.test.tsx
@@ -1,0 +1,39 @@
+import type { NewReturningRow } from '@/types/reports';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { NewVsReturning } from '@/components/reports/NewVsReturning';
+
+// recharts measures its container and jsdom reports zero, so the SVG never
+// renders. What is worth asserting here is the branch above it — chart or empty
+// state — which is exactly what the component decides.
+vi.mock('recharts', async () => {
+  const actual = await vi.importActual<typeof import('recharts')>('recharts');
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+      <div style={{ width: 800, height: 300 }}>{children}</div>
+    ),
+  };
+});
+
+const ROWS: NewReturningRow[] = [
+  { date: '2026-06-01', new_players: 12, returning_players: 40 },
+  { date: '2026-06-02', new_players: 9, returning_players: 44 },
+];
+
+describe('newVsReturning', () => {
+  it('says what the two bands mean, since neither is readable alone', () => {
+    render(<NewVsReturning rows={ROWS} />);
+
+    expect(screen.getByText('New vs returning players')).toBeInTheDocument();
+    expect(screen.getByText(/all returning means growth has stalled/)).toBeInTheDocument();
+  });
+
+  it('shows an empty state rather than an axis with nothing on it', () => {
+    // A bare chart frame reads as "zero players", which is a measurement. No
+    // rows is the absence of one.
+    render(<NewVsReturning rows={[]} />);
+
+    expect(screen.getByText('No player activity in this window.')).toBeInTheDocument();
+  });
+});

--- a/components/reports/__tests__/NewVsReturning.test.tsx
+++ b/components/reports/__tests__/NewVsReturning.test.tsx
@@ -17,8 +17,8 @@ vi.mock('recharts', async () => {
 });
 
 const ROWS: NewReturningRow[] = [
-  { date: '2026-06-01', new_players: 12, returning_players: 40 },
-  { date: '2026-06-02', new_players: 9, returning_players: 44 },
+  { date: '2026-06-01', new_players: 12, returning_players: 40, total_players: 52 },
+  { date: '2026-06-02', new_players: 9, returning_players: 44, total_players: 53 },
 ];
 
 describe('newVsReturning', () => {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -11,7 +11,7 @@ const nextConfig = {
       { source: '/reports/unfinished', destination: '/reports/games', permanent: true },
       { source: '/reports/favourites', destination: '/reports/games', permanent: true },
       // Patterns is gone rather than folded: play-by-hour is noise at this
-      // volume. Its one useful panel, new vs returning, is on the overview.
+      // volume. It's one useful panel, new vs returning, is on the overview.
       { source: '/reports/patterns', destination: '/reports', permanent: true },
     ];
   },


### PR DESCRIPTION
Copilot's findings on #117, applied after that PR merged without them — the pre-commit hook rejected my first attempt (it caught a real type error in the new fixture) and the push carried the unfixed tree. My fault for not re-running `check-types` after adding the test file.

**New-vs-returning now takes the unfiltered params.** Its own copy makes a platform claim — *"all returning means growth has stalled"* — and selecting a game silently turned that into a claim about one game while the copy went on saying otherwise. Everything else on the overview follows the selection; this is the one panel whose meaning changes if it does.

**Added the test coverage it should have shipped with**: the two bands are named, and no rows renders the empty state rather than an axis with nothing on it.

And `Its` where it meant `it is`.

512 tests, types OK, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)