### PR TITLE
Give Analytics its own section

### DIFF
--- a/app/analytics/career-path/page.tsx
+++ b/app/analytics/career-path/page.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import type { RangeState } from '@/lib/report-range';
+import { useMemo } from 'react';
+import { DifficultyTiers } from '@/components/analytics/panels/DifficultyTiers';
+import { FootballerContent } from '@/components/analytics/panels/FootballerContent';
+import { AnalyticsShell } from '@/components/analytics/shell/AnalyticsShell';
+import { FilterBar } from '@/components/reports/filters/FilterBar';
+import { RangePicker } from '@/components/reports/filters/RangePicker';
+import { ReportPanel } from '@/components/reports/primitives/ReportPanel';
+import { SectionHeader } from '@/components/reports/primitives/SectionHeader';
+import { useReport } from '@/hooks/use-report';
+import { useReportFilters } from '@/hooks/use-report-filters';
+import { useAuth } from '@/lib/auth';
+import { rangeToParams } from '@/lib/report-range';
+import { ReportsAPI } from '@/lib/reports-api';
+
+/**
+ * Career Path content quality — the first dashboard out of the Django admin.
+ *
+ * It shares the reporting section's primitives and filter bar deliberately, and
+ * its own section deliberately. The pieces are the same because a table is a
+ * table; the section is separate because the question is different. Reports ask
+ * how players are behaving and are read by whoever decides what to build.
+ * Analytics ask whether the material is any good and are read by whoever writes
+ * it, while they are writing it.
+ *
+ * No game filter: this page IS one game, and the endpoint rejects the parameter
+ * rather than echoing one it cannot apply. The bots toggle IS here and matters
+ * more than anywhere else — dummy accounts are the majority of Career Path play,
+ * so leaving them in makes an editor read a bot's guesses as a verdict on their
+ * own work.
+ */
+export default function CareerPathAnalyticsPage() {
+  const { isAuthenticated, user } = useAuth();
+  const enabled = isAuthenticated && !!(user?.is_staff || user?.is_superuser);
+
+  // 90 days, not the usual 30: a footballer needs 20 appearances before its
+  // rate is stated, and at this volume a month leaves most of the catalogue
+  // below that line and the table mostly withheld.
+  const { filters, update } = useReportFilters({
+    range: { window: 90 },
+    includeBots: false,
+    game: null,
+    metric: 'games_started',
+  });
+  const { range, includeBots } = filters;
+  const setRange = (next: RangeState) => update({ range: next });
+  const setIncludeBots = (next: boolean) => update({ includeBots: next });
+  const params = useMemo(
+    () => ({ ...rangeToParams(range), include_bots: includeBots }),
+    [range, includeBots],
+  );
+
+  const state = useReport(
+    ReportsAPI.getCareerPathAnalytics,
+    params,
+    enabled,
+    'The Career Path analytics endpoint',
+  );
+
+  return (
+    <AnalyticsShell
+      title="Career Path content"
+      description="Which footballers are too hard, which are merely common, and whether the grading means anything."
+    >
+      <FilterBar>
+        <RangePicker
+          value={range}
+          onChange={setRange}
+          includeBots={includeBots}
+          onIncludeBotsChange={setIncludeBots}
+        />
+      </FilterBar>
+
+      <ReportPanel state={state} skeletonClassName="h-96 w-full">
+        {data => <FootballerContent data={data} />}
+      </ReportPanel>
+
+      {/* After the table, because "which footballer should I look at" is the
+          question someone arrives with, and this answers the one they leave
+          with: whether the tiers those footballers are graded into mean
+          anything in the first place. */}
+      <SectionHeader
+        title="Whether the tiers hold up"
+        description="A grading that does not track what players actually do is decoration."
+      />
+
+      <ReportPanel state={state} skeletonClassName="h-64 w-full">
+        {data => <DifficultyTiers data={data} />}
+      </ReportPanel>
+    </AnalyticsShell>
+  );
+}

--- a/components/analytics/__tests__/CareerPathAnalytics.test.tsx
+++ b/components/analytics/__tests__/CareerPathAnalytics.test.tsx
@@ -1,0 +1,147 @@
+import type { CareerPathAnalyticsResponse, CareerPathFootballerRow } from '@/types/reports';
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { DifficultyTiers } from '@/components/analytics/panels/DifficultyTiers';
+import { FootballerContent } from '@/components/analytics/panels/FootballerContent';
+
+function footballer(over: Partial<CareerPathFootballerRow> & Pick<CareerPathFootballerRow, 'name'>): CareerPathFootballerRow {
+  return {
+    footballer_id: 1,
+    declared_difficulty: 'NORMAL',
+    appearances: 100,
+    hints: 4,
+    reveals: 1,
+    skips: 2,
+    help_rate_pct: 7,
+    solve_rate_pct: 44,
+    below_threshold: false,
+    ...over,
+  };
+}
+
+function response(over: Partial<CareerPathAnalyticsResponse> = {}): CareerPathAnalyticsResponse {
+  return {
+    start: '2026-05-01',
+    end: '2026-07-30',
+    days: 90,
+    window: 90,
+    game_type: null,
+    include_bots: false,
+    content: {
+      rows: [footballer({ name: 'Rui Pedro' })],
+      min_appearances: 20,
+      footballers_measured: 1046,
+      footballers_seen: 6364,
+    },
+    shape: {
+      modes: [{ mode: 'SINGLE', paths: 46279 }, { mode: 'LADDER', paths: 12722 }],
+      total_paths: 65765,
+      difficulty: [
+        { difficulty: 'EXTREME', appearances: 52479, solve_rate_pct: 15.9, help_rate_pct: 0.3 },
+        { difficulty: 'EASY', appearances: 158706, solve_rate_pct: 37.5, help_rate_pct: 0.8 },
+        { difficulty: 'NORMAL', appearances: 153443, solve_rate_pct: 25.5, help_rate_pct: 0.6 },
+      ],
+      total_appearances: 364628,
+      footballers_per_path: 3.3,
+      hint_effect: {
+        hinted_guesses: 3653,
+        hinted_solve_pct: 35.3,
+        unhinted_guesses: 102412,
+        unhinted_solve_pct: 43.3,
+      },
+    },
+    ...over,
+  } satisfies CareerPathAnalyticsResponse;
+}
+
+describe('footballerContent', () => {
+  it('leads with the rate, not the raw help count', () => {
+    // The dashboard this replaces ranked by count, which puts the most COMMON
+    // footballers on top and never surfaces a broken one shown twelve times.
+    render(<FootballerContent data={response()} />);
+    const cells = within(screen.getAllByRole('row')[1]).getAllByRole('cell');
+
+    expect(cells[2]).toHaveTextContent('7%');
+  });
+
+  it('shows the editor their own grading beside what players did', () => {
+    render(<FootballerContent data={response()} />);
+
+    expect(screen.getByText('graded normal')).toBeInTheDocument();
+    expect(screen.getByText('44%')).toBeInTheDocument();
+  });
+
+  it('withholds a rate below the threshold and keeps the counts', () => {
+    render(
+      <FootballerContent
+        data={response({
+          content: {
+            rows: [footballer({ name: 'Rare', appearances: 3, hints: 2, help_rate_pct: null, solve_rate_pct: null, below_threshold: true })],
+            min_appearances: 20,
+            footballers_measured: 0,
+            footballers_seen: 1,
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByText('— 3 appearances, needs 20')).toBeInTheDocument();
+
+    // The counts survive the withheld rate: "shown 3 times, hinted twice" is a
+    // fact, and it is how you tell a footballer nobody sees from a fine one.
+    const cells = within(screen.getAllByRole('row')[1]).getAllByRole('cell');
+
+    expect(cells[1]).toHaveTextContent('3');
+    expect(cells[4]).toHaveTextContent('2');
+  });
+
+  it('says how many footballers were rated against how many were seen', () => {
+    // The gap between them is the answer to "why is the one I want missing".
+    render(<FootballerContent data={response()} />);
+
+    expect(screen.getByText('1,046')).toBeInTheDocument();
+    expect(screen.getByText('6,364')).toBeInTheDocument();
+  });
+});
+
+describe('difficultyTiers', () => {
+  it('orders the tiers by the scale, not the alphabet', () => {
+    // A–Z puts EXTREME first and NORMAL last, which reads as a ranking by
+    // outcome rather than by difficulty.
+    render(<DifficultyTiers data={response()} />);
+    const rows = screen.getAllByRole('row').slice(1, 4);
+    const tiers = rows.map(row => within(row).getAllByRole('cell')[0].textContent?.trim());
+
+    expect(tiers).toEqual(['EASY', 'NORMAL', 'EXTREME']);
+  });
+
+  it('states the hint comparison is not a fair one', () => {
+    // Without this the panel reads "hints make players worse", which is the
+    // opposite of what the data supports.
+    render(<DifficultyTiers data={response()} />);
+
+    expect(screen.getByText(/Not a fair comparison/)).toBeInTheDocument();
+    expect(screen.getByText(/35.3% of the time, against 43.3%/)).toBeInTheDocument();
+  });
+
+  it('says nothing about hints when none were taken', () => {
+    render(
+      <DifficultyTiers
+        data={response({
+          shape: {
+            ...response().shape,
+            hint_effect: { hinted_guesses: 0, hinted_solve_pct: null, unhinted_guesses: 10, unhinted_solve_pct: 50 },
+          },
+        })}
+      />,
+    );
+
+    expect(screen.queryByText(/Not a fair comparison/)).not.toBeInTheDocument();
+  });
+
+  it('keeps the footballers-per-path figure, which is why the old numbers were wrong', () => {
+    render(<DifficultyTiers data={response()} />);
+
+    expect(screen.getByText(/3.3 footballers per path/)).toBeInTheDocument();
+  });
+});

--- a/components/analytics/panels/DifficultyTiers.tsx
+++ b/components/analytics/panels/DifficultyTiers.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import type { CareerPathAnalyticsResponse } from '@/types/reports';
+import { EmptyState } from '@/components/reports/primitives/EmptyState';
+import { MetricInfo } from '@/components/reports/primitives/MetricInfo';
+import { ReportHead, ReportRow, ReportTable, Td, Th } from '@/components/reports/primitives/ReportTable';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+/**
+ * Whether the editorial grading means anything.
+ *
+ * The only way to ask it: put each declared tier next to what players actually
+ * did on it. If EXTREME footballers solve at the same rate as EASY ones, the
+ * grading is decoration.
+ */
+
+/** The scale's own order. Alphabetically EXTREME leads and NORMAL ends. */
+const TIER_ORDER = ['EASY', 'NORMAL', 'HARD', 'EXTREME'];
+
+function tierRank(difficulty: string | null): number {
+  const index = difficulty === null ? -1 : TIER_ORDER.indexOf(difficulty);
+  return index === -1 ? TIER_ORDER.length : index;
+}
+
+export function DifficultyTiers({ data }: { data: CareerPathAnalyticsResponse }) {
+  const tiers = [...data.shape.difficulty].sort((a, b) => tierRank(a.difficulty) - tierRank(b.difficulty));
+  const modes = data.shape.modes;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          Does the grading hold up
+          <MetricInfo metric="declared_difficulty" />
+        </CardTitle>
+        <CardDescription>
+          Each tier an editor assigned, beside what players did on it. Ordered by
+          the scale rather than alphabetically — sorted A–Z, EXTREME leads and
+          NORMAL ends, which reads as a ranking by outcome.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6 overflow-x-auto">
+        {tiers.length === 0
+          ? <EmptyState hint="Try a wider date range.">No footballers were served in this window.</EmptyState>
+          : (
+              <ReportTable>
+                <ReportHead>
+                  <Th>Graded</Th>
+                  <Th align="right">Times shown</Th>
+                  <Th align="right" title="Should fall as the tier gets harder">Solved</Th>
+                  <Th align="right" title="Does not rise with difficulty — players take LESS help on harder footballers">Needed help</Th>
+                </ReportHead>
+                <tbody>
+                  {tiers.map(tier => (
+                    <ReportRow key={String(tier.difficulty)}>
+                      <Td strong>
+                        {tier.difficulty ?? <span className="text-muted-foreground">Not graded</span>}
+                      </Td>
+                      <Td align="right">{tier.appearances.toLocaleString()}</Td>
+                      <Td align="right" strong>
+                        {tier.solve_rate_pct === null ? '—' : `${tier.solve_rate_pct}%`}
+                      </Td>
+                      <Td align="right" className="text-muted-foreground">
+                        {tier.help_rate_pct === null ? '—' : `${tier.help_rate_pct}%`}
+                      </Td>
+                    </ReportRow>
+                  ))}
+                </tbody>
+              </ReportTable>
+            )}
+
+        {/* Reported with its confound stated, because the naive reading is
+            actively wrong: players take hints on the footballers they are
+            ALREADY stuck on, so a lower hinted rate does not mean hints make
+            people worse. What survives is the absolute number — a hinted guess
+            is still wrong about two thirds of the time, so the hints are not
+            rescuing hard content. */}
+        {data.shape.hint_effect.hinted_guesses > 0 && (
+          <div className="space-y-1.5 border-t pt-4">
+            <p className="flex items-center gap-2 text-sm font-medium">
+              Does a hint help
+              <MetricInfo metric="hint_effect" />
+            </p>
+            <p className="text-sm">
+              {`Guesses made after a hint are right ${data.shape.hint_effect.hinted_solve_pct}% of the time, against ${data.shape.hint_effect.unhinted_solve_pct}% without one.`}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Not a fair comparison — a hint is taken on the footballers someone is
+              already stuck on, so the hinted set is harder to begin with. Read the
+              first number on its own: a hinted guess is still wrong most of the time.
+            </p>
+          </div>
+        )}
+
+        {modes.length > 0 && (
+          <div className="space-y-2 border-t pt-4">
+            <p className="text-xs font-medium text-muted-foreground">What was built</p>
+            <dl className="flex flex-wrap gap-x-6 gap-y-1 text-xs">
+              {modes.map(mode => (
+                <div key={mode.mode} className="flex items-baseline gap-1.5">
+                  <dt className="text-muted-foreground">{mode.mode.replaceAll('_', ' ').toLowerCase()}</dt>
+                  <dd className="font-medium tabular-nums">{mode.paths.toLocaleString()}</dd>
+                </div>
+              ))}
+            </dl>
+            {data.shape.footballers_per_path !== null && (
+              // Kept visible on purpose: this number is why the dashboard this
+              // replaces was wrong. It counted one hint once per footballer in
+              // the path, so everything it reported was inflated by roughly
+              // this factor.
+              <p className="text-xs text-muted-foreground">
+                {`${data.shape.footballers_per_path} footballers per path on average, across ${data.shape.total_paths.toLocaleString()} paths.`}
+              </p>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/analytics/panels/FootballerContent.tsx
+++ b/components/analytics/panels/FootballerContent.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import type { CareerPathAnalyticsResponse } from '@/types/reports';
+import { EmptyState } from '@/components/reports/primitives/EmptyState';
+import { MetricInfo } from '@/components/reports/primitives/MetricInfo';
+import { MetricRow } from '@/components/reports/primitives/MetricRow';
+import { ReportHead, ReportRow, ReportTable, Td, Th } from '@/components/reports/primitives/ReportTable';
+import { SmallSampleNotice } from '@/components/reports/primitives/SmallSampleNotice';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+/**
+ * Which footballers need help, as a rate rather than a count.
+ *
+ * The admin dashboard this replaces ranked by raw hint count, which puts the
+ * most COMMON footballers on top and never surfaces a genuinely broken one that
+ * is shown twelve times. The list that exists to find bad content hid it.
+ */
+
+/** Above this share needing help, a footballer is worth an editor's attention. */
+const NOTABLE_HELP_PCT = 10;
+
+function Rate({ value }: { value: number | null }) {
+  if (value === null) {
+    return <span className="text-muted-foreground/70">—</span>;
+  }
+  return <>{`${value}%`}</>;
+}
+
+export function FootballerContent({ data }: { data: CareerPathAnalyticsResponse }) {
+  const { rows, min_appearances: minAppearances, footballers_measured: measured, footballers_seen: seen } = data.content;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          Which footballers need help
+          <MetricInfo metric="help_rate" />
+        </CardTitle>
+        <CardDescription>
+          A rate, not a count. A footballer shown 200 times and hinted on 10 is
+          fine; one shown 12 times and hinted on 10 is broken — and a list ranked
+          by count puts the first at the top and never shows the second.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4 overflow-x-auto">
+        <MetricRow
+          columns={3}
+          metrics={[
+            { label: 'Footballers rated', value: measured.toLocaleString(), metric: 'help_rate' },
+            // Both numbers, because the gap between them is the answer to "why
+            // is the one I am looking for missing".
+            { label: 'Seen at all', value: seen.toLocaleString() },
+            { label: 'Rate needs', value: `${minAppearances} appearances` },
+          ]}
+        />
+
+        {rows.length === 0
+          ? (
+              <EmptyState hint="Try a wider date range.">
+                No career paths were built in this window.
+              </EmptyState>
+            )
+          : (
+              <ReportTable>
+                <ReportHead>
+                  <Th>Footballer</Th>
+                  <Th align="right" title="Times this footballer appeared in a career path">Shown</Th>
+                  <Th align="right" title="Share of appearances where the player took a hint, reveal or skip">Needed help</Th>
+                  <Th align="right" title="Share of appearances guessed correctly">Solved</Th>
+                  <Th align="right">Hints</Th>
+                  <Th align="right">Reveals</Th>
+                  <Th align="right">Skips</Th>
+                </ReportHead>
+                <tbody>
+                  {rows.map(row => (
+                    <ReportRow key={row.footballer_id}>
+                      <Td strong>
+                        {row.name}
+                        {row.declared_difficulty && (
+                          // The editor's own grading, beside what players did
+                          // with it. A footballer graded EXTREME that everyone
+                          // solves is mis-graded one way; one graded EASY that
+                          // nobody solves is mis-graded the other, and both are
+                          // editorial work rather than a bug.
+                          <span className="mt-0.5 block text-xs font-normal text-muted-foreground">
+                            {`graded ${row.declared_difficulty.toLowerCase()}`}
+                          </span>
+                        )}
+                      </Td>
+                      <Td align="right">{row.appearances.toLocaleString()}</Td>
+                      <Td
+                        align="right"
+                        strong
+                        className={cn(
+                          row.help_rate_pct !== null && row.help_rate_pct >= NOTABLE_HELP_PCT
+                          && 'text-amber-600 dark:text-amber-500',
+                        )}
+                      >
+                        {row.below_threshold
+                          ? <SmallSampleNotice have={row.appearances} need={minAppearances} unit="appearances" />
+                          : <Rate value={row.help_rate_pct} />}
+                      </Td>
+                      <Td align="right"><Rate value={row.solve_rate_pct} /></Td>
+                      <Td align="right" className="text-muted-foreground">{row.hints.toLocaleString()}</Td>
+                      <Td align="right" className="text-muted-foreground">{row.reveals.toLocaleString()}</Td>
+                      <Td align="right" className="text-muted-foreground">{row.skips.toLocaleString()}</Td>
+                    </ReportRow>
+                  ))}
+                </tbody>
+              </ReportTable>
+            )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/analytics/shell/AnalyticsNav.tsx
+++ b/components/analytics/shell/AnalyticsNav.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import type { NavGroup } from '@/components/admin/SectionNav';
+import { Route } from 'lucide-react';
+
+/**
+ * Analytics, which is not Reports and should not be folded into it.
+ *
+ * Reports answer *how are players behaving* — volume, retention, abandonment,
+ * session length. Analytics answer *is the material any good* — which
+ * footballer makes everyone take a hint, which question nobody gets right.
+ * Different question, different reader, different cadence: a report is read
+ * weekly by whoever is deciding what to build, and this is read by whoever is
+ * writing content, when they are writing it.
+ *
+ * One destination today, grouped rather than flat because four more are coming
+ * (App#1475) and a heading that appears later reorganises the section under
+ * someone who had learned where things were.
+ */
+export const ANALYTICS_NAV_GROUPS: NavGroup[] = [
+  {
+    heading: 'Per game',
+    items: [
+      { href: '/analytics/career-path', label: 'Career Path', icon: Route },
+    ],
+  },
+];

--- a/components/analytics/shell/AnalyticsShell.tsx
+++ b/components/analytics/shell/AnalyticsShell.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { SectionShell } from '@/components/admin/SectionShell';
+import { ANALYTICS_NAV_GROUPS } from '@/components/analytics/shell/AnalyticsNav';
+
+/**
+ * Analytics chrome — the same shell Reports uses, with its own nav.
+ *
+ * Shares the staff gate for the same reason it shares the shell: every
+ * /core/analytics/* endpoint is `IsAdminUser`, exactly as the reporting ones
+ * are, and a second gate that could drift from it is worse than one.
+ */
+export function AnalyticsShell({ title, description, actions, children }: {
+  title: string;
+  description: string;
+  actions?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <SectionShell
+      title={title}
+      description={description}
+      groups={ANALYTICS_NAV_GROUPS}
+      actions={actions}
+    >
+      {children}
+    </SectionShell>
+  );
+}

--- a/lib/reports-api.ts
+++ b/lib/reports-api.ts
@@ -2,6 +2,7 @@ import type {
   ActivityResponse,
   AnomaliesResponse,
   AttemptsResponse,
+  CareerPathAnalyticsResponse,
   ContentResponse,
   DifficultyResponse,
   DurationResponse,
@@ -114,6 +115,17 @@ export class ReportsAPI {
    */
   static async getFirstSession(params?: ReportParams): Promise<FirstSessionResponse> {
     return apiFetcher<FirstSessionResponse>(`core/reporting/first-session/${buildQuery(params)}`);
+  }
+
+  /**
+   * GET /core/analytics/career-path/ — content quality, not player behaviour.
+   *
+   * A different surface from the reporting endpoints above and deliberately so:
+   * those answer "how are players behaving", this answers "is the material any
+   * good". Same admin gate and the same range parsing.
+   */
+  static async getCareerPathAnalytics(params?: ReportParams): Promise<CareerPathAnalyticsResponse> {
+    return apiFetcher<CareerPathAnalyticsResponse>(`core/analytics/career-path/${buildQuery(params)}`);
   }
 
   /** GET /core/reporting/content/ — content runway and pool depth. A snapshot. */

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -872,3 +872,64 @@ export type WeeklyPulse = {
     delta_pct: number | null;
   }>;
 };
+
+/**
+ * One footballer's content-quality row from the Career Path analytics endpoint.
+ *
+ * Rates are withheld below `min_appearances` and the counts are kept: a
+ * footballer shown three times and hinted on twice is a fact, and "67% needed
+ * help" from three appearances is noise that would top the table.
+ */
+export type CareerPathFootballerRow = {
+  footballer_id: number;
+  name: string;
+  /** The difficulty an editor assigned. Read against the measured solve rate. */
+  declared_difficulty: string | null;
+  appearances: number;
+  hints: number;
+  reveals: number;
+  skips: number;
+  /** Share of appearances where the player took a hint, reveal or skip. */
+  help_rate_pct: number | null;
+  solve_rate_pct: number | null;
+  below_threshold: boolean;
+};
+
+/** One declared difficulty tier, with what players actually did on it. */
+export type CareerPathTier = {
+  difficulty: string | null;
+  appearances: number;
+  solve_rate_pct: number | null;
+  help_rate_pct: number | null;
+};
+
+export type CareerPathAnalyticsResponse = {
+  content: {
+    rows: CareerPathFootballerRow[];
+    min_appearances: number;
+    footballers_measured: number;
+    footballers_seen: number;
+  };
+  shape: {
+    modes: { mode: string; paths: number }[];
+    total_paths: number;
+    difficulty: CareerPathTier[];
+    total_appearances: number;
+    /** Why the old dashboard's counts were inflated — kept visible on purpose. */
+    footballers_per_path: number | null;
+    /**
+     * Whether a hint rescues the guess it was taken on.
+     *
+     * NOT a controlled comparison: players take hints on the footballers they
+     * are already stuck on, so the hinted set is harder by construction. The
+     * panel says so rather than letting the two rates be read against each
+     * other.
+     */
+    hint_effect: {
+      hinted_guesses: number;
+      hinted_solve_pct: number | null;
+      unhinted_guesses: number;
+      unhinted_solve_pct: number | null;
+    };
+  };
+} & ResolvedRange;


### PR DESCRIPTION
FE half of the first dashboard in https://github.com/FootballExtraTime/App/issues/1475. Career Path content quality at `/analytics/career-path`, in an **Analytics** section rather than inside Reports.

## The sections are separate on purpose

This is the distinction the issue exists to protect:

| | Reports | Analytics |
|---|---|---|
| Question | How are **players** behaving? | Is the **material** any good? |
| Examples | volume, retention, abandonment, session length | which footballer makes everyone take a hint, which question nobody gets right |
| Read by | whoever decides what to build | whoever writes the content, *while* writing it |
| Cadence | weekly | when editing |

They share everything below that line — the same shell, admin gate, filter bar, R9 primitives and glossary. A table is a table. What differs is what the page is *for*.

## The panels

**Which footballers need help, as a rate.** The dashboard this replaces ranked by raw hint count, which puts the most *common* footballers on top and never surfaces a genuinely broken one shown twelve times — the list that exists to find bad content hid it. Rates withheld under 20 appearances, counts kept.

**The editor's own grading beside what players did with it**, so a footballer graded EXTREME that everyone solves is visible as mis-graded.

**Whether the tiers hold up at all** — ordered by the scale rather than alphabetically. A–Z puts EXTREME first and NORMAL last, which reads as a ranking by outcome.

**Whether a hint rescues the guess it was taken on**, with its confound stated *in the panel*. Without that line it reads "hints make players worse", which is the opposite of what the data supports.

## The bots toggle matters more here than anywhere

Dummy accounts are the **majority** of Career Path play (4,316 footballers pass the threshold with them, 1,046 without). Leaving them in makes an editor read a bot's guesses as a verdict on their own work.

575 tests. Three claims mutation-tested: alphabetical tier order, the missing confound warning, and a rate shown below its threshold.

## Next

Similar-footballers usage and per-mode rates, both requested — the feature is currently *configured but never recorded*, so it has to be derived from wrong-guess counts against the configured threshold. Then the Django admin dashboard comes out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)