### PR TITLE
Chart the modes, and put the two aids side by side

### DIFF
--- a/app/analytics/career-path/page.tsx
+++ b/app/analytics/career-path/page.tsx
@@ -2,6 +2,7 @@
 
 import type { RangeState } from '@/lib/report-range';
 import { useMemo } from 'react';
+import { ModeRates } from '@/components/analytics/charts/ModeRates';
 import { DifficultyTiers } from '@/components/analytics/panels/DifficultyTiers';
 import { FootballerContent } from '@/components/analytics/panels/FootballerContent';
 import { AnalyticsShell } from '@/components/analytics/shell/AnalyticsShell';
@@ -88,6 +89,13 @@ export default function CareerPathAnalyticsPage() {
 
       <ReportPanel state={state} skeletonClassName="h-64 w-full">
         {data => <DifficultyTiers data={data} />}
+      </ReportPanel>
+
+      {/* After the tiers, because it answers the objection they raise: if the
+          grading only half separates anything, what else moves the solve rate?
+          The mode does, by about as much. */}
+      <ReportPanel state={state} skeletonClassName="h-80 w-full">
+        {data => <ModeRates data={data} />}
       </ReportPanel>
     </AnalyticsShell>
   );

--- a/components/analytics/__tests__/CareerPathAnalytics.test.tsx
+++ b/components/analytics/__tests__/CareerPathAnalytics.test.tsx
@@ -178,6 +178,32 @@ describe('similar footballers', () => {
     expect(screen.getByText(/4,612 appearances could never show it/)).toBeInTheDocument();
   });
 
+  it('says nothing rather than "null%" when a rate is missing', () => {
+    // `reached_pct` and `solved_after_pct` are nullable independently of
+    // `reached`, so gating on the count alone leaked "null%" into the sentence
+    // (Copilot on #127).
+    render(
+      <DifficultyTiers
+        data={response({
+          shape: {
+            ...response().shape,
+            similar_footballers: {
+              recorded: false,
+              reached: 42,
+              ineligible: 0,
+              reached_pct: null,
+              solved_after_pct: null,
+              solved_without_pct: null,
+            },
+          },
+        })}
+      />,
+    );
+
+    expect(screen.queryByText(/null%/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Derived, not recorded/)).not.toBeInTheDocument();
+  });
+
   it('says nothing when the grid was never reached', () => {
     render(
       <DifficultyTiers

--- a/components/analytics/__tests__/CareerPathAnalytics.test.tsx
+++ b/components/analytics/__tests__/CareerPathAnalytics.test.tsx
@@ -34,20 +34,32 @@ function response(over: Partial<CareerPathAnalyticsResponse> = {}): CareerPathAn
       footballers_seen: 6364,
     },
     shape: {
-      modes: [{ mode: 'SINGLE', paths: 46279 }, { mode: 'LADDER', paths: 12722 }],
-      total_paths: 65765,
-      difficulty: [
-        { difficulty: 'EXTREME', appearances: 52479, solve_rate_pct: 15.9, help_rate_pct: 0.3 },
-        { difficulty: 'EASY', appearances: 158706, solve_rate_pct: 37.5, help_rate_pct: 0.8 },
-        { difficulty: 'NORMAL', appearances: 153443, solve_rate_pct: 25.5, help_rate_pct: 0.6 },
+      modes: [
+        { mode: 'SINGLE', paths: 25131, appearances: 25131, solve_rate_pct: 70.8, help_rate_pct: 2.6 },
+        { mode: 'HEAD_TO_HEAD', paths: 580, appearances: 2794, solve_rate_pct: 83.8, help_rate_pct: 2.1 },
+        { mode: 'RACE', paths: 12, appearances: 12, solve_rate_pct: 58.7, help_rate_pct: 5.1 },
       ],
-      total_appearances: 364628,
+      total_paths: 25723,
+      difficulty: [
+        { difficulty: 'EXTREME', appearances: 6748, solve_rate_pct: 56.5, help_rate_pct: 2.3 },
+        { difficulty: 'EASY', appearances: 23557, solve_rate_pct: 84.4, help_rate_pct: 4.6 },
+        { difficulty: 'NORMAL', appearances: 21359, solve_rate_pct: 67.1, help_rate_pct: 3.9 },
+      ],
+      total_appearances: 60545,
       footballers_per_path: 3.3,
       hint_effect: {
         hinted_guesses: 3653,
         hinted_solve_pct: 35.3,
         unhinted_guesses: 102412,
         unhinted_solve_pct: 43.3,
+      },
+      similar_footballers: {
+        recorded: false,
+        reached: 15973,
+        ineligible: 4612,
+        reached_pct: 28.6,
+        solved_after_pct: 66.9,
+        solved_without_pct: 74.7,
       },
     },
     ...over,
@@ -143,5 +155,48 @@ describe('difficultyTiers', () => {
     render(<DifficultyTiers data={response()} />);
 
     expect(screen.getByText(/3.3 footballers per path/)).toBeInTheDocument();
+  });
+});
+
+describe('similar footballers', () => {
+  it('reports reach and recovery, so it can be read against the hint figure', () => {
+    // The comparison is the finding: the grid recovers about two thirds of the
+    // attempts that reach it, a hint about a third. Both are triggered by the
+    // same struggle, so comparing them is fair even though neither is a trial.
+    render(<DifficultyTiers data={response()} />);
+
+    expect(screen.getByText(/28.6% of eligible appearances, and 66.9% of those/)).toBeInTheDocument();
+  });
+
+  it('says it is derived rather than recorded', () => {
+    // Nothing logs that the grid was served. Without this line an inference
+    // reads as a measurement, and instrumenting it later would look like a
+    // change in the data rather than a change in what is being counted.
+    render(<DifficultyTiers data={response()} />);
+
+    expect(screen.getByText(/Derived, not recorded/)).toBeInTheDocument();
+    expect(screen.getByText(/4,612 appearances could never show it/)).toBeInTheDocument();
+  });
+
+  it('says nothing when the grid was never reached', () => {
+    render(
+      <DifficultyTiers
+        data={response({
+          shape: {
+            ...response().shape,
+            similar_footballers: {
+              recorded: false,
+              reached: 0,
+              ineligible: 10,
+              reached_pct: 0,
+              solved_after_pct: null,
+              solved_without_pct: 80,
+            },
+          },
+        })}
+      />,
+    );
+
+    expect(screen.queryByText(/Derived, not recorded/)).not.toBeInTheDocument();
   });
 });

--- a/components/analytics/__tests__/ModeRates.test.tsx
+++ b/components/analytics/__tests__/ModeRates.test.tsx
@@ -1,0 +1,49 @@
+import type { CareerPathAnalyticsResponse } from '@/types/reports';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ModeRates } from '@/components/analytics/charts/ModeRates';
+
+// jsdom gives recharts a zero-size container, so the bars never render. What is
+// worth asserting is the decision above them: which modes are shown at all, and
+// whether the ones left out are named.
+vi.mock('recharts', async () => {
+  const actual = await vi.importActual<typeof import('recharts')>('recharts');
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+      <div style={{ width: 800, height: 300 }}>{children}</div>
+    ),
+  };
+});
+
+function data(modes: CareerPathAnalyticsResponse['shape']['modes']): CareerPathAnalyticsResponse {
+  return {
+    shape: { modes },
+  } as unknown as CareerPathAnalyticsResponse;
+}
+
+const SINGLE = { mode: 'SINGLE', paths: 100, appearances: 25131, solve_rate_pct: 70.8, help_rate_pct: 2.6 };
+const RARE = { mode: 'RACE', paths: 2, appearances: 12, solve_rate_pct: 58.7, help_rate_pct: 5.1 };
+
+describe('modeRates', () => {
+  it('names the modes it left out rather than dropping them silently', () => {
+    // A mode missing from a chart reads as a mode nobody plays, which is a
+    // different fact from one nobody has played enough to rate.
+    render(<ModeRates data={data([SINGLE, RARE])} />);
+
+    expect(screen.getByText(/1 mode is left out/)).toBeInTheDocument();
+    expect(screen.getByText(/under 30 appearances/)).toBeInTheDocument();
+  });
+
+  it('says nothing about omissions when every mode qualifies', () => {
+    render(<ModeRates data={data([SINGLE])} />);
+
+    expect(screen.queryByText(/left out/)).not.toBeInTheDocument();
+  });
+
+  it('shows an empty state when no mode has enough appearances', () => {
+    render(<ModeRates data={data([RARE])} />);
+
+    expect(screen.getByText('No mode has enough appearances to rate.')).toBeInTheDocument();
+  });
+});

--- a/components/analytics/__tests__/ModeRates.test.tsx
+++ b/components/analytics/__tests__/ModeRates.test.tsx
@@ -28,11 +28,26 @@ const RARE = { mode: 'RACE', paths: 2, appearances: 12, solve_rate_pct: 58.7, he
 describe('modeRates', () => {
   it('names the modes it left out rather than dropping them silently', () => {
     // A mode missing from a chart reads as a mode nobody plays, which is a
-    // different fact from one nobody has played enough to rate.
+    // different fact from one nobody has played enough to rate. A count alone
+    // does not resolve it either — the reader cannot tell WHICH bar is missing
+    // (Copilot on #127).
     render(<ModeRates data={data([SINGLE, RARE])} />);
 
-    expect(screen.getByText(/1 mode is left out/)).toBeInTheDocument();
+    expect(screen.getByText(/race/)).toBeInTheDocument();
     expect(screen.getByText(/under 30 appearances/)).toBeInTheDocument();
+  });
+
+  it('separates "too few to rate" from "nothing to rate at all"', () => {
+    // Two different reasons drop a mode, and one message for both picks the
+    // wrong one for somebody.
+    render(
+      <ModeRates
+        data={data([SINGLE, RARE, { mode: 'SUDDEN_DEATH', paths: 0, appearances: 0, solve_rate_pct: null, help_rate_pct: null }])}
+      />,
+    );
+
+    expect(screen.getByText(/under 30 appearances.*race/)).toBeInTheDocument();
+    expect(screen.getByText(/No appearances to rate at all: sudden death/)).toBeInTheDocument();
   });
 
   it('says nothing about omissions when every mode qualifies', () => {

--- a/components/analytics/charts/ModeRates.tsx
+++ b/components/analytics/charts/ModeRates.tsx
@@ -15,7 +15,8 @@ import { chartTheme } from '@/lib/chart-theme';
  * Horizontal bars because the mode names are long and there are seven of them —
  * vertical ticks would be rotated or truncated, and a mode nobody can read is a
  * bar nobody can act on. Sorted by solve rate rather than volume: the question
- * is which mode is hardest, and volume is already the label on each bar.
+ * is which mode is hardest, and the volume rides on the bar label beside the
+ * rate so neither is read without the other.
  *
  * One measure per chart. Solve rate and help rate live on different scales
  * (70-ish% against 2-ish%) and putting both on one axis would flatten the
@@ -30,16 +31,29 @@ export function ModeRates({ data }: { data: CareerPathAnalyticsResponse }) {
   const { resolvedTheme } = useTheme();
   const theme = chartTheme(resolvedTheme === 'dark');
 
-  const rows = data.shape.modes
-    .filter(mode => mode.appearances >= MIN_APPEARANCES && mode.solve_rate_pct !== null)
+  const label = (mode: string) => mode.replaceAll('_', ' ').toLowerCase();
+  const plotted = data.shape.modes.filter(
+    mode => mode.appearances >= MIN_APPEARANCES && mode.solve_rate_pct !== null,
+  );
+  const rows = plotted
     .map(mode => ({
-      mode: mode.mode.replaceAll('_', ' ').toLowerCase(),
+      mode: label(mode.mode),
       solve_rate_pct: mode.solve_rate_pct,
       appearances: mode.appearances,
     }))
     .sort((a, b) => (b.solve_rate_pct ?? 0) - (a.solve_rate_pct ?? 0));
 
-  const withheld = data.shape.modes.length - rows.length;
+  // Tracked explicitly rather than derived as "total minus plotted" (Copilot on
+  // #127). Two different reasons drop a mode — too few appearances, or no rate
+  // at all — and a single subtracted count would attribute both to the first.
+  // Naming them matters more than counting them: a bar that is simply absent is
+  // ambiguous, and the reader cannot tell which mode they are missing.
+  const thin = data.shape.modes
+    .filter(mode => mode.solve_rate_pct !== null && mode.appearances < MIN_APPEARANCES)
+    .map(mode => label(mode.mode));
+  const unrated = data.shape.modes
+    .filter(mode => mode.solve_rate_pct === null)
+    .map(mode => label(mode.mode));
 
   return (
     <Card>
@@ -66,13 +80,17 @@ export function ModeRates({ data }: { data: CareerPathAnalyticsResponse }) {
                     <YAxis type="category" dataKey="mode" tick={theme.tick} width={104} />
                     <Tooltip content={<ChartTooltip />} cursor={theme.tooltip.cursor} />
                     <Bar dataKey="solve_rate_pct" name="Solved" fill={theme.series[1]} radius={[0, 4, 4, 0]}>
-                      {/* The rate on the bar, so the chart is readable without
-                          hovering — this is a seven-row comparison, not an
-                          exploration. */}
+                      {/* Rate AND volume on the bar, so the chart is readable
+                          without hovering and a rate is never read without the
+                          count behind it — this page withholds rates under a
+                          threshold precisely because that pairing matters. */}
                       <LabelList
-                        dataKey="solve_rate_pct"
+                        dataKey="mode"
                         position="right"
-                        formatter={(value: React.ReactNode) => `${value}%`}
+                        content={({ index }) => {
+                          const row = rows[Number(index)];
+                          return row ? `${row.solve_rate_pct}%  ·  ${row.appearances.toLocaleString()}` : null;
+                        }}
                         className="fill-muted-foreground text-xs"
                       />
                     </Bar>
@@ -81,11 +99,18 @@ export function ModeRates({ data }: { data: CareerPathAnalyticsResponse }) {
               )}
         </div>
 
-        {withheld > 0 && (
-          // Named rather than silently dropped: a mode missing from a chart
-          // reads as a mode nobody plays, which is a different fact.
+        {thin.length > 0 && (
           <p className="text-xs text-muted-foreground">
-            {`${withheld} ${withheld === 1 ? 'mode is' : 'modes are'} left out — under ${MIN_APPEARANCES} appearances, a rate swings on a handful of guesses.`}
+            {`Left out under ${MIN_APPEARANCES} appearances, where a rate swings on a handful of guesses: ${thin.join(', ')}.`}
+          </p>
+        )}
+
+        {unrated.length > 0 && (
+          // A separate line, because "too few to rate" and "nothing to rate at
+          // all" are different answers and one message for both would pick the
+          // wrong one for somebody.
+          <p className="text-xs text-muted-foreground">
+            {`No appearances to rate at all: ${unrated.join(', ')}.`}
           </p>
         )}
       </CardContent>

--- a/components/analytics/charts/ModeRates.tsx
+++ b/components/analytics/charts/ModeRates.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import type { CareerPathAnalyticsResponse } from '@/types/reports';
+import { useTheme } from 'next-themes';
+import { Bar, BarChart, CartesianGrid, LabelList, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { ChartTooltip } from '@/components/reports/charts/ChartTooltip';
+import { EmptyState } from '@/components/reports/primitives/EmptyState';
+import { MetricInfo } from '@/components/reports/primitives/MetricInfo';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { chartTheme } from '@/lib/chart-theme';
+
+/**
+ * How each mode plays, not how much of it was built.
+ *
+ * Horizontal bars because the mode names are long and there are seven of them —
+ * vertical ticks would be rotated or truncated, and a mode nobody can read is a
+ * bar nobody can act on. Sorted by solve rate rather than volume: the question
+ * is which mode is hardest, and volume is already the label on each bar.
+ *
+ * One measure per chart. Solve rate and help rate live on different scales
+ * (70-ish% against 2-ish%) and putting both on one axis would flatten the
+ * second into the baseline — which is the argument against a second axis, not
+ * for one.
+ */
+
+/** Below this many appearances a rate swings on a handful of guesses. */
+const MIN_APPEARANCES = 30;
+
+export function ModeRates({ data }: { data: CareerPathAnalyticsResponse }) {
+  const { resolvedTheme } = useTheme();
+  const theme = chartTheme(resolvedTheme === 'dark');
+
+  const rows = data.shape.modes
+    .filter(mode => mode.appearances >= MIN_APPEARANCES && mode.solve_rate_pct !== null)
+    .map(mode => ({
+      mode: mode.mode.replaceAll('_', ' ').toLowerCase(),
+      solve_rate_pct: mode.solve_rate_pct,
+      appearances: mode.appearances,
+    }))
+    .sort((a, b) => (b.solve_rate_pct ?? 0) - (a.solve_rate_pct ?? 0));
+
+  const withheld = data.shape.modes.length - rows.length;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          How each mode plays
+          <MetricInfo metric="mode_solve_rate" />
+        </CardTitle>
+        <CardDescription>
+          The share of appearances solved, by the mode the path was built in. Read
+          it beside the difficulty grading rather than instead of it — the two are
+          tuned by different people and move the same number.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <div className="h-72">
+          {rows.length === 0
+            ? <EmptyState hint="Try a wider date range.">No mode has enough appearances to rate.</EmptyState>
+            : (
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={rows} layout="vertical" margin={{ top: 4, right: 44, bottom: 4, left: 8 }}>
+                    <CartesianGrid strokeDasharray="3 3" stroke={theme.grid.stroke} horizontal={false} />
+                    <XAxis type="number" domain={[0, 100]} tick={theme.tick} unit="%" />
+                    <YAxis type="category" dataKey="mode" tick={theme.tick} width={104} />
+                    <Tooltip content={<ChartTooltip />} cursor={theme.tooltip.cursor} />
+                    <Bar dataKey="solve_rate_pct" name="Solved" fill={theme.series[1]} radius={[0, 4, 4, 0]}>
+                      {/* The rate on the bar, so the chart is readable without
+                          hovering — this is a seven-row comparison, not an
+                          exploration. */}
+                      <LabelList
+                        dataKey="solve_rate_pct"
+                        position="right"
+                        formatter={(value: React.ReactNode) => `${value}%`}
+                        className="fill-muted-foreground text-xs"
+                      />
+                    </Bar>
+                  </BarChart>
+                </ResponsiveContainer>
+              )}
+        </div>
+
+        {withheld > 0 && (
+          // Named rather than silently dropped: a mode missing from a chart
+          // reads as a mode nobody plays, which is a different fact.
+          <p className="text-xs text-muted-foreground">
+            {`${withheld} ${withheld === 1 ? 'mode is' : 'modes are'} left out — under ${MIN_APPEARANCES} appearances, a rate swings on a handful of guesses.`}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/analytics/panels/DifficultyTiers.tsx
+++ b/components/analytics/panels/DifficultyTiers.tsx
@@ -97,7 +97,9 @@ export function DifficultyTiers({ data }: { data: CareerPathAnalyticsResponse })
             controlled trial — and the comparison is the finding. The grid
             recovers about two thirds of the attempts that reach it; the hint
             text recovers about a third. */}
-        {data.shape.similar_footballers.reached > 0 && (
+        {data.shape.similar_footballers.reached > 0
+          && data.shape.similar_footballers.reached_pct !== null
+          && data.shape.similar_footballers.solved_after_pct !== null && (
           <div className="space-y-1.5 border-t pt-4">
             <p className="flex items-center gap-2 text-sm font-medium">
               Does the similar-footballers grid help

--- a/components/analytics/panels/DifficultyTiers.tsx
+++ b/components/analytics/panels/DifficultyTiers.tsx
@@ -92,6 +92,29 @@ export function DifficultyTiers({ data }: { data: CareerPathAnalyticsResponse })
           </div>
         )}
 
+        {/* Beside the hint figure on purpose: both aids are triggered by the
+            same struggle, so comparing them IS fair even though neither is a
+            controlled trial — and the comparison is the finding. The grid
+            recovers about two thirds of the attempts that reach it; the hint
+            text recovers about a third. */}
+        {data.shape.similar_footballers.reached > 0 && (
+          <div className="space-y-1.5 border-t pt-4">
+            <p className="flex items-center gap-2 text-sm font-medium">
+              Does the similar-footballers grid help
+              <MetricInfo metric="similar_footballers" />
+            </p>
+            <p className="text-sm">
+              {`Shown on ${data.shape.similar_footballers.reached_pct}% of eligible appearances, and ${data.shape.similar_footballers.solved_after_pct}% of those are then solved.`}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {/* An inference, and it says so. Nothing records that the grid was
+                  served, so this counts what each game's own configuration says
+                  happens — enabled, and past its own wrong-guess threshold. */}
+              {`Derived, not recorded: nothing logs that the grid was shown, so this counts appearances past each game's own wrong-guess threshold. ${data.shape.similar_footballers.ineligible.toLocaleString()} appearances could never show it and are left out of both figures.`}
+            </p>
+          </div>
+        )}
+
         {modes.length > 0 && (
           <div className="space-y-2 border-t pt-4">
             <p className="text-xs font-medium text-muted-foreground">What was built</p>

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -911,7 +911,15 @@ export type CareerPathAnalyticsResponse = {
     footballers_seen: number;
   };
   shape: {
-    modes: { mode: string; paths: number }[];
+    modes: {
+      mode: string;
+      /** Career paths built in this mode. */
+      paths: number;
+      /** Footballer appearances inside them — distinct, not join-multiplied. */
+      appearances: number;
+      solve_rate_pct: number | null;
+      help_rate_pct: number | null;
+    }[];
     total_paths: number;
     difficulty: CareerPathTier[];
     total_appearances: number;
@@ -930,6 +938,22 @@ export type CareerPathAnalyticsResponse = {
       hinted_solve_pct: number | null;
       unhinted_guesses: number;
       unhinted_solve_pct: number | null;
+    };
+    /**
+     * Whether the similar-footballers grid rescues an attempt.
+     *
+     * `recorded: false` because nothing logs that the grid was served — this
+     * counts what each game's configuration says happens. The panel says so, so
+     * an inference is never read as a measurement.
+     */
+    similar_footballers: {
+      recorded: boolean;
+      reached: number;
+      /** Appearances that could never show it — the feature was off. */
+      ineligible: number;
+      reached_pct: number | null;
+      solved_after_pct: number | null;
+      solved_without_pct: number | null;
     };
   };
 } & ResolvedRange;


### PR DESCRIPTION
FE for the two additions in FootballExtraTime/App#1490.

## Mode rates as a chart

Horizontal bars: seven mode names, long ones, and a rotated tick is a mode nobody reads. Sorted by solve rate rather than volume — the question is which mode is hardest, and the volume is already on the bar.

**One measure per chart.** Solve rate sits near 70% and help rate near 2%, so plotting both on one axis flattens the second into the baseline. That's the argument *against* a second axis, not for one — help rate stays in the tier table where it sits beside a comparable number.

**Modes under 30 appearances are left out and named.** A mode missing from a chart reads as a mode nobody plays, which is a different fact from one nobody has played enough to rate.

## The two aids, side by side

The comparison is the finding:

| | recovers |
|---|---|
| Similar-footballers grid | **~2/3** of attempts that reach it |
| Hint text | ~1/3 |

Both are triggered by the same struggle, so comparing them is fair even though neither is a controlled trial.

The panel says **"derived, not recorded"** and names the appearances that could never show the grid. Nothing logs that it was served, so this counts what each game's configuration says happens — and without that line an inference reads as a measurement, which would make instrumenting it properly later look like *the data changed* rather than the counting.

## Fixtures

The tier fixtures now carry the **corrected** numbers from #1490 — the old ones came from join-inflated counts.

581 tests. Three claims mutation-tested: presenting the inference as recorded, dropping thin modes silently, and charting every mode regardless of volume.

Next: the Django admin dashboard comes out, which closes dashboard 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)