### PR TITLE
Show the four options, not just the score

### DIFF
--- a/app/analytics/questions/page.tsx
+++ b/app/analytics/questions/page.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import type { RangeState } from '@/lib/report-range';
+import { useMemo } from 'react';
+import { QuestionBank } from '@/components/analytics/panels/QuestionBank';
+import { QuestionQuality } from '@/components/analytics/panels/QuestionQuality';
+import { AnalyticsShell } from '@/components/analytics/shell/AnalyticsShell';
+import { FilterBar } from '@/components/reports/filters/FilterBar';
+import { RangePicker } from '@/components/reports/filters/RangePicker';
+import { ReportPanel } from '@/components/reports/primitives/ReportPanel';
+import { SectionHeader } from '@/components/reports/primitives/SectionHeader';
+import { useReport } from '@/hooks/use-report';
+import { useReportFilters } from '@/hooks/use-report-filters';
+import { useAuth } from '@/lib/auth';
+import { rangeToParams } from '@/lib/report-range';
+import { ReportsAPI } from '@/lib/reports-api';
+
+/**
+ * Question quality — a worklist, not a dashboard.
+ *
+ * Someone opens this to find the handful of questions worth an afternoon, so
+ * the suspect ones lead and the bank-level view sits underneath. The reverse
+ * order would make them scroll past four rows of aggregate to reach the only
+ * part they can act on.
+ */
+export default function QuestionsAnalyticsPage() {
+  const { isAuthenticated, user } = useAuth();
+  const enabled = isAuthenticated && !!(user?.is_staff || user?.is_superuser);
+
+  // 90 days: a question needs 30 answers before its distribution says anything,
+  // and a 30-day window leaves most of a 7,000-question bank under that line.
+  const { filters, update } = useReportFilters({
+    range: { window: 90 },
+    includeBots: false,
+    game: null,
+    metric: 'games_started',
+  });
+  const { range, includeBots } = filters;
+  const setRange = (next: RangeState) => update({ range: next });
+  const setIncludeBots = (next: boolean) => update({ includeBots: next });
+  const params = useMemo(
+    () => ({ ...rangeToParams(range), include_bots: includeBots }),
+    [range, includeBots],
+  );
+
+  const state = useReport(
+    ReportsAPI.getQuestionsAnalytics,
+    params,
+    enabled,
+    'The questions analytics endpoint',
+  );
+
+  return (
+    <AnalyticsShell
+      title="Question quality"
+      description="Which questions are broken, and how — read from what players chose, not just whether they were right."
+    >
+      <FilterBar>
+        <RangePicker
+          value={range}
+          onChange={setRange}
+          includeBots={includeBots}
+          onIncludeBotsChange={setIncludeBots}
+        />
+      </FilterBar>
+
+      <ReportPanel state={state} skeletonClassName="h-96 w-full">
+        {data => <QuestionQuality data={data} />}
+      </ReportPanel>
+
+      {/* Underneath, because it answers the question the list raises rather than
+          the one someone arrives with: is this a few bad questions, or is the
+          whole bank mis-graded? */}
+      <SectionHeader
+        title="The bank as a whole"
+        description="Whether the grading separates anything, and whether there is material left."
+      />
+
+      <ReportPanel state={state} skeletonClassName="h-64 w-full">
+        {data => <QuestionBank data={data} />}
+      </ReportPanel>
+    </AnalyticsShell>
+  );
+}

--- a/components/analytics/__tests__/QuestionsAnalytics.test.tsx
+++ b/components/analytics/__tests__/QuestionsAnalytics.test.tsx
@@ -101,6 +101,29 @@ describe('questionQuality', () => {
     expect(screen.getByText('33.3% ran out of time')).toBeInTheDocument();
   });
 
+  it('shows a count rather than "null%" when every answer timed out', () => {
+    // No deliberate answers means no share to state, and `null%` is worse than
+    // the raw number (Copilot on #128).
+    render(
+      <QuestionQuality
+        data={response([question({
+          question_id: 4,
+          text: 'All timed out',
+          answered: 0,
+          timeouts: 31,
+          timeout_pct: null,
+          options: options([0, 0, 0, 0], 1),
+          correct_pct: null,
+          top_wrong_pct: null,
+          beaten_by_a_wrong_answer: false,
+        })])}
+      />,
+    );
+
+    expect(screen.getByText('31 ran out of time')).toBeInTheDocument();
+    expect(screen.queryByText(/null%/)).not.toBeInTheDocument();
+  });
+
   it('leads with how many need a look', () => {
     render(<QuestionQuality data={response([question({ question_id: 1, text: 'Q' })])} />);
 

--- a/components/analytics/__tests__/QuestionsAnalytics.test.tsx
+++ b/components/analytics/__tests__/QuestionsAnalytics.test.tsx
@@ -1,0 +1,134 @@
+import type { QuestionRow, QuestionsAnalyticsResponse } from '@/types/reports';
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { QuestionBank } from '@/components/analytics/panels/QuestionBank';
+import { QuestionQuality } from '@/components/analytics/panels/QuestionQuality';
+
+function options(counts: [number, number, number, number], correct: number) {
+  const answered = counts.reduce((sum, n) => sum + n, 0);
+  return counts.map((count, index) => ({
+    option: index + 1,
+    count,
+    pct: answered ? Math.round((count * 1000) / answered) / 10 : null,
+    is_correct: index + 1 === correct,
+  }));
+}
+
+function question(over: Partial<QuestionRow> & Pick<QuestionRow, 'question_id' | 'text'>): QuestionRow {
+  return {
+    difficulty: 'NORMAL',
+    correct_answer: 1,
+    asked: 24,
+    answered: 24,
+    timeouts: 0,
+    timeout_pct: 0,
+    options: options([6, 18, 0, 0], 1),
+    correct_pct: 25,
+    top_wrong_option: 2,
+    top_wrong_pct: 75,
+    beaten_by_a_wrong_answer: true,
+    ...over,
+  };
+}
+
+function response(rows: QuestionRow[], over: Partial<QuestionsAnalyticsResponse['shape']> = {}): QuestionsAnalyticsResponse {
+  return {
+    quality: {
+      rows,
+      min_answers: 30,
+      questions_measured: 2487,
+      beaten_by_a_wrong_answer: rows.filter(r => r.beaten_by_a_wrong_answer).length,
+    },
+    shape: {
+      difficulty: [
+        { difficulty: 'EXTREME', answered: 12362, correct_pct: 50.3, timeouts: 2 },
+        { difficulty: 'EASY', answered: 67679, correct_pct: 90.6, timeouts: 22 },
+        { difficulty: 'NORMAL', answered: 64822, correct_pct: 70.7, timeouts: 17 },
+      ],
+      questions_served: 7120,
+      questions_in_bank: 7219,
+      bank_used_pct: 98.6,
+      ...over,
+    },
+  } as unknown as QuestionsAnalyticsResponse;
+}
+
+describe('questionQuality', () => {
+  it('marks a question a wrong option won', () => {
+    // The finding. Without it the row is just a low correct rate, which a hard
+    // question produces too.
+    render(<QuestionQuality data={response([question({ question_id: 1, text: 'How many goals?' })])} />);
+
+    expect(screen.getByText('A wrong option won')).toBeInTheDocument();
+    expect(screen.getByText('How many goals?')).toBeInTheDocument();
+  });
+
+  it('shows every option, not only the winner', () => {
+    // The split IS the evidence: 75/25 across two options is a different
+    // question from 25/25/25/25, and both have the same correct rate.
+    render(<QuestionQuality data={response([question({ question_id: 1, text: 'Q' })])} />);
+
+    expect(screen.getByText('75%')).toBeInTheDocument();
+    expect(screen.getByText('25%')).toBeInTheDocument();
+  });
+
+  it('does not flag a merely hard question', () => {
+    render(
+      <QuestionQuality
+        data={response([question({
+          question_id: 2,
+          text: 'Hard one',
+          options: options([2, 3, 3, 3], 1),
+          correct_pct: 18.2,
+          top_wrong_pct: 27.3,
+          beaten_by_a_wrong_answer: false,
+        })])}
+      />,
+    );
+
+    expect(screen.queryByText('A wrong option won')).not.toBeInTheDocument();
+  });
+
+  it('reports timeouts beside the row rather than inside the bars', () => {
+    // A timed-out answer carries whatever was highlighted when the clock ran
+    // out. Counting it as a choice attributes an accident to the player.
+    render(
+      <QuestionQuality
+        data={response([question({ question_id: 3, text: 'Long one', timeouts: 12, timeout_pct: 33.3 })])}
+      />,
+    );
+
+    expect(screen.getByText('33.3% ran out of time')).toBeInTheDocument();
+  });
+
+  it('leads with how many need a look', () => {
+    render(<QuestionQuality data={response([question({ question_id: 1, text: 'Q' })])} />);
+
+    expect(screen.getByText('Need a look')).toBeInTheDocument();
+  });
+
+  it('says nothing was rated rather than showing an empty list', () => {
+    render(<QuestionQuality data={response([])} />);
+
+    expect(screen.getByText('No question was answered enough times to rate.')).toBeInTheDocument();
+  });
+});
+
+describe('questionBank', () => {
+  it('answers whether more questions are needed', () => {
+    // "We need more questions" is either true or it is not, and nothing said
+    // which before.
+    render(<QuestionBank data={response([])} />);
+
+    expect(screen.getByText(/7,120 of 7,219 questions were served/)).toBeInTheDocument();
+    expect(screen.getByText(/98.6% of the bank/)).toBeInTheDocument();
+  });
+
+  it('orders the tiers by the scale, not the alphabet', () => {
+    render(<QuestionBank data={response([])} />);
+    const rows = screen.getAllByRole('row').slice(1, 4);
+
+    expect(rows.map(row => within(row).getAllByRole('cell')[0].textContent?.trim()))
+      .toEqual(['EASY', 'NORMAL', 'EXTREME']);
+  });
+});

--- a/components/analytics/panels/DifficultyTiers.tsx
+++ b/components/analytics/panels/DifficultyTiers.tsx
@@ -14,7 +14,12 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
  * grading is decoration.
  */
 
-/** The scale's own order. Alphabetically EXTREME leads and NORMAL ends. */
+/**
+ * The scale's own order, easiest first — which is NOT what sorting the names
+ * gives you. Alphabetically the list runs EASY, EXTREME, HARD, NORMAL, so the
+ * hardest tier lands second and the middle one last, and a reader scanning down
+ * the column sees a ranking by nothing at all.
+ */
 const TIER_ORDER = ['EASY', 'NORMAL', 'HARD', 'EXTREME'];
 
 function tierRank(difficulty: string | null): number {

--- a/components/analytics/panels/QuestionBank.tsx
+++ b/components/analytics/panels/QuestionBank.tsx
@@ -12,7 +12,12 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
  * questions" is either true or it is not, and until now nothing said which.
  */
 
-/** The scale's own order. Alphabetically EXTREME leads and NORMAL ends. */
+/**
+ * The scale's own order, easiest first — which is NOT what sorting the names
+ * gives you. Alphabetically the list runs EASY, EXTREME, HARD, NORMAL, so the
+ * hardest tier lands second and the middle one last, and a reader scanning down
+ * the column sees a ranking by nothing at all.
+ */
 const TIER_ORDER = ['EASY', 'NORMAL', 'HARD', 'EXTREME'];
 
 function tierRank(difficulty: string | null): number {

--- a/components/analytics/panels/QuestionBank.tsx
+++ b/components/analytics/panels/QuestionBank.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import type { QuestionsAnalyticsResponse } from '@/types/reports';
+import { MetricInfo } from '@/components/reports/primitives/MetricInfo';
+import { ReportHead, ReportRow, ReportTable, Td, Th } from '@/components/reports/primitives/ReportTable';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+/**
+ * Whether the grading works, and whether the bank is running out.
+ *
+ * The second question is the one that settles an argument: "we need more
+ * questions" is either true or it is not, and until now nothing said which.
+ */
+
+/** The scale's own order. Alphabetically EXTREME leads and NORMAL ends. */
+const TIER_ORDER = ['EASY', 'NORMAL', 'HARD', 'EXTREME'];
+
+function tierRank(difficulty: string | null): number {
+  const index = difficulty === null ? -1 : TIER_ORDER.indexOf(difficulty);
+  return index === -1 ? TIER_ORDER.length : index;
+}
+
+export function QuestionBank({ data }: { data: QuestionsAnalyticsResponse }) {
+  const tiers = [...data.shape.difficulty].sort(
+    (a, b) => tierRank(a.difficulty) - tierRank(b.difficulty),
+  );
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          The bank, and whether its grading works
+          <MetricInfo metric="bank_used" />
+        </CardTitle>
+        <CardDescription>
+          {data.shape.bank_used_pct === null
+            ? 'No questions in the bank.'
+            : `${data.shape.questions_served.toLocaleString()} of ${data.shape.questions_in_bank.toLocaleString()} questions were served in this window — ${data.shape.bank_used_pct}% of the bank.`}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="overflow-x-auto">
+        <ReportTable>
+          <ReportHead>
+            <Th>Graded</Th>
+            <Th align="right">Answered</Th>
+            <Th align="right" title="Should fall as the tier gets harder">Correct</Th>
+            <Th align="right" title="Answers submitted when the clock ran out">Ran out of time</Th>
+          </ReportHead>
+          <tbody>
+            {tiers.map(tier => (
+              <ReportRow key={String(tier.difficulty)}>
+                <Td strong>
+                  {tier.difficulty ?? <span className="text-muted-foreground">Not graded</span>}
+                </Td>
+                <Td align="right">{tier.answered.toLocaleString()}</Td>
+                <Td align="right" strong>
+                  {tier.correct_pct === null ? '—' : `${tier.correct_pct}%`}
+                </Td>
+                <Td align="right" className="text-muted-foreground">
+                  {tier.timeouts.toLocaleString()}
+                </Td>
+              </ReportRow>
+            ))}
+          </tbody>
+        </ReportTable>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/analytics/panels/QuestionQuality.tsx
+++ b/components/analytics/panels/QuestionQuality.tsx
@@ -131,7 +131,13 @@ export function QuestionQuality({ data }: { data: QuestionsAnalyticsResponse }) 
                           out often may simply be too long to read. */}
                       {row.timeouts > 0 && (
                         <span title="Answers submitted when the clock ran out — not counted as choices above">
-                          {`${row.timeout_pct}% ran out of time`}
+                          {/* The count when the share is missing: a question
+                              where EVERY answer timed out has no deliberate
+                              denominator, and `null%` is worse than a raw
+                              number (Copilot on #128). */}
+                          {row.timeout_pct === null
+                            ? `${row.timeouts.toLocaleString()} ran out of time`
+                            : `${row.timeout_pct}% ran out of time`}
                         </span>
                       )}
                     </p>

--- a/components/analytics/panels/QuestionQuality.tsx
+++ b/components/analytics/panels/QuestionQuality.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import type { QuestionRow, QuestionsAnalyticsResponse } from '@/types/reports';
+import { EmptyState } from '@/components/reports/primitives/EmptyState';
+import { MetricInfo } from '@/components/reports/primitives/MetricInfo';
+import { MetricRow } from '@/components/reports/primitives/MetricRow';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+/**
+ * What players actually chose, per question.
+ *
+ * Not a table of correct rates — the admin already had those, and on their own
+ * they are ambiguous: a hard question and a mis-keyed one both read as 20%
+ * correct. The four options side by side say which.
+ *
+ * Deliberately NOT the shared `Distribution` primitive. That draws one hue
+ * varied by opacity, which is right for ordered bands (under 25%, under 50%)
+ * and wrong here — the options are categorical and exactly one of them is the
+ * key. The whole point is that one bar is different in kind, not further along
+ * a scale.
+ */
+
+/** Which answer text each option index refers to, for the row label. */
+const OPTION_LABELS = ['A', 'B', 'C', 'D'];
+
+function OptionBar({ option, suspect }: { option: QuestionRow['options'][number]; suspect: boolean }) {
+  const pct = option.pct ?? 0;
+  return (
+    <div className="flex items-center gap-2">
+      <span
+        className={cn(
+          'w-4 shrink-0 text-xs font-medium tabular-nums',
+          option.is_correct ? 'text-emerald-600 dark:text-emerald-400' : 'text-muted-foreground',
+        )}
+      >
+        {OPTION_LABELS[option.option - 1] ?? option.option}
+      </span>
+      <span className="h-2 flex-1 overflow-hidden rounded-full bg-muted">
+        <span
+          className={cn(
+            'block h-full rounded-full',
+            option.is_correct
+              ? 'bg-emerald-500'
+              // Amber, not red: a dominant wrong option is a question to LOOK
+              // at, not a confirmed error. Red would claim the key is wrong,
+              // which this cannot know — the distractor may be defensible.
+              : suspect
+                ? 'bg-amber-500'
+                : 'bg-muted-foreground/30',
+          )}
+          style={{ width: `${pct}%` }}
+        />
+      </span>
+      <span className="w-11 shrink-0 text-right text-xs tabular-nums text-muted-foreground">
+        {option.pct === null ? '—' : `${option.pct}%`}
+      </span>
+    </div>
+  );
+}
+
+export function QuestionQuality({ data }: { data: QuestionsAnalyticsResponse }) {
+  const { rows, min_answers: minAnswers, questions_measured: measured } = data.quality;
+  const suspect = data.quality.beaten_by_a_wrong_answer;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          What players actually chose
+          <MetricInfo metric="answer_distribution" />
+        </CardTitle>
+        <CardDescription>
+          A correct rate cannot tell a hard question from a mis-keyed one — both
+          read as 20% correct. The split can: when most players pick the same
+          wrong option, the question is wrong or its distractor is defensible.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <MetricRow
+          columns={3}
+          metrics={[
+            {
+              label: 'Need a look',
+              value: suspect.toLocaleString(),
+              metric: 'beaten_by_a_wrong_answer',
+            },
+            { label: 'Questions rated', value: measured.toLocaleString() },
+            { label: 'Rating needs', value: `${minAnswers} answers` },
+          ]}
+        />
+
+        {rows.length === 0
+          ? (
+              <EmptyState hint="Try a wider date range.">
+                No question was answered enough times to rate.
+              </EmptyState>
+            )
+          : (
+              <ul className="space-y-4">
+                {rows.map(row => (
+                  <li key={row.question_id} className="space-y-2 rounded-md border p-3">
+                    <div className="flex flex-wrap items-start justify-between gap-2">
+                      <p className="min-w-0 flex-1 text-sm font-medium">{row.text}</p>
+                      {row.beaten_by_a_wrong_answer && (
+                        <span
+                          className="shrink-0 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900/40 dark:text-amber-300"
+                          title="More players chose one wrong option than the keyed answer, by more than chance"
+                        >
+                          A wrong option won
+                        </span>
+                      )}
+                    </div>
+
+                    <div className="space-y-1">
+                      {row.options.map(option => (
+                        <OptionBar
+                          key={option.option}
+                          option={option}
+                          suspect={option.option === row.top_wrong_option && row.beaten_by_a_wrong_answer}
+                        />
+                      ))}
+                    </div>
+
+                    <p className="flex flex-wrap gap-x-3 text-xs text-muted-foreground">
+                      <span>{`${row.answered.toLocaleString()} answered`}</span>
+                      {row.difficulty && <span>{`graded ${row.difficulty.toLowerCase()}`}</span>}
+                      {/* Timeouts sit here rather than in the bars: they carry
+                          whatever option was highlighted when the clock ran out,
+                          so they are not a choice — but a question that times
+                          out often may simply be too long to read. */}
+                      {row.timeouts > 0 && (
+                        <span title="Answers submitted when the clock ran out — not counted as choices above">
+                          {`${row.timeout_pct}% ran out of time`}
+                        </span>
+                      )}
+                    </p>
+                  </li>
+                ))}
+              </ul>
+            )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/analytics/shell/AnalyticsNav.tsx
+++ b/components/analytics/shell/AnalyticsNav.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { NavGroup } from '@/components/admin/SectionNav';
-import { Route } from 'lucide-react';
+import { HelpCircle, Route } from 'lucide-react';
 
 /**
  * Analytics, which is not Reports and should not be folded into it.
@@ -13,15 +13,16 @@ import { Route } from 'lucide-react';
  * weekly by whoever is deciding what to build, and this is read by whoever is
  * writing content, when they are writing it.
  *
- * One destination today, grouped rather than flat because four more are coming
- * (App#1475) and a heading that appears later reorganises the section under
- * someone who had learned where things were.
+ * Grouped rather than flat because three more are coming (App#1475) and a
+ * heading that appears later reorganises the section under someone who had
+ * learned where things were.
  */
 export const ANALYTICS_NAV_GROUPS: NavGroup[] = [
   {
     heading: 'Per game',
     items: [
       { href: '/analytics/career-path', label: 'Career Path', icon: Route },
+      { href: '/analytics/questions', label: 'Quiz questions', icon: HelpCircle },
     ],
   },
 ];

--- a/lib/reports-api.ts
+++ b/lib/reports-api.ts
@@ -15,6 +15,7 @@ import type {
   PatternsResponse,
   PlayerDetailResponse,
   ProgressResponse,
+  QuestionsAnalyticsResponse,
   ReportParams,
   RetentionResponse,
   RollupHealth,
@@ -126,6 +127,11 @@ export class ReportsAPI {
    */
   static async getCareerPathAnalytics(params?: ReportParams): Promise<CareerPathAnalyticsResponse> {
     return apiFetcher<CareerPathAnalyticsResponse>(`core/analytics/career-path/${buildQuery(params)}`);
+  }
+
+  /** GET /core/analytics/questions/ — question quality and answer distribution. */
+  static async getQuestionsAnalytics(params?: ReportParams): Promise<QuestionsAnalyticsResponse> {
+    return apiFetcher<QuestionsAnalyticsResponse>(`core/analytics/questions/${buildQuery(params)}`);
   }
 
   /** GET /core/reporting/content/ — content runway and pool depth. A snapshot. */

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -957,3 +957,53 @@ export type CareerPathAnalyticsResponse = {
     };
   };
 } & ResolvedRange;
+
+/** One option of a quiz question, with how often it was chosen. */
+export type QuestionOption = {
+  option: number;
+  count: number;
+  /** Share of DELIBERATE answers. Null when nobody answered without timing out. */
+  pct: number | null;
+  is_correct: boolean;
+};
+
+/**
+ * One question's quality.
+ *
+ * `beaten_by_a_wrong_answer` is the finding: a wrong option chosen decisively
+ * more often than the keyed one. Decisively, not merely — any margin flags 86
+ * questions on real data and most are near-ties; two sigma flags 8.
+ */
+export type QuestionRow = {
+  question_id: number;
+  text: string;
+  difficulty: string | null;
+  correct_answer: number;
+  /** Every answer, including timed-out ones. */
+  asked: number;
+  /** Deliberate answers — the denominator for every share below. */
+  answered: number;
+  timeouts: number;
+  timeout_pct: number | null;
+  options: QuestionOption[];
+  correct_pct: number | null;
+  top_wrong_option: number | null;
+  top_wrong_pct: number | null;
+  beaten_by_a_wrong_answer: boolean;
+};
+
+export type QuestionsAnalyticsResponse = {
+  quality: {
+    rows: QuestionRow[];
+    min_answers: number;
+    questions_measured: number;
+    beaten_by_a_wrong_answer: number;
+  };
+  shape: {
+    difficulty: { difficulty: string | null; answered: number; correct_pct: number | null; timeouts: number }[];
+    questions_served: number;
+    questions_in_bank: number;
+    /** Whether "we need more questions" is true. Currently 98.6%, so it is not. */
+    bank_used_pct: number | null;
+  };
+} & ResolvedRange;


### PR DESCRIPTION
FE for the second dashboard of FootballExtraTime/App#1475, at `/analytics/questions`. Backend: FootballExtraTime/App#1492.

A correct rate cannot tell a **hard** question from a **mis-keyed** one — both read as 20% correct. The four options side by side can, which is why this page shows a distribution where the admin showed a number.

## Deliberately not the shared `Distribution` primitive

That draws one hue varied by opacity, which is right for *ordered* bands (under 25%, under 50%) and wrong here: the options are **categorical** and exactly one is the key. The point is that one bar differs in **kind**, not in how far along a scale it sits.

- correct option — green
- a dominant wrong option — **amber, not red**. A wrong option winning is a question to *look at*, not a confirmed error; the distractor may be defensible and this can't know which.
- the rest — muted

## Timeouts sit beside the row, not inside the bars

A timed-out answer carries whatever option happened to be highlighted when the clock ran out. Reported anyway, because it says something else: a question that times out often may simply be too long to read.

## A worklist, not a dashboard

The suspect questions lead; the bank-level view sits underneath. The reverse would make someone scroll past four rows of aggregate to reach the only part they can act on. The bank panel answers the question the list *raises* rather than the one someone arrives with — a few bad questions, or a mis-graded bank?

591 tests. Four claims mutation-tested: dropping the badge, showing only the winning option, folding timeouts into the bars, and alphabetical tier order.

Analytics now has two of its five destinations. Next: the admin Questions dashboards come out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)