### PR TITLE
Print the answer, not the letter

### DIFF
--- a/components/analytics/__tests__/QuestionsAnalytics.test.tsx
+++ b/components/analytics/__tests__/QuestionsAnalytics.test.tsx
@@ -6,8 +6,10 @@ import { QuestionQuality } from '@/components/analytics/panels/QuestionQuality';
 
 function options(counts: [number, number, number, number], correct: number) {
   const answered = counts.reduce((sum, n) => sum + n, 0);
+  const TEXTS = ['Zero', 'One goal', 'Two goals', 'A hat-trick'];
   return counts.map((count, index) => ({
     option: index + 1,
+    text: TEXTS[index],
     count,
     pct: answered ? Math.round((count * 1000) / answered) / 10 : null,
     is_correct: index + 1 === correct,
@@ -61,6 +63,16 @@ describe('questionQuality', () => {
 
     expect(screen.getByText('A wrong option won')).toBeInTheDocument();
     expect(screen.getByText('How many goals?')).toBeInTheDocument();
+  });
+
+  it('shows what each answer says, not just its letter', () => {
+    // "72% chose option B" cannot be judged. Whether a distractor is defensible
+    // is the question a dominant wrong option raises, and it cannot be asked
+    // without reading the answer.
+    render(<QuestionQuality data={response([question({ question_id: 1, text: 'How many goals?' })])} />);
+
+    expect(screen.getByText('One goal')).toBeInTheDocument();
+    expect(screen.getByText('A hat-trick')).toBeInTheDocument();
   });
 
   it('shows every option, not only the winner', () => {

--- a/components/analytics/panels/QuestionQuality.tsx
+++ b/components/analytics/panels/QuestionQuality.tsx
@@ -36,6 +36,19 @@ function OptionBar({ option, suspect }: { option: QuestionRow['options'][number]
       >
         {OPTION_LABELS[option.option - 1] ?? option.option}
       </span>
+      {/* The answer as written, before the bar. A share attached to a letter is
+          not something anyone can judge — the question a dominant wrong option
+          raises is whether that answer is defensible, and it cannot be asked
+          without reading it. */}
+      <span
+        className={cn(
+          'w-0 min-w-32 flex-[2] truncate text-xs',
+          option.is_correct ? 'font-medium text-foreground' : 'text-muted-foreground',
+        )}
+        title={option.text}
+      >
+        {option.text || '—'}
+      </span>
       <span className="h-2 flex-1 overflow-hidden rounded-full bg-muted">
         <span
           className={cn(

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -961,6 +961,11 @@ export type CareerPathAnalyticsResponse = {
 /** One option of a quiz question, with how often it was chosen. */
 export type QuestionOption = {
   option: number;
+  /**
+   * The answer as written. "72% chose option B" cannot be judged — deciding
+   * whether a distractor is defensible means reading it.
+   */
+  text: string;
   count: number;
   /** Share of DELIBERATE answers. Null when nobody answered without timing out. */
   pct: number | null;


### PR DESCRIPTION
Backend: FootballExtraTime/App#1493.

The admin view this dashboard replaces showed each answer's **text** beside its percentage; the new one showed `A / B / C / D`. That's the difference between a number and something an editor can act on — **"72% chose option B" cannot be judged**, and whether a distractor is defensible is precisely the question a dominant wrong option raises.

Truncated with the full text on hover, so a long answer doesn't push the bar off the row.

Found by reading the admin view *before* deleting it — which is why the removal PR sits behind this one rather than in front of it.

593 tests; the claim is mutation-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)