### PR TITLE
Rank slots by what they cost, not by whether they were solved

### DIFF
--- a/app/analytics/lineups/page.tsx
+++ b/app/analytics/lineups/page.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import type { RangeState } from '@/lib/report-range';
+import { useMemo } from 'react';
+import { LineupSlots } from '@/components/analytics/panels/LineupSlots';
+import { LineupWorkload } from '@/components/analytics/panels/LineupWorkload';
+import { AnalyticsShell } from '@/components/analytics/shell/AnalyticsShell';
+import { FilterBar } from '@/components/reports/filters/FilterBar';
+import { RangePicker } from '@/components/reports/filters/RangePicker';
+import { ReportPanel } from '@/components/reports/primitives/ReportPanel';
+import { SectionHeader } from '@/components/reports/primitives/SectionHeader';
+import { useReport } from '@/hooks/use-report';
+import { useReportFilters } from '@/hooks/use-report-filters';
+import { useAuth } from '@/lib/auth';
+import { rangeToParams } from '@/lib/report-range';
+import { ReportsAPI } from '@/lib/reports-api';
+
+/**
+ * Missing11 content quality — slots first, lineups second.
+ *
+ * A slot is what an editor changes: swap one unguessable footballer and the
+ * lineup is fixed. So the slot table leads and the whole-lineup view sits
+ * underneath, answering the question the first one raises — is this a bad slot
+ * or a lineup that is hard all the way through?
+ */
+export default function LineupsAnalyticsPage() {
+  const { isAuthenticated, user } = useAuth();
+  const enabled = isAuthenticated && !!(user?.is_staff || user?.is_superuser);
+
+  // 90 days: a slot needs 30 sessions before its effort figure means anything,
+  // and this game's content rotates daily — a month leaves most slots short.
+  const { filters, update } = useReportFilters({
+    range: { window: 90 },
+    includeBots: false,
+    game: null,
+    metric: 'games_started',
+  });
+  const { range, includeBots } = filters;
+  const setRange = (next: RangeState) => update({ range: next });
+  const setIncludeBots = (next: boolean) => update({ includeBots: next });
+  const params = useMemo(
+    () => ({ ...rangeToParams(range), include_bots: includeBots }),
+    [range, includeBots],
+  );
+
+  const state = useReport(
+    ReportsAPI.getLineupsAnalytics,
+    params,
+    enabled,
+    'The lineups analytics endpoint',
+  );
+
+  return (
+    <AnalyticsShell
+      title="Lineup content"
+      description="Which slots cost the most guesses, and which lineups ask the most of a player."
+    >
+      <FilterBar>
+        <RangePicker
+          value={range}
+          onChange={setRange}
+          includeBots={includeBots}
+          onIncludeBotsChange={setIncludeBots}
+        />
+      </FilterBar>
+
+      <ReportPanel state={state} skeletonClassName="h-96 w-full">
+        {data => <LineupSlots data={data} />}
+      </ReportPanel>
+
+      <SectionHeader
+        title="The lineups themselves"
+        description="A demanding lineup is only a problem when people stop finishing it."
+      />
+
+      <ReportPanel state={state} skeletonClassName="h-80 w-full">
+        {data => <LineupWorkload data={data} />}
+      </ReportPanel>
+    </AnalyticsShell>
+  );
+}

--- a/components/analytics/__tests__/LineupsAnalytics.test.tsx
+++ b/components/analytics/__tests__/LineupsAnalytics.test.tsx
@@ -1,0 +1,87 @@
+import type { LineupRow, LineupsAnalyticsResponse, LineupSlotRow } from '@/types/reports';
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { LineupSlots } from '@/components/analytics/panels/LineupSlots';
+import { LineupWorkload } from '@/components/analytics/panels/LineupWorkload';
+
+function slot(over: Partial<LineupSlotRow> & Pick<LineupSlotRow, 'slot_id' | 'player'>): LineupSlotRow {
+  return {
+    shirt_number: 11,
+    lineup_id: 1,
+    lineup: 'Roma - Lazio',
+    sessions: 70,
+    guesses_per_session: 5.3,
+    solve_rate_pct: 74.2,
+    hint_rate_pct: 64.5,
+    ...over,
+  };
+}
+
+function lineup(over: Partial<LineupRow> & Pick<LineupRow, 'lineup_id' | 'title'>): LineupRow {
+  return {
+    sessions: 120,
+    finished_pct: 77.8,
+    guesses_per_session: 25.2,
+    ...over,
+  };
+}
+
+function response(slots: LineupSlotRow[], lineups: LineupRow[] = []): LineupsAnalyticsResponse {
+  return {
+    slots: { rows: slots, min_sessions: 30, slots_measured: slots.length },
+    lineups: { rows: lineups, min_sessions: 20, lineups_measured: lineups.length },
+  } as unknown as LineupsAnalyticsResponse;
+}
+
+describe('lineupSlots', () => {
+  it('leads with effort, which is the only thing that separates a slot here', () => {
+    // The solve rate is 99% on the median slot, so a ranking by it reads the
+    // same all the way down.
+    render(<LineupSlots data={response([slot({ slot_id: 1, player: 'Barmby' })])} />);
+
+    expect(screen.getByText('Hardest')).toBeInTheDocument();
+    expect(screen.getByText('5.3 guesses')).toBeInTheDocument();
+  });
+
+  it('names the lineup, because the same footballer elsewhere is a different slot', () => {
+    // The shirt number and the positions around them are what make a player
+    // guessable — "Barmby" on its own is not a thing an editor can fix.
+    render(<LineupSlots data={response([slot({ slot_id: 1, player: 'Barmby' })])} />);
+    const cells = within(screen.getAllByRole('row')[1]).getAllByRole('cell');
+
+    expect(cells[0]).toHaveTextContent('#11');
+    expect(cells[1]).toHaveTextContent('Roma - Lazio');
+  });
+
+  it('keeps the solve rate visible as a floor', () => {
+    // Near-universal by design, so it is not the ranking — but a slot below 90%
+    // is not being solved reliably and that is worth seeing.
+    render(<LineupSlots data={response([slot({ slot_id: 1, player: 'Barmby' })])} />);
+
+    expect(screen.getByText('74.2%')).toBeInTheDocument();
+  });
+
+  it('says nothing was rated rather than showing an empty table', () => {
+    render(<LineupSlots data={response([])} />);
+
+    expect(screen.getByText('No slot was played enough times to rate.')).toBeInTheDocument();
+  });
+});
+
+describe('lineupWorkload', () => {
+  it('puts effort and completion in the same row', () => {
+    // A demanding lineup is only a problem when people stop finishing it, and
+    // separating the two columns would make each look like a verdict.
+    render(<LineupWorkload data={response([], [lineup({ lineup_id: 1, title: 'Roma - Lazio' })])} />);
+    const cells = within(screen.getAllByRole('row')[1]).getAllByRole('cell');
+
+    expect(cells[2]).toHaveTextContent('25.2');
+    expect(cells[3]).toHaveTextContent('77.8%');
+  });
+
+  it('states the threshold it applied', () => {
+    render(<LineupWorkload data={response([], [lineup({ lineup_id: 1, title: 'X' })])} />);
+
+    expect(screen.getByText(/played at least 20 times/)).toBeInTheDocument();
+  });
+});

--- a/components/analytics/__tests__/LineupsAnalytics.test.tsx
+++ b/components/analytics/__tests__/LineupsAnalytics.test.tsx
@@ -43,6 +43,19 @@ describe('lineupSlots', () => {
     expect(screen.getByText('5.3 guesses')).toBeInTheDocument();
   });
 
+  it('shows a dash rather than "null guesses" when the figure is missing', () => {
+    // The field is nullable and the tile checked the ROW rather than the value
+    // (Copilot on #130).
+    render(
+      <LineupSlots
+        data={response([slot({ slot_id: 1, player: 'Unknown', guesses_per_session: null })])}
+      />,
+    );
+
+    expect(screen.queryByText(/null guesses/)).not.toBeInTheDocument();
+    expect(screen.getAllByText('—').length).toBeGreaterThan(0);
+  });
+
   it('names the lineup, because the same footballer elsewhere is a different slot', () => {
     // The shirt number and the positions around them are what make a player
     // guessable — "Barmby" on its own is not a thing an editor can fix.

--- a/components/analytics/panels/LineupSlots.tsx
+++ b/components/analytics/panels/LineupSlots.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import type { LineupsAnalyticsResponse } from '@/types/reports';
+import { EmptyState } from '@/components/reports/primitives/EmptyState';
+import { MetricInfo } from '@/components/reports/primitives/MetricInfo';
+import { MetricRow } from '@/components/reports/primitives/MetricRow';
+import { ReportHead, ReportRow, ReportTable, Td, Th } from '@/components/reports/primitives/ReportTable';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+/**
+ * Which lineup slots cost the most work.
+ *
+ * Ranked by guesses per session rather than by solve rate, which would be a
+ * column of 99s: the game lets a player keep guessing, so almost everything is
+ * eventually solved and effort is the only thing that separates a slot.
+ */
+
+/** Above this many guesses a slot is worth an editor's attention. */
+const NOTABLE_GUESSES = 3;
+
+/** Below this, a slot is not being solved at all reliably. */
+const LOW_SOLVE_PCT = 90;
+
+export function LineupSlots({ data }: { data: LineupsAnalyticsResponse }) {
+  const { rows, min_sessions: minSessions, slots_measured: measured } = data.slots;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          Which slots take the most work
+          <MetricInfo metric="guesses_per_session" />
+        </CardTitle>
+        <CardDescription>
+          Guesses per session, not the share solved. This game lets a player keep
+          guessing, so nearly everything is solved eventually — what separates a
+          slot is how much work it costs to get there.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4 overflow-x-auto">
+        <MetricRow
+          columns={3}
+          metrics={[
+            { label: 'Slots rated', value: measured.toLocaleString(), metric: 'guesses_per_session' },
+            { label: 'Rating needs', value: `${minSessions} sessions` },
+            {
+              label: 'Hardest',
+              value: rows[0] ? `${rows[0].guesses_per_session} guesses` : '—',
+            },
+          ]}
+        />
+
+        {rows.length === 0
+          ? (
+              <EmptyState hint="Try a wider date range.">
+                No slot was played enough times to rate.
+              </EmptyState>
+            )
+          : (
+              <ReportTable>
+                <ReportHead>
+                  <Th>Player</Th>
+                  <Th>Lineup</Th>
+                  <Th align="right">Sessions</Th>
+                  <Th align="right" title="Guesses made on this slot per session that reached it">Guesses each</Th>
+                  <Th align="right" title="Eventually solved — near-universal by design, so read it as a floor">Solved</Th>
+                  <Th align="right" title="Share of sessions where a hint was taken on this slot">Hinted</Th>
+                </ReportHead>
+                <tbody>
+                  {rows.map(row => (
+                    <ReportRow key={row.slot_id}>
+                      <Td strong>
+                        {row.player}
+                        {row.shirt_number !== null && (
+                          <span className="ml-1.5 text-xs font-normal text-muted-foreground">
+                            {`#${row.shirt_number}`}
+                          </span>
+                        )}
+                      </Td>
+                      {/* The lineup, because the same footballer elsewhere is a
+                          different slot — the shirt number and the positions
+                          around them are what make them guessable. */}
+                      <Td className="text-muted-foreground">{row.lineup}</Td>
+                      <Td align="right">{row.sessions.toLocaleString()}</Td>
+                      <Td
+                        align="right"
+                        strong
+                        className={cn(
+                          row.guesses_per_session !== null
+                          && row.guesses_per_session >= NOTABLE_GUESSES
+                          && 'text-amber-600 dark:text-amber-500',
+                        )}
+                      >
+                        {row.guesses_per_session ?? '—'}
+                      </Td>
+                      <Td
+                        align="right"
+                        className={cn(
+                          row.solve_rate_pct !== null && row.solve_rate_pct < LOW_SOLVE_PCT
+                            ? 'text-amber-600 dark:text-amber-500'
+                            : 'text-muted-foreground',
+                        )}
+                      >
+                        {row.solve_rate_pct === null ? '—' : `${row.solve_rate_pct}%`}
+                      </Td>
+                      <Td align="right" className="text-muted-foreground">
+                        {row.hint_rate_pct === null ? '—' : `${row.hint_rate_pct}%`}
+                      </Td>
+                    </ReportRow>
+                  ))}
+                </tbody>
+              </ReportTable>
+            )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/analytics/panels/LineupSlots.tsx
+++ b/components/analytics/panels/LineupSlots.tsx
@@ -16,10 +16,10 @@ import { cn } from '@/lib/utils';
  * eventually solved and effort is the only thing that separates a slot.
  */
 
-/** Above this many guesses a slot is worth an editor's attention. */
+/** At or above this many guesses, a slot is worth an editor's attention. */
 const NOTABLE_GUESSES = 3;
 
-/** Below this, a slot is not being solved at all reliably. */
+/** Under this, a slot is not being solved reliably whatever its effort says. */
 const LOW_SOLVE_PCT = 90;
 
 export function LineupSlots({ data }: { data: LineupsAnalyticsResponse }) {
@@ -46,7 +46,12 @@ export function LineupSlots({ data }: { data: LineupsAnalyticsResponse }) {
             { label: 'Rating needs', value: `${minSessions} sessions` },
             {
               label: 'Hardest',
-              value: rows[0] ? `${rows[0].guesses_per_session} guesses` : '—',
+              // The VALUE, not just the row: `guesses_per_session` is nullable
+              // and a present row with a null figure rendered "null guesses"
+              // (Copilot on #130).
+              value: rows[0]?.guesses_per_session == null
+                ? '—'
+                : `${rows[0].guesses_per_session} guesses`,
             },
           ]}
         />

--- a/components/analytics/panels/LineupWorkload.tsx
+++ b/components/analytics/panels/LineupWorkload.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import type { LineupsAnalyticsResponse } from '@/types/reports';
+import { EmptyState } from '@/components/reports/primitives/EmptyState';
+import { ReportHead, ReportRow, ReportTable, Td, Th } from '@/components/reports/primitives/ReportTable';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+/**
+ * Whole lineups, by the work they ask for.
+ *
+ * A lineup that costs 25 guesses a session is not automatically bad — it may be
+ * eleven obscure players on purpose. It is the one to look at when completion
+ * drops, which is why the two sit in the same row.
+ */
+export function LineupWorkload({ data }: { data: LineupsAnalyticsResponse }) {
+  const { rows, min_sessions: minSessions, lineups_measured: measured } = data.lineups;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Lineups by the work they ask for</CardTitle>
+        <CardDescription>
+          {`${measured.toLocaleString()} lineups played at least ${minSessions} times. Read the two columns together — a demanding lineup is only a problem when people stop finishing it.`}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="overflow-x-auto">
+        {rows.length === 0
+          ? (
+              <EmptyState hint="Try a wider date range.">
+                No lineup was played enough times to rate.
+              </EmptyState>
+            )
+          : (
+              <ReportTable>
+                <ReportHead>
+                  <Th>Lineup</Th>
+                  <Th align="right">Sessions</Th>
+                  <Th align="right" title="Guesses across the whole lineup, per session">Guesses each</Th>
+                  <Th align="right">Finished</Th>
+                </ReportHead>
+                <tbody>
+                  {rows.map(row => (
+                    <ReportRow key={row.lineup_id}>
+                      <Td strong>{row.title}</Td>
+                      <Td align="right">{row.sessions.toLocaleString()}</Td>
+                      <Td align="right" strong>{row.guesses_per_session ?? '—'}</Td>
+                      <Td align="right" className="text-muted-foreground">
+                        {row.finished_pct === null ? '—' : `${row.finished_pct}%`}
+                      </Td>
+                    </ReportRow>
+                  ))}
+                </tbody>
+              </ReportTable>
+            )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/analytics/shell/AnalyticsNav.tsx
+++ b/components/analytics/shell/AnalyticsNav.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { NavGroup } from '@/components/admin/SectionNav';
-import { HelpCircle, Route } from 'lucide-react';
+import { HelpCircle, Route, Users } from 'lucide-react';
 
 /**
  * Analytics, which is not Reports and should not be folded into it.
@@ -13,7 +13,7 @@ import { HelpCircle, Route } from 'lucide-react';
  * weekly by whoever is deciding what to build, and this is read by whoever is
  * writing content, when they are writing it.
  *
- * Grouped rather than flat because three more are coming (App#1475) and a
+ * Grouped rather than flat because two more are coming (App#1475) and a
  * heading that appears later reorganises the section under someone who had
  * learned where things were.
  */
@@ -23,6 +23,7 @@ export const ANALYTICS_NAV_GROUPS: NavGroup[] = [
     items: [
       { href: '/analytics/career-path', label: 'Career Path', icon: Route },
       { href: '/analytics/questions', label: 'Quiz questions', icon: HelpCircle },
+      { href: '/analytics/lineups', label: 'Lineups', icon: Users },
     ],
   },
 ];

--- a/lib/reports-api.ts
+++ b/lib/reports-api.ts
@@ -11,6 +11,7 @@ import type {
   GamesResponse,
   GlossaryResponse,
   GrowthResponse,
+  LineupsAnalyticsResponse,
   MultiplayerResponse,
   PatternsResponse,
   PlayerDetailResponse,
@@ -132,6 +133,11 @@ export class ReportsAPI {
   /** GET /core/analytics/questions/ — question quality and answer distribution. */
   static async getQuestionsAnalytics(params?: ReportParams): Promise<QuestionsAnalyticsResponse> {
     return apiFetcher<QuestionsAnalyticsResponse>(`core/analytics/questions/${buildQuery(params)}`);
+  }
+
+  /** GET /core/analytics/lineups/ — Missing11 slot and lineup difficulty. */
+  static async getLineupsAnalytics(params?: ReportParams): Promise<LineupsAnalyticsResponse> {
+    return apiFetcher<LineupsAnalyticsResponse>(`core/analytics/lineups/${buildQuery(params)}`);
   }
 
   /** GET /core/reporting/content/ — content runway and pool depth. A snapshot. */

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -1012,3 +1012,44 @@ export type QuestionsAnalyticsResponse = {
     bank_used_pct: number | null;
   };
 } & ResolvedRange;
+
+/**
+ * One lineup slot — a single footballer in a single lineup.
+ *
+ * The metric is `guesses_per_session`, not the solve rate. Missing11 lets a
+ * player keep guessing, so the median slot is solved 99% of the time and a
+ * solve-rate ranking reads the same all the way down.
+ */
+export type LineupSlotRow = {
+  slot_id: number;
+  player: string;
+  shirt_number: number | null;
+  lineup_id: number;
+  lineup: string;
+  sessions: number;
+  guesses_per_session: number | null;
+  solve_rate_pct: number | null;
+  /** Share of sessions where a hint was taken on this slot — per session, not per guess. */
+  hint_rate_pct: number | null;
+};
+
+export type LineupRow = {
+  lineup_id: number;
+  title: string;
+  sessions: number;
+  finished_pct: number | null;
+  guesses_per_session: number | null;
+};
+
+export type LineupsAnalyticsResponse = {
+  slots: {
+    rows: LineupSlotRow[];
+    min_sessions: number;
+    slots_measured: number;
+  };
+  lineups: {
+    rows: LineupRow[];
+    min_sessions: number;
+    lineups_measured: number;
+  };
+} & ResolvedRange;


### PR DESCRIPTION
FE for the third dashboard of FootballExtraTime/App#1475, at `/analytics/lineups`. Backend: FootballExtraTime/App#1495.

A solve-rate table would read **99 all the way down** — this game lets a player keep guessing, so almost everything is eventually solved. The metric that separates a slot is how much **work** it takes: 5.3 guesses a session on the worst against roughly one on an easy one.

## The lineup is a column, not a detail

The same footballer in another lineup is a **different slot** — the shirt number and the positions around them are what make them guessable. "Barmby" on its own isn't something an editor can fix.

## The solve rate stays, as a floor

Near-universal by design, so it isn't the ranking. But a slot under 90% isn't being solved reliably whatever its effort figure says, so both get amber at their own thresholds.

## Slots lead, lineups follow

A slot is what gets edited: swap one unguessable footballer and the lineup is fixed. The second panel answers the question the first raises — a bad slot, or a lineup that's hard all the way through — and keeps **effort and completion in the same row**, since a demanding lineup is only a problem when people stop finishing it.

599 tests. Three claims mutation-tested: leading with the solve rate, dropping the lineup column, and separating completion from effort.

Analytics now has three of its five destinations. Next: the Lineup admin view comes out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)