### PR TITLE
Two panels, not a fourth destination

### DIFF
--- a/app/analytics/questions/page.tsx
+++ b/app/analytics/questions/page.tsx
@@ -2,6 +2,8 @@
 
 import type { RangeState } from '@/lib/report-range';
 import { useMemo } from 'react';
+import { CategoryQuality } from '@/components/analytics/panels/CategoryQuality';
+import { GlobalQuizUsage } from '@/components/analytics/panels/GlobalQuizUsage';
 import { QuestionBank } from '@/components/analytics/panels/QuestionBank';
 import { QuestionQuality } from '@/components/analytics/panels/QuestionQuality';
 import { AnalyticsShell } from '@/components/analytics/shell/AnalyticsShell';
@@ -52,8 +54,8 @@ export default function QuestionsAnalyticsPage() {
 
   return (
     <AnalyticsShell
-      title="Question quality"
-      description="Which questions are broken, and how — read from what players chose, not just whether they were right."
+      title="Quiz content"
+      description="Which questions are broken, which subjects are weakest, and which quizzes people played."
     >
       <FilterBar>
         <RangePicker
@@ -78,6 +80,24 @@ export default function QuestionsAnalyticsPage() {
 
       <ReportPanel state={state} skeletonClassName="h-64 w-full">
         {data => <QuestionBank data={data} />}
+      </ReportPanel>
+
+      {/* The Quiz dashboard's content half, folded in here rather than given its
+          own destination (#1475). Its other half was top players by quizzes
+          played, which is Reports and better there. Two panels about this same
+          bank do not earn a nav entry — the argument R4 used to cut the
+          reporting nav from ten destinations to six. */}
+      <SectionHeader
+        title="Categories and what ran"
+        description="Where the bank is weakest by subject, and which scheduled quizzes people actually played."
+      />
+
+      <ReportPanel state={state} skeletonClassName="h-80 w-full">
+        {data => <CategoryQuality data={data} />}
+      </ReportPanel>
+
+      <ReportPanel state={state} skeletonClassName="h-64 w-full">
+        {data => <GlobalQuizUsage data={data} />}
       </ReportPanel>
     </AnalyticsShell>
   );

--- a/components/analytics/__tests__/QuestionsAnalytics.test.tsx
+++ b/components/analytics/__tests__/QuestionsAnalytics.test.tsx
@@ -1,6 +1,8 @@
 import type { QuestionRow, QuestionsAnalyticsResponse } from '@/types/reports';
 import { render, screen, within } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
+import { CategoryQuality } from '@/components/analytics/panels/CategoryQuality';
+import { GlobalQuizUsage } from '@/components/analytics/panels/GlobalQuizUsage';
 import { QuestionBank } from '@/components/analytics/panels/QuestionBank';
 import { QuestionQuality } from '@/components/analytics/panels/QuestionQuality';
 
@@ -40,6 +42,21 @@ function response(rows: QuestionRow[], over: Partial<QuestionsAnalyticsResponse[
       min_answers: 30,
       questions_measured: 2487,
       beaten_by_a_wrong_answer: rows.filter(r => r.beaten_by_a_wrong_answer).length,
+    },
+    categories: {
+      rows: [
+        { category_id: 1, name: 'Portsmouth', questions: 4, questions_answered: 4, answers: 204, correct_pct: 37.7 },
+        { category_id: 2, name: 'Japan', questions: 16, questions_answered: 9, answers: 204, correct_pct: 43.6 },
+      ],
+      min_answers: 200,
+      categories_measured: 210,
+    },
+    quizzes: {
+      rows: [
+        { quiz_id: 1, title: 'England', plays: 2940, scheduled_days: 549, plays_per_day: 5.4 },
+        { quiz_id: 2, title: 'Rare one', plays: 40, scheduled_days: 2, plays_per_day: 20 },
+      ],
+      total_plays: 12238,
     },
     shape: {
       difficulty: [
@@ -165,5 +182,58 @@ describe('questionBank', () => {
 
     expect(rows.map(row => within(row).getAllByRole('cell')[0].textContent?.trim()))
       .toEqual(['EASY', 'NORMAL', 'EXTREME']);
+  });
+});
+
+describe('categoryQuality', () => {
+  it('leads with the hardest category, not the busiest', () => {
+    // The dashboard this replaces ranked by how many quizzes used a category,
+    // which is a fact about scheduling rather than about the questions.
+    render(<CategoryQuality data={response([])} />);
+    const rows = screen.getAllByRole('row').slice(1);
+
+    expect(within(rows[0]).getAllByRole('cell')[0]).toHaveTextContent('Portsmouth');
+    expect(within(rows[0]).getAllByRole('cell')[3]).toHaveTextContent('37.7%');
+  });
+
+  it('shows how many questions sit behind a category', () => {
+    // Four questions is an afternoon; forty is a project. The rate alone does
+    // not say which.
+    render(<CategoryQuality data={response([])} />);
+    const rows = screen.getAllByRole('row').slice(1);
+
+    expect(within(rows[0]).getAllByRole('cell')[1]).toHaveTextContent('4');
+  });
+
+  it('shows how much of a category anyone was actually served', () => {
+    // A question nobody was served is invisible to the rate and still has to be
+    // rewritten, so the size of the fix and the basis of the rate are separate.
+    render(<CategoryQuality data={response([])} />);
+
+    expect(screen.getByText('9 served')).toBeInTheDocument();
+  });
+
+  it('says why the list stops where it does', () => {
+    render(<CategoryQuality data={response([])} />);
+
+    expect(screen.getByText(/answered at least 200 times/)).toBeInTheDocument();
+  });
+});
+
+describe('globalQuizUsage', () => {
+  it('shows plays per day offered, which is the comparable figure', () => {
+    // 40 plays over 2 days beats 2,940 over 549. The raw total says the
+    // opposite, and mostly measures how often a quiz was scheduled.
+    render(<GlobalQuizUsage data={response([])} />);
+    const rows = screen.getAllByRole('row').slice(1);
+
+    expect(within(rows[0]).getAllByRole('cell')[3]).toHaveTextContent('5.4');
+    expect(within(rows[1]).getAllByRole('cell')[3]).toHaveTextContent('20');
+  });
+
+  it('tells the reader which column to trust', () => {
+    render(<GlobalQuizUsage data={response([])} />);
+
+    expect(screen.getByText(/Read the per-day column rather than the total/)).toBeInTheDocument();
   });
 });

--- a/components/analytics/panels/CategoryQuality.tsx
+++ b/components/analytics/panels/CategoryQuality.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import type { QuestionsAnalyticsResponse } from '@/types/reports';
+import { EmptyState } from '@/components/reports/primitives/EmptyState';
+import { MetricInfo } from '@/components/reports/primitives/MetricInfo';
+import { ReportHead, ReportRow, ReportTable, Td, Th } from '@/components/reports/primitives/ReportTable';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+/**
+ * Categories ranked by how often players get them wrong.
+ *
+ * The admin dashboard this replaces ranked them by how many QUIZZES used them,
+ * which is a fact about scheduling. This is the level an editor commissions at:
+ * nobody writes one question, they write ten about Portsmouth.
+ */
+
+/** Below this, a category is harder than the bank's own EXTREME tier. */
+const HARD_PCT = 50;
+
+export function CategoryQuality({ data }: { data: QuestionsAnalyticsResponse }) {
+  const { rows, min_answers: minAnswers, categories_measured: measured } = data.categories;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          Which categories are hardest
+          <MetricInfo metric="category_correct_rate" />
+        </CardTitle>
+        <CardDescription>
+          {`${measured.toLocaleString()} categories were answered at least ${minAnswers} times. The rest of the bank's 2,017 are a handful of questions about one footballer, which is why the list stops here rather than listing them all.`}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="overflow-x-auto">
+        {rows.length === 0
+          ? (
+              <EmptyState hint="Try a wider date range.">
+                No category was answered enough times to rate.
+              </EmptyState>
+            )
+          : (
+              <ReportTable>
+                <ReportHead>
+                  <Th>Category</Th>
+                  <Th align="right" title="Questions in this category that were answered in the window">Questions</Th>
+                  <Th align="right">Answers</Th>
+                  <Th align="right">Correct</Th>
+                </ReportHead>
+                <tbody>
+                  {rows.map(row => (
+                    <ReportRow key={row.category_id}>
+                      <Td strong>{row.name}</Td>
+                      {/* Both counts, because they answer different questions.
+                          `questions` is what a fix would cost — four is an
+                          afternoon, forty is a project — and `questions_answered`
+                          is how much of the category the rate is actually about.
+                          A question nobody was served is invisible to the rate
+                          and still has to be rewritten. */}
+                      <Td align="right" className="text-muted-foreground">
+                        {row.questions.toLocaleString()}
+                        {row.questions_answered < row.questions && (
+                          <span className="mt-0.5 block text-xs">
+                            {`${row.questions_answered.toLocaleString()} served`}
+                          </span>
+                        )}
+                      </Td>
+                      <Td align="right">{row.answers.toLocaleString()}</Td>
+                      <Td
+                        align="right"
+                        strong
+                        className={cn(
+                          row.correct_pct !== null && row.correct_pct < HARD_PCT
+                          && 'text-amber-600 dark:text-amber-500',
+                        )}
+                      >
+                        {row.correct_pct === null ? '—' : `${row.correct_pct}%`}
+                      </Td>
+                    </ReportRow>
+                  ))}
+                </tbody>
+              </ReportTable>
+            )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/analytics/panels/GlobalQuizUsage.tsx
+++ b/components/analytics/panels/GlobalQuizUsage.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import type { QuestionsAnalyticsResponse } from '@/types/reports';
+import { EmptyState } from '@/components/reports/primitives/EmptyState';
+import { MetricInfo } from '@/components/reports/primitives/MetricInfo';
+import { ReportHead, ReportRow, ReportTable, Td, Th } from '@/components/reports/primitives/ReportTable';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+/**
+ * Which scheduled quizzes ran, and how much they were played.
+ *
+ * Sorted by total plays because that is what the payload ranks by, but the
+ * column that answers "is this quiz any good" is plays per day it was offered —
+ * the total mostly measures how often it was scheduled.
+ */
+export function GlobalQuizUsage({ data }: { data: QuestionsAnalyticsResponse }) {
+  const { rows, total_plays: totalPlays } = data.quizzes;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          Which quizzes ran
+          <MetricInfo metric="quiz_plays_per_day" />
+        </CardTitle>
+        <CardDescription>
+          {`${totalPlays.toLocaleString()} plays across the quizzes scheduled in this window. Read the per-day column rather than the total — the total mostly says how often a quiz was offered.`}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="overflow-x-auto">
+        {rows.length === 0
+          ? (
+              <EmptyState hint="Try a wider date range.">
+                No quiz was scheduled in this window.
+              </EmptyState>
+            )
+          : (
+              <ReportTable>
+                <ReportHead>
+                  <Th>Quiz</Th>
+                  <Th align="right" title="Days this quiz was actually offered">Days offered</Th>
+                  <Th align="right">Plays</Th>
+                  <Th align="right" title="Plays divided by the days it was offered — the comparable figure">Per day</Th>
+                </ReportHead>
+                <tbody>
+                  {rows.map(row => (
+                    <ReportRow key={row.quiz_id}>
+                      <Td strong>{row.title}</Td>
+                      <Td align="right" className="text-muted-foreground">
+                        {row.scheduled_days.toLocaleString()}
+                      </Td>
+                      <Td align="right" className="text-muted-foreground">
+                        {row.plays.toLocaleString()}
+                      </Td>
+                      <Td align="right" strong>
+                        {row.plays_per_day === null ? '—' : row.plays_per_day.toLocaleString()}
+                      </Td>
+                    </ReportRow>
+                  ))}
+                </tbody>
+              </ReportTable>
+            )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/analytics/shell/AnalyticsNav.tsx
+++ b/components/analytics/shell/AnalyticsNav.tsx
@@ -13,7 +13,7 @@ import { HelpCircle, Route, Users } from 'lucide-react';
  * weekly by whoever is deciding what to build, and this is read by whoever is
  * writing content, when they are writing it.
  *
- * Grouped rather than flat because two more are coming (App#1475) and a
+ * Grouped rather than flat because one more is coming (App#1475) and a
  * heading that appears later reorganises the section under someone who had
  * learned where things were.
  */
@@ -22,7 +22,7 @@ export const ANALYTICS_NAV_GROUPS: NavGroup[] = [
     heading: 'Per game',
     items: [
       { href: '/analytics/career-path', label: 'Career Path', icon: Route },
-      { href: '/analytics/questions', label: 'Quiz questions', icon: HelpCircle },
+      { href: '/analytics/questions', label: 'Quiz content', icon: HelpCircle },
       { href: '/analytics/lineups', label: 'Lineups', icon: Users },
     ],
   },

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -997,7 +997,43 @@ export type QuestionRow = {
   beaten_by_a_wrong_answer: boolean;
 };
 
+/** One category, ranked by how often players get it wrong. */
+export type CategoryRow = {
+  category_id: number;
+  name: string;
+  /** Every question in the category — what a fix would cost. */
+  questions: number;
+  /** The part of it anyone was served in the window — what the rate is about. */
+  questions_answered: number;
+  answers: number;
+  correct_pct: number | null;
+};
+
+/**
+ * One global quiz's usage.
+ *
+ * `plays_per_day` is the figure to read: the raw total measures scheduling, so
+ * a quiz offered twice and played 40 times looks less popular than one offered
+ * 500 times and played 15,000.
+ */
+export type GlobalQuizRow = {
+  quiz_id: number;
+  title: string;
+  plays: number;
+  scheduled_days: number;
+  plays_per_day: number | null;
+};
+
 export type QuestionsAnalyticsResponse = {
+  categories: {
+    rows: CategoryRow[];
+    min_answers: number;
+    categories_measured: number;
+  };
+  quizzes: {
+    rows: GlobalQuizRow[];
+    total_plays: number;
+  };
   quality: {
     rows: QuestionRow[];
     min_answers: number;


### PR DESCRIPTION
FE for the folded Quiz dashboard (FootballExtraTime/App#1498). Categories and global quizzes join the questions page rather than getting a nav entry of their own — the page is now **Quiz content** and covers the bank end to end.

That's the whole finding about this dashboard: its biggest block was *top players by quizzes played*, which is Reports and better there. What remained doesn't fill a page, and **two panels don't earn a destination** — the argument R4 used to cut the reporting nav from ten to six.

## Categories ranked by difficulty, not by how many quizzes used them

| category | correct |
|---|---|
| Portsmouth | **37.7%** |
| Japan | 43.6% |

Both question counts are shown where they differ: the category's **size** is what a fix would cost, and the part anyone was **served** is what the rate is about. A question nobody has been given is invisible to the rate and still has to be rewritten.

## Quizzes by plays per day offered

With the total beside it and the copy saying which to read. The total mostly measures scheduling — a quiz offered twice and played 40 times is not less popular than one offered 549 times and played 2,940.

Those figures are the **corrected** ones: the backend now counts plays from the sessions rather than from a counter a signal increments for bot accounts too, which was inflating them roughly tenfold.

606 tests. Four claims mutation-tested.

Four of five dashboards done. Remaining: Football Data Analytics, then the Quiz admin view comes out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)