### PR TITLE
Say what each gap breaks, beside how big it is

### DIFF
--- a/app/analytics/football-data/page.tsx
+++ b/app/analytics/football-data/page.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import type { RangeState } from '@/lib/report-range';
+import { useMemo } from 'react';
+import { DataCoverage } from '@/components/analytics/panels/DataCoverage';
+import { AnalyticsShell } from '@/components/analytics/shell/AnalyticsShell';
+import { FilterBar } from '@/components/reports/filters/FilterBar';
+import { RangePicker } from '@/components/reports/filters/RangePicker';
+import { ReportPanel } from '@/components/reports/primitives/ReportPanel';
+import { useReport } from '@/hooks/use-report';
+import { useReportFilters } from '@/hooks/use-report-filters';
+import { useAuth } from '@/lib/auth';
+import { rangeToParams } from '@/lib/report-range';
+import { ReportsAPI } from '@/lib/reports-api';
+
+/**
+ * Football data completeness — the one analytics page that is not about a game.
+ *
+ * It earns its own destination rather than folding in because every game reads
+ * this data: a gap here is not a Career Path problem or a Scout problem, it is
+ * both. And the answer it produces is "go and add data" rather than "go and
+ * rewrite content", which is a different job for a different person.
+ */
+export default function FootballDataAnalyticsPage() {
+  const { isAuthenticated, user } = useAuth();
+  const enabled = isAuthenticated && !!(user?.is_staff || user?.is_superuser);
+
+  const { filters, update } = useReportFilters({
+    range: { window: 90 },
+    includeBots: false,
+    game: null,
+    metric: 'games_started',
+  });
+  const { range, includeBots } = filters;
+  const setRange = (next: RangeState) => update({ range: next });
+  const setIncludeBots = (next: boolean) => update({ includeBots: next });
+  const params = useMemo(
+    () => ({ ...rangeToParams(range), include_bots: includeBots }),
+    [range, includeBots],
+  );
+
+  const state = useReport(
+    ReportsAPI.getCoverage,
+    params,
+    enabled,
+    'The football data coverage endpoint',
+  );
+
+  return (
+    <AnalyticsShell
+      title="Football data"
+      description="What the games are missing, counted where it is actually used."
+    >
+      <FilterBar>
+        <RangePicker
+          value={range}
+          onChange={setRange}
+          includeBots={includeBots}
+          onIncludeBotsChange={setIncludeBots}
+        />
+      </FilterBar>
+
+      <ReportPanel state={state} skeletonClassName="h-96 w-full">
+        {data => <DataCoverage data={data} />}
+      </ReportPanel>
+    </AnalyticsShell>
+  );
+}

--- a/components/analytics/__tests__/DataCoverage.test.tsx
+++ b/components/analytics/__tests__/DataCoverage.test.tsx
@@ -1,0 +1,90 @@
+import type { CoverageCheck, CoverageResponse } from '@/types/reports';
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { DataCoverage } from '@/components/analytics/panels/DataCoverage';
+
+function check(over: Partial<CoverageCheck> & Pick<CoverageCheck, 'key' | 'label'>): CoverageCheck {
+  return {
+    breaks: 'Something breaks.',
+    served_missing: 0,
+    served_missing_pct: 0,
+    unserved_missing: 0,
+    ...over,
+  };
+}
+
+function response(over: Partial<CoverageResponse> = {}): CoverageResponse {
+  return {
+    checks: [
+      check({
+        key: 'picture',
+        label: 'Active picture',
+        breaks: 'Scout serves the dossier with no image rather than failing, so this degrades quietly.',
+        served_missing: 4609,
+        served_missing_pct: 82.1,
+        unserved_missing: 362,
+      }),
+      check({
+        key: 'club',
+        label: 'Club history',
+        breaks: 'Career Path cannot build a path without it — the footballer is unusable there.',
+        unserved_missing: 3,
+      }),
+    ],
+    served: 5617,
+    unserved: 365,
+    by_difficulty: [
+      { difficulty: 'HARD', served: 2272, picture: 1963, club: 0, nation: 0 },
+      { difficulty: 'EASY', served: 954, picture: 672, club: 0, nation: 0 },
+    ],
+    ...over,
+  } as unknown as CoverageResponse;
+}
+
+describe('dataCoverage', () => {
+  it('keeps served and unserved gaps in separate columns', () => {
+    // A gap in a row nothing serves costs nothing. One percentage across both
+    // populations is true of neither.
+    render(<DataCoverage data={response()} />);
+    const cells = within(screen.getAllByRole('row')[1]).getAllByRole('cell');
+
+    expect(cells[1]).toHaveTextContent('4,609');
+    expect(cells[1]).toHaveTextContent('82.1%');
+    expect(cells[2]).toHaveTextContent('362');
+  });
+
+  it('says what each gap breaks, because they are not equivalent', () => {
+    // A missing club makes a footballer unusable; a missing picture degrades
+    // quietly. A table listing both without that invites fixing the cheap one.
+    render(<DataCoverage data={response()} />);
+
+    expect(screen.getByText(/unusable there/)).toBeInTheDocument();
+    expect(screen.getByText(/degrades quietly/)).toBeInTheDocument();
+  });
+
+  it('states a clean check rather than leaving it blank', () => {
+    // A check earns its place by being able to say a thing is fine.
+    render(<DataCoverage data={response()} />);
+    const cells = within(screen.getAllByRole('row')[2]).getAllByRole('cell');
+
+    expect(cells[1]).toHaveTextContent('0');
+  });
+
+  it('reports "none" when nothing is missing at all', () => {
+    render(
+      <DataCoverage
+        data={response({ checks: [check({ key: 'club', label: 'Club history' })] })}
+      />,
+    );
+
+    expect(screen.getByText('none')).toBeInTheDocument();
+  });
+
+  it('breaks the picture gap down by difficulty, where it costs most', () => {
+    // The footballers players most need a visual cue for are the hard ones.
+    render(<DataCoverage data={response()} />);
+
+    expect(screen.getByText('1,963 (86%)')).toBeInTheDocument();
+    expect(screen.getByText('672 (70%)')).toBeInTheDocument();
+  });
+});

--- a/components/analytics/panels/DataCoverage.tsx
+++ b/components/analytics/panels/DataCoverage.tsx
@@ -15,7 +15,7 @@ import { cn } from '@/lib/utils';
  * true of neither.
  */
 
-/** Above this share missing, a check is worth acting on rather than noting. */
+/** At or above this share missing, a check is worth acting on rather than noting. */
 const NOTABLE_PCT = 10;
 
 export function DataCoverage({ data }: { data: CoverageResponse }) {

--- a/components/analytics/panels/DataCoverage.tsx
+++ b/components/analytics/panels/DataCoverage.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import type { CoverageResponse } from '@/types/reports';
+import { MetricInfo } from '@/components/reports/primitives/MetricInfo';
+import { MetricRow } from '@/components/reports/primitives/MetricRow';
+import { ReportHead, ReportRow, ReportTable, Td, Th } from '@/components/reports/primitives/ReportTable';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+/**
+ * What is missing from the football data, where it is actually used.
+ *
+ * The served and unserved populations stay apart on purpose. A gap in a row
+ * nothing serves costs nothing today, and one percentage across both would be
+ * true of neither.
+ */
+
+/** Above this share missing, a check is worth acting on rather than noting. */
+const NOTABLE_PCT = 10;
+
+export function DataCoverage({ data }: { data: CoverageResponse }) {
+  const worst = data.checks.reduce<number>(
+    (highest, check) => Math.max(highest, check.served_missing_pct ?? 0),
+    0,
+  );
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          What is missing where it is used
+          <MetricInfo metric="data_coverage" />
+        </CardTitle>
+        <CardDescription>
+          Counted over the footballers actually put in front of players. The bank
+          also holds rows nobody has been served, and their gaps cost nothing
+          today — they are reported apart rather than averaged in.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4 overflow-x-auto">
+        <MetricRow
+          columns={3}
+          metrics={[
+            { label: 'Footballers served', value: data.served.toLocaleString(), metric: 'data_coverage' },
+            { label: 'Never served', value: data.unserved.toLocaleString() },
+            { label: 'Worst gap', value: worst ? `${worst}%` : 'none' },
+          ]}
+        />
+
+        <ReportTable>
+          <ReportHead>
+            <Th>Needs</Th>
+            <Th align="right" title="Footballers served to players that are missing it">Missing</Th>
+            <Th align="right" title="In the bank but never served — a gap that costs nothing today">Unserved</Th>
+            <Th>What breaks without it</Th>
+          </ReportHead>
+          <tbody>
+            {data.checks.map(check => (
+              <ReportRow key={check.key}>
+                <Td strong>{check.label}</Td>
+                <Td
+                  align="right"
+                  strong
+                  className={cn(
+                    check.served_missing_pct !== null && check.served_missing_pct >= NOTABLE_PCT
+                      ? 'text-amber-600 dark:text-amber-500'
+                      // A clean check earns its place by being able to say a
+                      // thing is fine, so zero is stated rather than blank.
+                      : 'text-emerald-600 dark:text-emerald-400',
+                  )}
+                >
+                  {check.served_missing.toLocaleString()}
+                  {check.served_missing_pct !== null && (
+                    <span className="mt-0.5 block text-xs font-normal text-muted-foreground">
+                      {`${check.served_missing_pct}%`}
+                    </span>
+                  )}
+                </Td>
+                <Td align="right" className="text-muted-foreground">
+                  {check.unserved_missing.toLocaleString()}
+                </Td>
+                {/* The gaps are not equivalent, and a table listing them without
+                    saying so invites fixing the cheap one. */}
+                <Td className="text-xs text-muted-foreground">{check.breaks}</Td>
+              </ReportRow>
+            ))}
+          </tbody>
+        </ReportTable>
+
+        {data.by_difficulty.length > 0 && (
+          <div className="space-y-2 border-t pt-4">
+            <p className="text-xs font-medium text-muted-foreground">
+              Missing pictures by declared difficulty
+            </p>
+            <ReportTable>
+              <ReportHead>
+                <Th>Graded</Th>
+                <Th align="right">Served</Th>
+                <Th align="right">No picture</Th>
+              </ReportHead>
+              <tbody>
+                {data.by_difficulty.map(row => (
+                  <ReportRow key={String(row.difficulty)}>
+                    <Td strong>
+                      {row.difficulty ?? <span className="text-muted-foreground">Not graded</span>}
+                    </Td>
+                    <Td align="right">{row.served.toLocaleString()}</Td>
+                    <Td align="right" className="text-muted-foreground">
+                      {`${row.picture.toLocaleString()}${row.served ? ` (${Math.round((row.picture / row.served) * 100)}%)` : ''}`}
+                    </Td>
+                  </ReportRow>
+                ))}
+              </tbody>
+            </ReportTable>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/analytics/shell/AnalyticsNav.tsx
+++ b/components/analytics/shell/AnalyticsNav.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { NavGroup } from '@/components/admin/SectionNav';
-import { HelpCircle, Route, Users } from 'lucide-react';
+import { Database, HelpCircle, Route, Users } from 'lucide-react';
 
 /**
  * Analytics, which is not Reports and should not be folded into it.
@@ -24,6 +24,15 @@ export const ANALYTICS_NAV_GROUPS: NavGroup[] = [
       { href: '/analytics/career-path', label: 'Career Path', icon: Route },
       { href: '/analytics/questions', label: 'Quiz content', icon: HelpCircle },
       { href: '/analytics/lineups', label: 'Lineups', icon: Users },
+    ],
+  },
+  {
+    // Its own group, not a fourth per-game entry: every game reads this data,
+    // so a gap here belongs to none of them in particular — and the answer it
+    // produces is "add data" rather than "rewrite content".
+    heading: 'Across the platform',
+    items: [
+      { href: '/analytics/football-data', label: 'Football data', icon: Database },
     ],
   },
 ];

--- a/lib/reports-api.ts
+++ b/lib/reports-api.ts
@@ -4,6 +4,7 @@ import type {
   AttemptsResponse,
   CareerPathAnalyticsResponse,
   ContentResponse,
+  CoverageResponse,
   DifficultyResponse,
   DurationResponse,
   FallbacksResponse,
@@ -138,6 +139,11 @@ export class ReportsAPI {
   /** GET /core/analytics/lineups/ — Missing11 slot and lineup difficulty. */
   static async getLineupsAnalytics(params?: ReportParams): Promise<LineupsAnalyticsResponse> {
     return apiFetcher<LineupsAnalyticsResponse>(`core/analytics/lineups/${buildQuery(params)}`);
+  }
+
+  /** GET /core/analytics/football-data/ — data completeness where it is used. */
+  static async getCoverage(params?: ReportParams): Promise<CoverageResponse> {
+    return apiFetcher<CoverageResponse>(`core/analytics/football-data/${buildQuery(params)}`);
   }
 
   /** GET /core/reporting/content/ — content runway and pool depth. A snapshot. */

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -1089,3 +1089,35 @@ export type LineupsAnalyticsResponse = {
     lineups_measured: number;
   };
 } & ResolvedRange;
+
+/**
+ * One completeness check on the football data.
+ *
+ * `served_missing` and `unserved_missing` are never averaged: a gap in a row
+ * nothing serves costs nothing, and one percentage across both is true of
+ * neither population.
+ */
+export type CoverageCheck = {
+  key: string;
+  label: string;
+  /** What breaks without it — the gaps are not equivalent. */
+  breaks: string;
+  served_missing: number;
+  served_missing_pct: number | null;
+  unserved_missing: number;
+};
+
+export type CoverageResponse = {
+  checks: CoverageCheck[];
+  /** Footballers put in front of a real player in the window. */
+  served: number;
+  /** In the bank, never served. Their gaps cost nothing today. */
+  unserved: number;
+  by_difficulty: {
+    difficulty: string | null;
+    served: number;
+    picture: number;
+    club: number;
+    nation: number;
+  }[];
+} & ResolvedRange;


### PR DESCRIPTION
FE for the fifth dashboard of FootballExtraTime/App#1475, at `/analytics/football-data`. Backend: FootballExtraTime/App#1499.

**Its own destination and its own nav group.** Every game reads this data, so a gap here belongs to none of them in particular — and the answer it produces is *"add data"* rather than *"rewrite content"*, which is a different job for a different person.

## Served and unserved stay in separate columns

A gap in a row nothing serves costs nothing today, and one percentage across both populations would be true of neither.

## Each check says what it breaks

- **Missing club** — Career Path cannot build a path. *Unusable.*
- **Missing picture** — Scout serves the dossier without an image rather than failing. *Degrades quietly.*

Listing both as "missing data" invites fixing the cheap one.

## A clean check is stated in green, not left blank

Club history and nation are complete on every served footballer. A check earns its place by being able to say a thing is fine — a blank cell reads as *"not measured"*.

## Worst where it costs most

The picture gap by declared difficulty: **86%** of served HARD footballers have no picture against **70%** at EASY. The hard ones are exactly the footballers players need a visual cue for.

611 tests. Three claims mutation-tested.

All five dashboards now exist in `automation_et`. What's left of #1475 is removing the last two admin views.

🤖 Generated with [Claude Code](https://claude.com/claude-code)