### PR TITLE
Finish R9: the sparkline it was missing

### DIFF
--- a/app/reports/games/page.tsx
+++ b/app/reports/games/page.tsx
@@ -22,6 +22,7 @@ import { MetricInfo } from '@/components/reports/primitives/MetricInfo';
 import { ReportPanel } from '@/components/reports/primitives/ReportPanel';
 import { ReportHead, ReportRow, ReportTable, Td, Th } from '@/components/reports/primitives/ReportTable';
 import { SectionHeader } from '@/components/reports/primitives/SectionHeader';
+import { Sparkline } from '@/components/reports/primitives/Sparkline';
 import { ReportsShell } from '@/components/reports/shell/ReportsShell';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { useFavouredVsPlayed } from '@/hooks/use-favoured-vs-played';
@@ -209,6 +210,10 @@ export default function GamesIndexPage() {
                         <MetricInfo metric={column.metric} />
                       </Th>
                     ))}
+                    {/* Not sortable: there is no single number to sort a shape
+                        by, and the Trend column beside it already sorts on the
+                        figure this draws. */}
+                    <Th title="Daily sessions over the last 30 days of the window">Shape</Th>
                   </ReportHead>
                   <tbody>
                     {rows.map((row: GameRowWithDuration) => (
@@ -254,6 +259,22 @@ export default function GamesIndexPage() {
                                   %
                                 </span>
                               )}
+                        </Td>
+                        {/* The shape beside the figure (#1474 R9). A trend
+                            percentage says a game is down 12% and cannot say
+                            whether it fell off a cliff on Tuesday or has been
+                            sliding for a month — those want different
+                            responses, and the second page nobody opens is where
+                            that distinction used to live. */}
+                        <Td>
+                          {data.series?.[row.game_type]
+                            ? (
+                                <Sparkline
+                                  points={data.series[row.game_type]}
+                                  label={`Daily sessions for ${meta[row.game_type]?.display_name ?? row.game_type}`}
+                                />
+                              )
+                            : <span className="text-muted-foreground/70">—</span>}
                         </Td>
                       </ReportRow>
                     ))}

--- a/components/reports/__tests__/Sparkline.test.tsx
+++ b/components/reports/__tests__/Sparkline.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Sparkline } from '@/components/reports/primitives/Sparkline';
+import { toPath } from '@/lib/sparkline';
+
+describe('toPath', () => {
+  it('breaks the line where the data is unknown', () => {
+    // `null` is a day the rollup never computed, not a zero. Joined across, the
+    // line draws a slope nobody measured; drawn as zero it shows a collapse.
+    const path = toPath([10, 12, null, 14, 15]);
+    const moves = path.match(/M/g) ?? [];
+
+    // Two subpaths: one before the gap, one after.
+    expect(moves).toHaveLength(2);
+  });
+
+  it('centres a flat series rather than dividing by zero', () => {
+    // Every value equal means no span to scale against. Naively that puts the
+    // line along the top edge, which reads as a maximum.
+    const path = toPath([5, 5, 5, 5]);
+
+    expect(path).toContain('10.0');
+    expect(path).not.toContain('NaN');
+  });
+
+  it('draws nothing from a single point, which has no direction', () => {
+    expect(toPath([7])).toBe('');
+    expect(toPath([null, 7, null])).toBe('');
+  });
+
+  it('spans the full height between the lowest and highest values', () => {
+    const path = toPath([0, 100]);
+
+    // Bottom and top, inset by the stroke so neither clips.
+    expect(path).toContain('18.5');
+    expect(path).toContain('1.5');
+  });
+});
+
+describe('sparkline', () => {
+  it('carries a label, so the shape is not the only way to read it', () => {
+    render(<Sparkline points={[1, 5, 3]} label="Daily sessions for Grid" />);
+
+    expect(screen.getByRole('img', { name: 'Daily sessions for Grid' })).toBeInTheDocument();
+  });
+
+  it('shows a dash rather than an empty box when there is no shape', () => {
+    // An empty SVG in a table cell reads as a rendering failure.
+    render(<Sparkline points={[4]} label="Daily sessions for Grid" />);
+
+    expect(screen.getByText('—')).toBeInTheDocument();
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
+
+  it('colours by direction, comparing the ends rather than the extremes', () => {
+    // A game that spiked mid-window and came back down has not risen.
+    const { container: falling } = render(<Sparkline points={[10, 99, 2]} label="x" />);
+
+    expect(falling.querySelector('path')?.getAttribute('class')).toContain('red');
+
+    const { container: rising } = render(<Sparkline points={[2, 1, 10]} label="y" />);
+
+    expect(rising.querySelector('path')?.getAttribute('class')).toContain('emerald');
+  });
+});

--- a/components/reports/primitives/Sparkline.tsx
+++ b/components/reports/primitives/Sparkline.tsx
@@ -1,0 +1,56 @@
+import type { SparklinePoint } from '@/lib/sparkline';
+import { HEIGHT, toPath, VIEWBOX, WIDTH } from '@/lib/sparkline';
+import { cn } from '@/lib/utils';
+
+/**
+ * Direction for one row of a ranked table, in the width of a cell.
+ *
+ * The last of R9's shared pieces, and the one that had to wait: it needs a
+ * per-row series, and until `per_game_series` shipped no endpoint returned one.
+ * Building it earlier would have meant building it against imagined data.
+ *
+ * Deliberately not a chart library. Recharts needs a measured container and
+ * renders nothing at this size in a table cell; this is one `<path>` and no
+ * axes, because a sparkline that needs a legend is a chart in the wrong place.
+ * The trend column beside it carries the precise figure — this only has to show
+ * the shape.
+ */
+export function Sparkline({ points, label, className }: {
+  points: SparklinePoint[];
+  /** What the line is of, for anyone not reading it visually. */
+  label: string;
+  className?: string;
+}) {
+  const path = toPath(points);
+  if (!path) {
+    // Two points is the minimum that has a direction. One is a dot pretending
+    // to be a trend.
+    return <span className={cn('text-xs text-muted-foreground/70', className)}>—</span>;
+  }
+
+  const known = points.filter((point): point is number => point !== null);
+  const rising = known[known.length - 1] >= known[0];
+
+  return (
+    <svg
+      viewBox={VIEWBOX}
+      width={WIDTH}
+      height={HEIGHT}
+      className={cn('overflow-visible', className)}
+      role="img"
+      aria-label={label}
+      preserveAspectRatio="none"
+    >
+      <path
+        d={path}
+        fill="none"
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className={rising
+          ? 'stroke-emerald-500 dark:stroke-emerald-400'
+          : 'stroke-red-500 dark:stroke-red-400'}
+      />
+    </svg>
+  );
+}

--- a/lib/sparkline.ts
+++ b/lib/sparkline.ts
@@ -1,0 +1,56 @@
+/**
+ * The geometry behind the table sparkline.
+ *
+ * Its own module so the one decision worth testing is testable without a DOM,
+ * and because exporting a helper from a component file breaks fast refresh —
+ * the same reason `lib/growth-flow.ts` exists.
+ */
+
+export const WIDTH = 72;
+export const HEIGHT = 20;
+/** Half the stroke, so a flat line at either extreme is not clipped. */
+const PADDING = 1.5;
+
+export type SparklinePoint = number | null;
+
+/**
+ * Points to an SVG path, breaking the line wherever the data is unknown.
+ *
+ * `null` means the rollup never computed that day, which is NOT zero — drawn as
+ * zero it puts a hole in the line that reads as a collapse. A break says "no
+ * data here" in the only way a line can.
+ */
+export function toPath(points: SparklinePoint[]): string {
+  const known = points.filter((point): point is number => point !== null);
+  if (known.length < 2) {
+    return '';
+  }
+
+  const highest = Math.max(...known);
+  const lowest = Math.min(...known);
+  const span = highest - lowest;
+  const step = points.length > 1 ? (WIDTH - PADDING * 2) / (points.length - 1) : 0;
+
+  let path = '';
+  let penDown = false;
+  points.forEach((point, index) => {
+    if (point === null) {
+      // Lift the pen. The next known point starts a new subpath rather than
+      // joining across the gap, which would draw a line nobody measured.
+      penDown = false;
+      return;
+    }
+    const x = PADDING + index * step;
+    // A flat series has no span to scale against; centre it rather than
+    // dividing by zero and drawing it along the top edge.
+    const y = span === 0
+      ? HEIGHT / 2
+      : HEIGHT - PADDING - ((point - lowest) / span) * (HEIGHT - PADDING * 2);
+    path += `${penDown ? 'L' : 'M'}${x.toFixed(1)} ${y.toFixed(1)}`;
+    penDown = true;
+  });
+  return path;
+}
+
+/** The viewBox both dimensions describe, so the component cannot drift from them. */
+export const VIEWBOX = `0 0 ${WIDTH} ${HEIGHT}`;

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -60,6 +60,14 @@ export type Pulse = {
   metrics: Record<keyof ActivityMetrics, PulseMetric>;
 };
 
+/**
+ * Per-game daily series for the table sparkline.
+ *
+ * `null` is a day the rollup never computed — NOT zero. Drawn as zero it puts a
+ * hole in the line that reads as a collapse.
+ */
+export type GameSeries = Record<string, (number | null)[]>;
+
 export type GameTotals = {
   game_type: string;
   /** finished / started. Null when nobody played — 0% would read as "everyone bailed". */
@@ -123,6 +131,13 @@ export type SummaryResponse = {
   comparison: PeriodComparison;
   window_totals: ActivityMetrics;
   by_game: GameTotals[];
+  /**
+   * Sparkline series keyed by game. OPTIONAL, because the backend that sends it
+   * may not be deployed yet — the two repositories ship independently, and a
+   * required field plus an unguarded render is a crash rather than a missing
+   * column.
+   */
+  series?: GameSeries;
 } & ResolvedRange;
 
 export type MultiplayerGameRow = {


### PR DESCRIPTION
The last of the five shared pieces R9 asked for, and the only one never built. Backend: FootballExtraTime/App#1501.

It waited for a per-row series — building it earlier would have meant building it against imagined data.

**A trend percentage says a game is down 12%.** It cannot say whether it fell off a cliff on Tuesday or has been sliding for a month, and those want different responses. That distinction used to live on a second page nobody opens.

## The line breaks where the data is unknown

A `null` is a day the rollup never computed, not a zero:

- joined across → the line draws a slope nobody measured
- drawn as zero → it shows a collapse that didn't happen

A gap says "no data here" in the only way a line can.

## Not a chart library

Recharts needs a measured container and renders nothing at this size in a table cell. One `<path>`, no axes — a sparkline that needs a legend is a chart in the wrong place, and the Trend column beside it already carries the precise figure.

## Three smaller decisions, each mutation-tested

- **A flat series is centred** rather than divided by a zero span, which would put the line along the top edge and read as a maximum.
- **One point draws nothing.** A dot has no direction, and an empty SVG in a table cell reads as a rendering failure — it shows a dash.
- **Colour compares the ends, not the extremes.** A game that spiked mid-window and came back down has not risen.

The column isn't sortable: there's no single number to sort a shape by, and Trend already sorts on the figure this draws.

`series` is optional on the response — the two repos ship independently, and a required field with an unguarded render is a crash rather than a missing column.

618 tests. Geometry lives in `lib/sparkline.ts` so it's testable without a DOM, and because exporting a helper from a component file breaks fast refresh — the same rule that moved `toChartRow` out earlier.

**This closes R9's done-when.** #1474 is now down to R10 alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)