### PR TITLE
Give the stacked charts a legend

### DIFF
--- a/components/reports/charts/GrowthFlow.tsx
+++ b/components/reports/charts/GrowthFlow.tsx
@@ -4,6 +4,7 @@ import type { GrowthResponse } from '@/types/reports';
 import { useTheme } from 'next-themes';
 import { Bar, BarChart, CartesianGrid, Cell, ReferenceLine, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import { ChartTooltip } from '@/components/reports/charts/ChartTooltip';
+import { ChartLegend } from '@/components/reports/primitives/ChartLegend';
 import { EmptyState } from '@/components/reports/primitives/EmptyState';
 import { MetricRow } from '@/components/reports/primitives/MetricRow';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -33,6 +34,20 @@ const BAND_NAMES = {
   new: 'New',
   churned: 'Churned',
 } as const;
+
+/** The glossary entry behind each band. None of these four words define themselves. */
+const BAND_METRICS = {
+  retained: 'retained_players',
+  resurrected: 'resurrected_players',
+  new: 'new_players_weekly',
+  churned: 'churned_players',
+} as const;
+
+/**
+ * Stack order, bottom to top — and the order the legend reads in, so the key
+ *  and the chart cannot drift apart.
+ */
+const BAND_ORDER = ['retained', 'resurrected', 'new', 'churned'] as const;
 
 export function GrowthFlow({ data }: { data: GrowthResponse }) {
   const { resolvedTheme } = useTheme();
@@ -97,7 +112,7 @@ export function GrowthFlow({ data }: { data: GrowthResponse }) {
                     {/* The line the shape is read against. Without it, a week
                         that lost more than it gained still looks like a bar. */}
                     <ReferenceLine y={0} stroke={theme.axisLine.stroke} />
-                    {(['retained', 'resurrected', 'new', 'churned'] as const).map(band => (
+                    {BAND_ORDER.map(band => (
                       <Bar key={band} dataKey={band} name={BAND_NAMES[band]} stackId="players" fill={colours[band]}>
                         {rows.map(row => (
                           // The provisional week is drawn faint rather than
@@ -112,6 +127,16 @@ export function GrowthFlow({ data }: { data: GrowthResponse }) {
                 </ResponsiveContainer>
               )}
         </div>
+
+        {rows.length > 0 && (
+          <ChartLegend
+            series={BAND_ORDER.map(band => ({
+              label: BAND_NAMES[band],
+              colour: colours[band],
+              metric: BAND_METRICS[band],
+            }))}
+          />
+        )}
 
         {provisional && (
           <p className="text-xs text-muted-foreground">

--- a/components/reports/charts/NewVsReturning.tsx
+++ b/components/reports/charts/NewVsReturning.tsx
@@ -4,6 +4,7 @@ import type { NewReturningRow } from '@/types/reports';
 import { useTheme } from 'next-themes';
 import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import { ChartTooltip } from '@/components/reports/charts/ChartTooltip';
+import { ChartLegend } from '@/components/reports/primitives/ChartLegend';
 import { EmptyState } from '@/components/reports/primitives/EmptyState';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { chartTheme } from '@/lib/chart-theme';
@@ -35,11 +36,13 @@ export function NewVsReturning({ rows }: { rows: NewReturningRow[] }) {
           returning means growth has stalled, all new means nobody is staying.
         </CardDescription>
       </CardHeader>
-      <CardContent className="h-64 sm:h-72">
+      {/* A column rather than a fixed-height box: the legend is a real row that
+          has to come out of the card's height, not overlap the plot. */}
+      <CardContent className="flex h-72 flex-col gap-3 sm:h-80">
         {rows.length === 0
           ? <EmptyState hint="Try a wider date range.">No player activity in this window.</EmptyState>
           : (
-              <ResponsiveContainer width="100%" height="100%">
+              <ResponsiveContainer width="100%" height="100%" className="min-h-0 flex-1">
                 <AreaChart data={rows} margin={{ top: 8, right: 8, bottom: 8, left: -12 }}>
                   <CartesianGrid strokeDasharray="3 3" stroke={theme.grid.stroke} />
                   <XAxis dataKey="date" tick={theme.tick} interval="preserveStartEnd" minTickGap={24} />
@@ -66,6 +69,16 @@ export function NewVsReturning({ rows }: { rows: NewReturningRow[] }) {
                 </AreaChart>
               </ResponsiveContainer>
             )}
+
+        {rows.length > 0 && (
+          <ChartLegend
+            series={[
+              // Stack order, bottom to top — matching the chart.
+              { label: 'Returning', colour: theme.series[1] },
+              { label: 'New', colour: theme.series[0], metric: 'new_players' },
+            ]}
+          />
+        )}
       </CardContent>
     </Card>
   );

--- a/components/reports/primitives/ChartLegend.tsx
+++ b/components/reports/primitives/ChartLegend.tsx
@@ -1,0 +1,57 @@
+import { MetricInfo } from '@/components/reports/primitives/MetricInfo';
+import { cn } from '@/lib/utils';
+
+/**
+ * The key to a chart with more than one series.
+ *
+ * Every stacked chart on this surface identified its bands through the hover
+ * tooltip alone. That works for exactly one reader: someone with a mouse,
+ * looking at the screen, who thinks to hover. It is unreachable by keyboard,
+ * absent on touch, and gone the moment the chart is screenshotted into a
+ * message — which is how these charts actually travel.
+ *
+ * Deliberately not recharts' `<Legend />`: that one reserves layout inside the
+ * plot area and re-flows the chart, and it cannot carry the glossary link. The
+ * bands here are `retained`/`resurrected`/`new`/`churned` — four words that each
+ * mean something specific and none of which explain themselves.
+ *
+ * A single series gets no legend. The card title already names it, and a
+ * one-row key beside one colour is furniture.
+ */
+export type LegendSeries = {
+  /** The name of the series, as it reads in the tooltip. */
+  label: string;
+  /** The colour of the mark, from the chart theme — never a literal. */
+  colour: string;
+  /** Glossary key, when the label cannot say what is counted. */
+  metric?: string;
+};
+
+export function ChartLegend({ series, className }: {
+  series: LegendSeries[];
+  className?: string;
+}) {
+  // One series is named by the title above it. Rendering the key anyway would
+  // add a row that carries no information the reader does not already have.
+  if (series.length < 2) {
+    return null;
+  }
+
+  return (
+    <ul className={cn('flex flex-wrap items-center gap-x-4 gap-y-1.5 text-xs', className)}>
+      {series.map(({ label, colour, metric }) => (
+        <li key={label} className="flex items-center gap-1.5">
+          {/* The swatch carries the colour; the label carries the identity. A
+              reader who cannot separate two of these hues still has the word. */}
+          <span
+            aria-hidden
+            className="size-2.5 shrink-0 rounded-[3px]"
+            style={{ backgroundColor: colour }}
+          />
+          <span className="text-muted-foreground">{label}</span>
+          {metric && <MetricInfo metric={metric} />}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/components/reports/primitives/__tests__/ChartLegend.test.tsx
+++ b/components/reports/primitives/__tests__/ChartLegend.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ChartLegend } from '@/components/reports/primitives/ChartLegend';
+
+// The glossary popover fetches its definitions; this component's job is only to
+// decide whether the link is offered at all, so stand it in with a marker.
+vi.mock('@/components/reports/primitives/MetricInfo', () => ({
+  MetricInfo: ({ metric }: { metric: string }) => <span data-testid={`info-${metric}`} />,
+}));
+
+describe('chartLegend', () => {
+  it('names every series in text, so identity is never colour alone', () => {
+    render(
+      <ChartLegend
+        series={[
+          { label: 'Stayed', colour: '#0a0' },
+          { label: 'Churned', colour: '#a00' },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('Stayed')).toBeInTheDocument();
+    expect(screen.getByText('Churned')).toBeInTheDocument();
+  });
+
+  it('renders nothing for a single series — the card title already names it', () => {
+    const { container } = render(
+      <ChartLegend series={[{ label: 'Sessions', colour: '#0a0' }]} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('offers the glossary only for the series that declare a key', () => {
+    render(
+      <ChartLegend
+        series={[
+          { label: 'Returning', colour: '#0a0' },
+          { label: 'New', colour: '#00a', metric: 'new_players' },
+        ]}
+      />,
+    );
+
+    expect(screen.getByTestId('info-new_players')).toBeInTheDocument();
+    // Not a definition that does not exist: there is no `returning_players`
+    // entry in the BE glossary, and linking one would render "no definition".
+    expect(screen.queryByTestId('info-returning_players')).not.toBeInTheDocument();
+  });
+
+  it('hides the swatch from assistive tech — the label carries the meaning', () => {
+    const { container } = render(
+      <ChartLegend
+        series={[
+          { label: 'Stayed', colour: 'rgb(0, 170, 0)' },
+          { label: 'New', colour: 'rgb(0, 0, 170)' },
+        ]}
+      />,
+    );
+
+    const swatches = container.querySelectorAll('[aria-hidden]');
+
+    expect(swatches).toHaveLength(2);
+    expect(swatches[0]).toHaveStyle({ backgroundColor: 'rgb(0, 170, 0)' });
+  });
+});


### PR DESCRIPTION

Both stacked charts identified their bands through the hover tooltip and
nothing else. That works for one reader: someone with a mouse, looking at
the screen, who thinks to hover. It is unreachable by keyboard, absent on
touch, and gone the moment the chart is screenshotted into a message --
which is how these charts actually travel.

GrowthFlow is the worse of the two: four bands, and `retained`,
`resurrected`, `new` and `churned` are four words that each mean something
specific and none of which explain themselves.

Adds `ChartLegend` and adopts it in both. The swatch carries the colour and
the label carries the identity, so a reader who cannot separate two hues
still has the word. Where a glossary entry exists the legend links it --
which is also how `retained_players` becomes reachable from the UI at all;
it was defined and linked from nowhere.

Not recharts' own `<Legend />`: it reserves layout inside the plot area and
re-flows the chart, and it cannot carry the glossary link.

A single series renders no legend. The card title already names it, and a
one-row key beside one colour is furniture.

`new_players` is linked on the areas chart; `Returning` is not. There is no
`returning_players` entry in the BE glossary, and pointing at a key that
does not exist renders "no definition recorded" -- worse than no link.

Guard mutation-tested three ways: dropping the single-series check, linking
the glossary unconditionally, and exposing the swatch to assistive tech each
fail exactly one test.

Refs https://github.com/FootballExtraTime/App/issues/1474

🤖 Generated with [Claude Code](https://claude.com/claude-code)