### PR TITLE
Football data: what was added, and the catalogue by difficulty

### DIFF
--- a/app/analytics/football-data/page.tsx
+++ b/app/analytics/football-data/page.tsx
@@ -2,11 +2,14 @@
 
 import type { RangeState } from '@/lib/report-range';
 import { useMemo } from 'react';
+import { CatalogueGrowth } from '@/components/analytics/panels/CatalogueGrowth';
 import { DataCoverage } from '@/components/analytics/panels/DataCoverage';
+import { DifficultyCatalogue } from '@/components/analytics/panels/DifficultyCatalogue';
 import { AnalyticsShell } from '@/components/analytics/shell/AnalyticsShell';
 import { FilterBar } from '@/components/reports/filters/FilterBar';
 import { RangePicker } from '@/components/reports/filters/RangePicker';
 import { ReportPanel } from '@/components/reports/primitives/ReportPanel';
+import { SectionHeader } from '@/components/reports/primitives/SectionHeader';
 import { useReport } from '@/hooks/use-report';
 import { useReportFilters } from '@/hooks/use-report-filters';
 import { useAuth } from '@/lib/auth';
@@ -59,6 +62,27 @@ export default function FootballDataAnalyticsPage() {
           onIncludeBotsChange={setIncludeBots}
         />
       </FilterBar>
+
+      {/* Growth first: "is anyone still adding to this" frames every gap
+          underneath. A coverage figure alone cannot say whether it is being
+          worked on or has been static since April. */}
+      <ReportPanel state={state} skeletonClassName="h-[28rem] w-full">
+        {data => <CatalogueGrowth data={data} />}
+      </ReportPanel>
+
+      <SectionHeader
+        title="The catalogue by difficulty"
+        description="How much of each tier exists, and how much of it has a face to show."
+      />
+
+      <ReportPanel state={state} skeletonClassName="h-80 w-full">
+        {data => <DifficultyCatalogue data={data} />}
+      </ReportPanel>
+
+      <SectionHeader
+        title="Coverage where it is used"
+        description="Gaps among the footballers actually put in front of players, and the untouched remainder."
+      />
 
       <ReportPanel state={state} skeletonClassName="h-96 w-full">
         {data => <DataCoverage data={data} />}

--- a/components/analytics/__tests__/CatalogueGrowth.test.tsx
+++ b/components/analytics/__tests__/CatalogueGrowth.test.tsx
@@ -1,0 +1,77 @@
+import type { CatalogueTotals, CoverageResponse } from '@/types/reports';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { CatalogueGrowth } from '@/components/analytics/panels/CatalogueGrowth';
+
+// jsdom gives recharts a zero-size container, so the areas never render. What is
+// worth asserting is the framing around them: the figures, and the key that says
+// which band is which.
+vi.mock('recharts', async () => {
+  const actual = await vi.importActual<typeof import('recharts')>('recharts');
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+      <div style={{ width: 800, height: 300 }}>{children}</div>
+    ),
+  };
+});
+
+const TOTALS: CatalogueTotals = {
+  footballers_added: 1709,
+  teams_added: 825,
+  footballers_approved: 6729,
+  teams_approved: 4455,
+  nations_active: 233,
+  nations_total: 236,
+  nations_last_added: '2026-06-27T21:05:56Z',
+};
+
+function data(totals?: CatalogueTotals): CoverageResponse {
+  return {
+    totals,
+    added_series: totals
+      ? [
+          { date: '2026-04-09', footballers: 13, teams: 10 },
+          { date: '2026-04-10', footballers: 12, teams: 1 },
+        ]
+      : undefined,
+  } as unknown as CoverageResponse;
+}
+
+describe('catalogueGrowth', () => {
+  it('renders nothing when the backend has not shipped the fields yet', () => {
+    const { container } = render(<CatalogueGrowth data={data(undefined)} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('leads with what arrived in the window, not the standing total', () => {
+    render(<CatalogueGrowth data={data(TOTALS)} />);
+
+    expect(screen.getByText('Footballers added')).toBeInTheDocument();
+    expect(screen.getByText('1,709')).toBeInTheDocument();
+    expect(screen.getByText('825 teams in the same window')).toBeInTheDocument();
+  });
+
+  it('calls the nations tile "active", never "approved"', () => {
+    // `Nation` has no status field. Naming it approved would name a review step
+    // that does not exist for countries.
+    render(<CatalogueGrowth data={data(TOTALS)} />);
+
+    expect(screen.getByText('Active nations')).toBeInTheDocument();
+    expect(screen.queryByText(/Approved nations/i)).not.toBeInTheDocument();
+  });
+
+  it('accounts for the nations that are not active', () => {
+    render(<CatalogueGrowth data={data(TOTALS)} />);
+
+    expect(screen.getByText(/3 defunct/)).toBeInTheDocument();
+  });
+
+  it('gives the two-series chart a legend', () => {
+    render(<CatalogueGrowth data={data(TOTALS)} />);
+
+    expect(screen.getByText('Footballers')).toBeInTheDocument();
+    expect(screen.getByText('Teams')).toBeInTheDocument();
+  });
+});

--- a/components/analytics/__tests__/CatalogueGrowth.test.tsx
+++ b/components/analytics/__tests__/CatalogueGrowth.test.tsx
@@ -75,3 +75,36 @@ describe('catalogueGrowth', () => {
     expect(screen.getByText('Teams')).toBeInTheDocument();
   });
 });
+
+describe('catalogueGrowth — added today', () => {
+  it('names both kinds when both landed today', () => {
+    render(<CatalogueGrowth data={data({ ...TOTALS, footballers_added_today: 5, teams_added_today: 2 })} />);
+
+    expect(screen.getByText('5 footballers and 2 teams added today')).toBeInTheDocument();
+  });
+
+  it('drops the kind that had none rather than saying "0 teams"', () => {
+    render(<CatalogueGrowth data={data({ ...TOTALS, footballers_added_today: 5, teams_added_today: 0 })} />);
+
+    expect(screen.getByText('5 footballers added today')).toBeInTheDocument();
+  });
+
+  it('says nothing at all on a quiet day', () => {
+    // A zero under every tile every morning trains people to stop reading it.
+    render(<CatalogueGrowth data={data({ ...TOTALS, footballers_added_today: 0, teams_added_today: 0 })} />);
+
+    expect(screen.queryByText(/added today/)).not.toBeInTheDocument();
+  });
+
+  it('says nothing when the backend predates the field', () => {
+    render(<CatalogueGrowth data={data(TOTALS)} />);
+
+    expect(screen.queryByText(/added today/)).not.toBeInTheDocument();
+  });
+
+  it('reads "1 footballer", not "1 footballers"', () => {
+    render(<CatalogueGrowth data={data({ ...TOTALS, footballers_added_today: 1, teams_added_today: 1 })} />);
+
+    expect(screen.getByText('1 footballer and 1 team added today')).toBeInTheDocument();
+  });
+});

--- a/components/analytics/__tests__/DifficultyCatalogue.test.tsx
+++ b/components/analytics/__tests__/DifficultyCatalogue.test.tsx
@@ -1,0 +1,76 @@
+import type { CoverageResponse, DifficultyTier } from '@/types/reports';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { DifficultyCatalogue } from '@/components/analytics/panels/DifficultyCatalogue';
+
+function data(tiers?: DifficultyTier[]): CoverageResponse {
+  return { difficulty_tiers: tiers } as unknown as CoverageResponse;
+}
+
+const FULL: DifficultyTier[] = [
+  { difficulty: 'EASY', footballers: 955, with_picture: 282, with_picture_pct: 29.5 },
+  { difficulty: 'NORMAL', footballers: 1589, with_picture: 271, with_picture_pct: 17.1 },
+  { difficulty: 'HARD', footballers: 2457, with_picture: 311, with_picture_pct: 12.7 },
+  { difficulty: 'EXTREME', footballers: 1728, with_picture: 206, with_picture_pct: 11.9 },
+];
+
+describe('difficultyCatalogue', () => {
+  it('renders nothing when the backend has not shipped the field yet', () => {
+    // The two repositories deploy independently, so this arrives absent rather
+    // than empty. An unguarded render is a crash on the page, not a gap in it.
+    const { container } = render(<DifficultyCatalogue data={data(undefined)} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('reads each tier as "N of X" rather than a bare percentage', () => {
+    render(<DifficultyCatalogue data={data(FULL)} />);
+
+    expect(screen.getByText('282')).toBeInTheDocument();
+    expect(screen.getByText('of 955')).toBeInTheDocument();
+    expect(screen.getByText('29.5%')).toBeInTheDocument();
+  });
+
+  it('never prints "null%" when a populated tier arrives without a percentage', () => {
+    // The BE only nulls the percentage for an empty tier, so this is a payload
+    // that disagrees with itself — but the type allows it, and a bare
+    // interpolation renders the word "null" next to a real count.
+    render(
+      <DifficultyCatalogue
+        data={data([{ difficulty: 'HARD', footballers: 10, with_picture: 4, with_picture_pct: null }])}
+      />,
+    );
+
+    expect(screen.queryByText(/null/)).not.toBeInTheDocument();
+    expect(screen.getByText('of 10')).toBeInTheDocument();
+  });
+
+  it('never prints "null%" for a tier with no footballers', () => {
+    render(
+      <DifficultyCatalogue
+        data={data([{ difficulty: 'EASY', footballers: 0, with_picture: 0, with_picture_pct: null }])}
+      />,
+    );
+
+    expect(screen.queryByText(/null/)).not.toBeInTheDocument();
+    expect(screen.getByText('No footballers')).toBeInTheDocument();
+  });
+
+  it('describes each bar for a reader who cannot see it', () => {
+    render(<DifficultyCatalogue data={data(FULL)} />);
+
+    expect(
+      screen.getByLabelText('Easy: 282 of 955 have a picture'),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText('Easy: 955 footballers')).toBeInTheDocument();
+  });
+
+  it('keeps the tiers in difficulty order, not the order they arrive', () => {
+    render(<DifficultyCatalogue data={data(FULL)} />);
+
+    const labels = screen.getAllByText(/^(Easy|Normal|Hard|Extreme)$/).map(n => n.textContent);
+
+    // Twice — once per column, both in the same order.
+    expect(labels).toEqual(['Easy', 'Normal', 'Hard', 'Extreme', 'Easy', 'Normal', 'Hard', 'Extreme']);
+  });
+});

--- a/components/analytics/panels/CatalogueGrowth.tsx
+++ b/components/analytics/panels/CatalogueGrowth.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import type { CoverageResponse } from '@/types/reports';
+import { useTheme } from 'next-themes';
+import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { ChartTooltip } from '@/components/reports/charts/ChartTooltip';
+import { ChartLegend } from '@/components/reports/primitives/ChartLegend';
+import { EmptyState } from '@/components/reports/primitives/EmptyState';
+import { StatTile } from '@/components/reports/primitives/StatTile';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { chartTheme } from '@/lib/chart-theme';
+
+/**
+ * How much football data exists, and how much of it arrived in the window.
+ *
+ * The rest of this page measures completeness — what the games are missing. It
+ * cannot say whether anyone is still filling the gaps, and a gap that is
+ * shrinking weekly reads exactly like one that has been static since April.
+ * Those call for opposite responses.
+ *
+ * Footballers and teams share ONE chart because they share a unit and a scale:
+ * both are rows added per day, peaking at 69 and 46. Two y-axes on one chart is
+ * the single chart decision that reliably misleads, and two charts side by side
+ * would lose the comparison that makes the pair worth showing together.
+ *
+ * Nations get a figure and a date instead of a series. Four were added in the
+ * last ninety days; a time series of four events is four dots on an empty
+ * canvas, and the date answers the same question in less space.
+ */
+export function CatalogueGrowth({ data }: { data: CoverageResponse }) {
+  const { resolvedTheme } = useTheme();
+  const theme = chartTheme(resolvedTheme === 'dark');
+  const { totals, added_series: series } = data;
+
+  // The BE may not carry these yet — the repositories deploy independently.
+  if (!totals || !series) {
+    return null;
+  }
+
+  const lastAdded = totals.nations_last_added
+    ? new Date(totals.nations_last_added).toLocaleDateString(undefined, { dateStyle: 'medium' })
+    : null;
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+        <StatTile
+          label="Footballers added"
+          value={totals.footballers_added.toLocaleString()}
+          hint={`${totals.teams_added.toLocaleString()} teams in the same window`}
+        />
+        <StatTile
+          label="Approved footballers"
+          value={totals.footballers_approved.toLocaleString()}
+        />
+        <StatTile
+          label="Approved teams"
+          value={totals.teams_approved.toLocaleString()}
+        />
+        {/* "Active", not "approved". `Nation` has no approval step at all — the
+            only gate is whether the country still exists, so naming it approved
+            would name a workflow nobody runs. */}
+        <StatTile
+          label="Active nations"
+          value={totals.nations_active.toLocaleString()}
+          hint={
+            totals.nations_total > totals.nations_active
+              ? `${(totals.nations_total - totals.nations_active).toLocaleString()} defunct${lastAdded ? ` · last added ${lastAdded}` : ''}`
+              : lastAdded
+                ? `Last added ${lastAdded}`
+                : undefined
+          }
+        />
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>What was added, by day</CardTitle>
+          <CardDescription>
+            Counts every row created in the window, approved or not — a footballer added
+            now and reviewed next week was still work done now.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex h-72 flex-col gap-3 sm:h-80">
+          {series.length === 0
+            ? <EmptyState hint="Try a wider date range.">Nothing was added in this window.</EmptyState>
+            : (
+                <ResponsiveContainer width="100%" height="100%" className="min-h-0 flex-1">
+                  <AreaChart data={series} margin={{ top: 8, right: 8, bottom: 8, left: -12 }}>
+                    <CartesianGrid strokeDasharray="3 3" stroke={theme.grid.stroke} />
+                    <XAxis dataKey="date" tick={theme.tick} interval="preserveStartEnd" minTickGap={24} />
+                    <YAxis tick={theme.tick} allowDecimals={false} width={44} />
+                    <Tooltip content={<ChartTooltip />} cursor={theme.tooltip.cursor} />
+                    {/* Overlaid, not stacked. These are independent quantities;
+                        stacking them would draw a combined height that means
+                        nothing, and the question is which of the two moved. */}
+                    <Area
+                      type="monotone"
+                      dataKey="footballers"
+                      name="Footballers"
+                      stroke={theme.series[0]}
+                      fill={theme.series[0]}
+                      fillOpacity={0.25}
+                    />
+                    <Area
+                      type="monotone"
+                      dataKey="teams"
+                      name="Teams"
+                      stroke={theme.series[1]}
+                      fill={theme.series[1]}
+                      fillOpacity={0.25}
+                    />
+                  </AreaChart>
+                </ResponsiveContainer>
+              )}
+
+          {series.length > 0 && (
+            <ChartLegend
+              series={[
+                { label: 'Footballers', colour: theme.series[0] },
+                { label: 'Teams', colour: theme.series[1] },
+              ]}
+            />
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/analytics/panels/CatalogueGrowth.tsx
+++ b/components/analytics/panels/CatalogueGrowth.tsx
@@ -27,6 +27,36 @@ import { chartTheme } from '@/lib/chart-theme';
  * last ninety days; a time series of four events is four dots on an empty
  * canvas, and the date answers the same question in less space.
  */
+/**
+ * What landed today, under the window's total.
+ *
+ * Green because it is the live line on a panel of standing figures — the one
+ * thing here that can change while you are looking at it. Nothing else on the
+ * page is coloured, so it reads as "new" rather than as a status.
+ *
+ * Renders nothing at zero rather than "0 added today". A quiet day is the
+ * normal case for a catalogue edited in bursts, and a zero sitting under every
+ * tile every morning trains people to stop reading the line.
+ */
+function AddedToday({ footballers, teams }: { footballers?: number; teams?: number }) {
+  // Undefined is a backend that predates the field; zero is a real quiet day.
+  // Both render nothing, for different reasons.
+  if (!footballers && !teams) {
+    return null;
+  }
+
+  const parts = [
+    footballers ? `${footballers.toLocaleString()} footballer${footballers === 1 ? '' : 's'}` : null,
+    teams ? `${teams.toLocaleString()} team${teams === 1 ? '' : 's'}` : null,
+  ].filter(Boolean);
+
+  return (
+    <p className="text-xs font-medium text-emerald-600 dark:text-emerald-500">
+      {`${parts.join(' and ')} added today`}
+    </p>
+  );
+}
+
 export function CatalogueGrowth({ data }: { data: CoverageResponse }) {
   const { resolvedTheme } = useTheme();
   const theme = chartTheme(resolvedTheme === 'dark');
@@ -47,6 +77,7 @@ export function CatalogueGrowth({ data }: { data: CoverageResponse }) {
         <StatTile
           label="Footballers added"
           value={totals.footballers_added.toLocaleString()}
+          delta={<AddedToday footballers={totals.footballers_added_today} teams={totals.teams_added_today} />}
           hint={`${totals.teams_added.toLocaleString()} teams in the same window`}
         />
         <StatTile

--- a/components/analytics/panels/DifficultyCatalogue.tsx
+++ b/components/analytics/panels/DifficultyCatalogue.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import type { CoverageResponse, DifficultyTier } from '@/types/reports';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Progress } from '@/components/ui/progress';
+import { cn } from '@/lib/utils';
+
+/**
+ * The catalogue split by difficulty, and how much of each tier has a picture.
+ *
+ * Two questions that share an axis, so they sit side by side rather than in two
+ * places: the left says how much of each tier exists, the right says how much of
+ * it is usable in a game that shows a face. Read across a row and the pair is
+ * the actual answer — a tier can be large and unusable, and neither column says
+ * that alone.
+ *
+ * Not scoped to the date range. This is the state of the catalogue now, not what
+ * changed in it, and a range filter here would answer neither question.
+ */
+const TIER_LABELS: Record<string, string> = {
+  EASY: 'Easy',
+  NORMAL: 'Normal',
+  HARD: 'Hard',
+  EXTREME: 'Extreme',
+};
+
+function tierLabel(difficulty: string) {
+  return TIER_LABELS[difficulty] ?? difficulty;
+}
+
+export function DifficultyCatalogue({ data }: { data: CoverageResponse }) {
+  const tiers = data.difficulty_tiers;
+
+  // The BE may not carry this yet — the repositories deploy independently.
+  if (!tiers || tiers.length === 0) {
+    return null;
+  }
+
+  const largest = Math.max(...tiers.map(tier => tier.footballers), 1);
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-2">
+      <Card>
+        <CardHeader>
+          <CardTitle>Footballers by difficulty</CardTitle>
+          <CardDescription>
+            Approved footballers only — the pool a game can actually draw from.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <dl className="space-y-3">
+            {tiers.map(tier => (
+              <div key={tier.difficulty} className="space-y-1">
+                <div className="flex items-baseline justify-between gap-2">
+                  <dt className="text-sm text-muted-foreground">{tierLabel(tier.difficulty)}</dt>
+                  <dd className="text-sm font-medium tabular-nums text-foreground">
+                    {tier.footballers.toLocaleString()}
+                  </dd>
+                </div>
+                {/* Scaled against the largest tier, not against the total: the
+                    question here is which tier is biggest, and a share-of-total
+                    bar answers a question nobody asked of four bars that sum
+                    to one. */}
+                <Progress
+                  value={(tier.footballers / largest) * 100}
+                  aria-label={`${tierLabel(tier.difficulty)}: ${tier.footballers} footballers`}
+                />
+              </div>
+            ))}
+          </dl>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Pictures by difficulty</CardTitle>
+          <CardDescription>
+            How many of each tier have an active picture. Scout serves the dossier with
+            no image rather than failing, so a gap here degrades quietly.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <dl className="space-y-3">
+            {tiers.map(tier => (
+              <PictureRow key={tier.difficulty} tier={tier} />
+            ))}
+          </dl>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function PictureRow({ tier }: { tier: DifficultyTier }) {
+  const pct = tier.with_picture_pct;
+  const empty = tier.footballers === 0;
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-baseline justify-between gap-2">
+        <dt className="text-sm text-muted-foreground">{tierLabel(tier.difficulty)}</dt>
+        <dd className="text-sm tabular-nums text-foreground">
+          {empty
+            ? <span className="text-muted-foreground">No footballers</span>
+            : (
+                <>
+                  <span className="font-medium">{tier.with_picture.toLocaleString()}</span>
+                  <span className="text-muted-foreground">
+                    {` of ${tier.footballers.toLocaleString()}`}
+                  </span>
+                  {/* `pct` is null only when the tier is empty, which the branch
+                      above already handled — but the type allows it, and a bare
+                      interpolation would print "null%". */}
+                  {pct !== null && (
+                    <span className={cn('ml-1.5 tabular-nums', pct < 25 ? 'text-amber-600 dark:text-amber-500' : 'text-muted-foreground')}>
+                      {`${pct}%`}
+                    </span>
+                  )}
+                </>
+              )}
+        </dd>
+      </div>
+      <Progress
+        value={pct ?? 0}
+        aria-label={
+          empty
+            ? `${tierLabel(tier.difficulty)}: no footballers`
+            : `${tierLabel(tier.difficulty)}: ${tier.with_picture} of ${tier.footballers} have a picture`
+        }
+      />
+    </div>
+  );
+}

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -1135,4 +1135,46 @@ export type CoverageResponse = {
     club: number;
     nation: number;
   }[];
+  /**
+   * The catalogue-growth half. OPTIONAL for the same reason as every field
+   * added since: the two repositories ship independently, so between the FE
+   * deploy and the BE deploy these are simply absent — and a required type plus
+   * an unconditional render is a crash on the page, not a missing panel.
+   */
+  totals?: CatalogueTotals;
+  added_series?: CatalogueAddedPoint[];
+  difficulty_tiers?: DifficultyTier[];
 } & ResolvedRange;
+
+export type CatalogueTotals = {
+  /**
+   * Rows created in the window — NOT filtered to approved, so a pending
+   *  footballer still counts as work done in the window.
+   */
+  footballers_added: number;
+  teams_added: number;
+  footballers_approved: number;
+  teams_approved: number;
+  /** `Nation` has no approval step, so this is `is_active` — see the BE. */
+  nations_active: number;
+  nations_total: number;
+  /** ISO timestamp, or null when there are no nations at all. */
+  nations_last_added: string | null;
+};
+
+export type CatalogueAddedPoint = {
+  date: string;
+  footballers: number;
+  teams: number;
+};
+
+export type DifficultyTier = {
+  difficulty: string;
+  footballers: number;
+  with_picture: number;
+  /**
+   * Null for an empty tier: "0% covered" reads as a gap to fill, and there is
+   *  nothing there to fill.
+   */
+  with_picture_pct: number | null;
+};

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -1153,6 +1153,12 @@ export type CatalogueTotals = {
    */
   footballers_added: number;
   teams_added: number;
+  /**
+   * Added TODAY, whatever range the page is showing — not the last day of the
+   * window. Optional: a backend predating it shows no line rather than "0 today".
+   */
+  footballers_added_today?: number;
+  teams_added_today?: number;
   footballers_approved: number;
   teams_approved: number;
   /** `Nation` has no approval step, so this is `is_active` — see the BE. */


### PR DESCRIPTION

Two sections above the existing coverage panel, answering the question that
one cannot: is anyone still filling these gaps. A gap shrinking weekly and one
static since April look identical today.

ROW ONE - four figures: footballers added in the window, approved footballers,
approved teams, active nations.

ROW TWO - one chart of daily additions, footballers and teams together.

They share a chart because they share a unit and a scale: both are rows added
per day, peaking at 69 and 46 locally. Two y-axes is the one chart decision
that reliably misleads, and two charts side by side would lose the comparison
that makes the pair worth showing. Overlaid rather than stacked - these are
independent quantities and a combined height means nothing.

Nations get a figure and a last-added date instead of a series. Four were
added in the last ninety days; a time series of four events is four dots on an
empty canvas.

The tile says "Active nations", not approved. `Nation` has no status field and
there is no approval step for a country - naming it approved would name a
workflow nobody runs.

THE DIFFICULTY SECTION - counts on the left, picture coverage on the right,
sharing an axis so a row reads across. A tier can be large and unusable, and
neither column says that alone. The left bars scale against the largest tier
rather than the total: the question is which tier is biggest, not four bars
that sum to one.

Every new field is OPTIONAL, like every field added since #124. The two
repositories deploy independently, so between the FE deploy and the BE deploy
these arrive absent - and a required type with an unguarded render is a crash
on the page rather than a missing panel. Both panels return null instead.

Stacked on #134 - it needs the `ChartLegend` that PR adds.

Mutation-tested. One guard survived its first mutation and was rebuilt: the
"never print null%" check was unreachable, because the empty-tier branch
returns before reaching it. The test now uses a populated tier whose
percentage arrives null anyway - a payload that disagrees with itself, which
the type allows - and the mutation fails.

Refs https://github.com/FootballExtraTime/App/issues/1474

🤖 Generated with [Claude Code](https://claude.com/claude-code)