### PR TITLE
Put Analytics in the nav, and take the dead reports out

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ import {
   FileQuestion,
   FileText,
   MessageCircle,
+  Microscope,
   Search,
   Settings,
   Users,
@@ -14,9 +15,10 @@ import {
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import React from 'react';
+import { ANALYTICS_QUICK_LINKS } from '@/components/analytics/shell/AnalyticsNav';
 import { LoadingSpinner } from '@/components/loading-spinner';
-import { LoginForm } from '@/components/login-form';
 
+import { LoginForm } from '@/components/login-form';
 import { Navigation } from '@/components/navigation';
 import { REPORT_QUICK_LINKS } from '@/components/reports/shell/ReportsNav';
 import { Button } from '@/components/ui/button';
@@ -249,6 +251,45 @@ export default function DashboardPage() {
               </Button>
               <div className="flex flex-wrap gap-1">
                 {REPORT_QUICK_LINKS.map(({ href, label, icon: Icon }) => (
+                  <Link
+                    key={href}
+                    href={href}
+                    className="flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted"
+                  >
+                    <Icon className="size-3.5 shrink-0" />
+                    {label}
+                  </Link>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Analytics sits beside Reports rather than inside it. Reports say
+              how players are behaving; analytics say whether the material they
+              are playing is any good — a different question asked by a
+              different person, usually while they are writing content. */}
+          <Card className="transition-shadow duration-200 hover:shadow-lg">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Microscope className="size-5 text-sky-600" />
+                Analytics
+              </CardTitle>
+              <CardDescription>
+                Whether the content holds up: which footballers make everyone take a
+                hint, which questions nobody gets right, and what the data behind
+                them is missing.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <Button
+                onClick={() => router.push('/analytics/football-data')}
+                className="w-full border-emerald-500 bg-gradient-to-r from-emerald-500 to-green-600 text-white shadow-lg transition-all duration-200 hover:border-emerald-600 hover:from-emerald-600 hover:to-green-700 hover:shadow-xl"
+              >
+                <Microscope className="mr-2 size-4" />
+                Open Analytics
+              </Button>
+              <div className="flex flex-wrap gap-1">
+                {ANALYTICS_QUICK_LINKS.map(({ href, label, icon: Icon }) => (
                   <Link
                     key={href}
                     href={href}

--- a/app/user-hub/analytics/page.tsx
+++ b/app/user-hub/analytics/page.tsx
@@ -1,13 +1,18 @@
 import { permanentRedirect } from 'next/navigation';
 
 /**
- * Favourites analytics moved to /reports/favourites.
+ * Favourites analytics moved into the games report.
  *
  * The redirect stays because this URL is bookmarked and linked from outside the
  * app; a moved page that 404s teaches people the report is gone rather than
  * that it is somewhere better. Permanent, so it is cached and the old address
  * quietly stops being used.
+ *
+ * Points at the FINAL destination, not at `/reports/favourites`. That address
+ * was itself retired into `/reports/games`, so this used to be two hops — and a
+ * redirect chain costs an extra round trip, drops the permanent-cache benefit
+ * of the first hop, and breaks outright the day the middle link is cleaned up.
  */
 export default function UserHubAnalyticsRedirect() {
-  permanentRedirect('/reports/favourites');
+  permanentRedirect('/reports/games');
 }

--- a/components/admin/__tests__/SectionNav.test.tsx
+++ b/components/admin/__tests__/SectionNav.test.tsx
@@ -2,8 +2,10 @@ import { render, screen } from '@testing-library/react';
 import { BarChart3, BookOpen, Users } from 'lucide-react';
 import { describe, expect, it, vi } from 'vitest';
 import { SectionNav } from '@/components/admin/SectionNav';
+import { ANALYTICS_NAV_GROUPS, ANALYTICS_QUICK_LINKS } from '@/components/analytics/shell/AnalyticsNav';
 import { REPORT_NAV_GROUPS, REPORT_NAV_TRAILING, REPORT_QUICK_LINKS } from '@/components/reports/shell/ReportsNav';
 import { USER_HUB_NAV_GROUPS, USER_HUB_NAV_TRAILING } from '@/components/user-hub/UserHubShell';
+import { GLOBAL_NAV_SECTION_HREFS } from '@/lib/global-nav';
 
 vi.mock('next/navigation', () => ({ usePathname: () => '/reports/players' }));
 
@@ -157,8 +159,45 @@ describe('user hub nav groups', () => {
     expect(missing, `User Hub pages not in the nav: ${missing.join(', ')}`).toEqual([]);
   });
 
-  it('points at where favourites went', () => {
+  it('points at where favourites went, in one hop', () => {
     // The section lost a tab. A pointer beats a page that quietly disappears.
-    expect(USER_HUB_NAV_TRAILING.href).toBe('/reports/favourites');
+    //
+    // The FINAL destination, not `/reports/favourites`. That address was itself
+    // retired into the games report, so this pointer was two redirects deep —
+    // an extra round trip, no permanent-cache benefit on the first hop, and a
+    // dead link the day the middle one is cleaned up. This test previously
+    // asserted the middle hop, which is how the chain survived unnoticed.
+    expect(USER_HUB_NAV_TRAILING.href).toBe('/reports/games');
+  });
+});
+
+describe('the global nav agrees with the sections it links into', () => {
+  // The section navs already guard their own shortcuts. Nothing guarded the
+  // GLOBAL nav, which is a hand-maintained second copy of the same lists — and
+  // it had drifted: it still offered Patterns, Session length and Favourites,
+  // three routes retired in #1474 R4, while omitting Needs attention, Games and
+  // the glossary. Every one of those was a click into a redirect.
+  const sectionHrefs = new Set([
+    ...REPORT_NAV_GROUPS.flatMap(group => group.items.map(item => item.href)),
+    REPORT_NAV_TRAILING.href,
+    ...ANALYTICS_NAV_GROUPS.flatMap(group => group.items.map(item => item.href)),
+  ]);
+
+  it.each([...GLOBAL_NAV_SECTION_HREFS])('%s is a real destination', (href) => {
+    expect(sectionHrefs).toContain(href);
+  });
+
+  it('offers every reports and analytics destination', () => {
+    // The other direction: a page nobody links to is a page nobody finds.
+    for (const href of sectionHrefs) {
+      expect(GLOBAL_NAV_SECTION_HREFS).toContain(href);
+    }
+  });
+
+  it('every analytics shortcut is a real nav destination', () => {
+    const analyticsHrefs = ANALYTICS_NAV_GROUPS.flatMap(g => g.items.map(i => i.href));
+    for (const link of ANALYTICS_QUICK_LINKS) {
+      expect(analyticsHrefs).toContain(link.href);
+    }
   });
 });

--- a/components/analytics/shell/AnalyticsNav.tsx
+++ b/components/analytics/shell/AnalyticsNav.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { NavGroup } from '@/components/admin/SectionNav';
+import type { NavGroup, NavItem } from '@/components/admin/SectionNav';
 import { Database, HelpCircle, Route, Users } from 'lucide-react';
 
 /**
@@ -35,4 +35,21 @@ export const ANALYTICS_NAV_GROUPS: NavGroup[] = [
       { href: '/analytics/football-data', label: 'Football data', icon: Database },
     ],
   },
+];
+
+/**
+ * The handful of analytics worth offering from the dashboard.
+ *
+ * A shortlist, not the nav — same reasoning as `REPORT_QUICK_LINKS`: a card
+ * that reprints every destination is the nav with worse typography. These are
+ * the two someone arrives with (is the material too hard, is the data behind
+ * it complete); the per-game pages are where you go once you know which.
+ *
+ * Every entry must be a real nav destination, guarded in
+ * `components/admin/__tests__/SectionNav.test.tsx`.
+ */
+export const ANALYTICS_QUICK_LINKS: NavItem[] = [
+  { href: '/analytics/football-data', label: 'Football data', icon: Database },
+  { href: '/analytics/career-path', label: 'Career Path', icon: Route },
+  { href: '/analytics/questions', label: 'Quiz content', icon: HelpCircle },
 ];

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -1,23 +1,19 @@
 'use client';
 
+import type { NavigationPage } from '@/lib/global-nav';
 import {
-  BarChart3,
   ChevronDown,
   ChevronUp,
-  Clock,
   Database,
   FileQuestion,
-  Gamepad2,
   Home,
   LayoutDashboard,
   LineChart,
   Menu,
   MessageCircle,
-  Repeat,
+  Microscope,
   Search,
   Sparkles,
-  Star,
-  Timer,
   UserCog,
   Users,
   Users2,
@@ -32,19 +28,11 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { UserMenu } from '@/components/user-menu';
+import { ANALYTICS_CHILDREN, REPORTS_CHILDREN } from '@/lib/global-nav';
 import { cn } from '@/lib/utils';
 
 type NavigationProps = {
   className?: string;
-};
-
-type NavigationPage = {
-  label: string;
-  href?: string;
-  icon: any;
-  description: string;
-  children?: NavigationPage[];
-  defaultExpanded?: boolean;
 };
 
 export function Navigation({ className }: NavigationProps) {
@@ -56,6 +44,7 @@ export function Navigation({ className }: NavigationProps) {
     'Footballer Data': true, // Expanded by default
     'User Hub': true,
     'Reports': true,
+    'Analytics': true,
   });
 
   // State for mobile menu
@@ -123,50 +112,17 @@ export function Navigation({ className }: NavigationProps) {
       label: 'Reports',
       icon: LineChart,
       description: 'Platform activity and multiplayer reporting',
-      children: [
-        {
-          label: 'Daily Pulse',
-          href: '/reports',
-          icon: BarChart3,
-          description: 'How today compares with a typical day',
-        },
-        {
-          label: 'Multiplayer',
-          href: '/reports/multiplayer',
-          icon: Gamepad2,
-          description: 'Room funnel: created, started, finished',
-        },
-        {
-          label: 'Patterns',
-          href: '/reports/patterns',
-          icon: Clock,
-          description: 'When people play, new vs returning',
-        },
-        {
-          label: 'Players',
-          href: '/reports/players',
-          icon: Users,
-          description: 'Most active players over a window',
-        },
-        {
-          label: 'Session length',
-          href: '/reports/duration',
-          icon: Timer,
-          description: 'How long people stay in each game',
-        },
-        {
-          label: 'Retention',
-          href: '/reports/retention',
-          icon: Repeat,
-          description: 'Do players come back? D1/D7/D30 cohorts',
-        },
-        {
-          label: 'Favourites',
-          href: '/reports/favourites',
-          icon: Star,
-          description: 'Which games players save, and whether they play them',
-        },
-      ],
+      children: REPORTS_CHILDREN,
+    },
+    {
+      // Analytics is not Reports: reports answer "how are players behaving",
+      // analytics answer "is the material any good". Different question,
+      // different reader — so it gets its own section rather than a fifth
+      // entry under Reports.
+      label: 'Analytics',
+      icon: Microscope,
+      description: 'Whether the content and the data behind it are any good',
+      children: ANALYTICS_CHILDREN,
     },
     {
       label: 'Discord Control',

--- a/components/user-hub/UserHubShell.tsx
+++ b/components/user-hub/UserHubShell.tsx
@@ -26,7 +26,9 @@ export const USER_HUB_NAV_GROUPS: NavGroup[] = [
  * teaches people the page is gone.
  */
 export const USER_HUB_NAV_TRAILING: NavItem = {
-  href: '/reports/favourites',
+  // The final destination. `/reports/favourites` is itself retired into the
+  // games report, so linking it sent people through two redirects.
+  href: '/reports/games',
   label: 'Favourites moved to Reports',
   icon: Star,
 };

--- a/lib/global-nav.ts
+++ b/lib/global-nav.ts
@@ -1,0 +1,57 @@
+import {
+  BarChart3,
+  BookOpen,
+  Database,
+  Gamepad2,
+  HelpCircle,
+  LayoutGrid,
+  Repeat,
+  Route,
+  TriangleAlert,
+  Users,
+  Users2,
+} from 'lucide-react';
+
+export type NavigationPage = {
+  label: string;
+  href?: string;
+  icon: any;
+  description: string;
+  children?: NavigationPage[];
+  defaultExpanded?: boolean;
+};
+
+/**
+ * The Reports and Analytics children, at module scope so a guard can read the
+ * SAME array the nav renders rather than a second copy of it.
+ *
+ * This nav had drifted from the section navs: it still offered Patterns,
+ * Session length and Favourites — three routes retired in #1474 R4 — while
+ * omitting Needs attention, Games and the glossary. Every one of those was a
+ * click into a redirect, and nothing failed.
+ */
+export const REPORTS_CHILDREN: NavigationPage[] = [
+  { label: 'Daily Pulse', href: '/reports', icon: BarChart3, description: 'How today compares with a typical day' },
+  { label: 'Needs attention', href: '/reports/anomalies', icon: TriangleAlert, description: 'What moved more than noise explains' },
+  { label: 'Games', href: '/reports/games', icon: LayoutGrid, description: 'Per-game health, content and format' },
+  { label: 'Multiplayer', href: '/reports/multiplayer', icon: Gamepad2, description: 'Room funnel: created, started, finished' },
+  { label: 'Players', href: '/reports/players', icon: Users, description: 'Most active players over a window' },
+  { label: 'Retention', href: '/reports/retention', icon: Repeat, description: 'Do players come back? D1/D7/D30 cohorts' },
+  { label: 'What the numbers mean', href: '/reports/glossary', icon: BookOpen, description: 'How each figure is calculated, and how it gets misread' },
+];
+
+export const ANALYTICS_CHILDREN: NavigationPage[] = [
+  { label: 'Football data', href: '/analytics/football-data', icon: Database, description: 'What the games are missing, and what is being added' },
+  { label: 'Career Path', href: '/analytics/career-path', icon: Route, description: 'Which footballers make everyone take a hint' },
+  { label: 'Quiz content', href: '/analytics/questions', icon: HelpCircle, description: 'Which questions nobody gets right' },
+  { label: 'Lineups', href: '/analytics/lineups', icon: Users2, description: 'Which slots cost the most guesses' },
+];
+
+/**
+ * Every reports/analytics destination the global nav offers. Guarded against
+ *  the section navs in `components/admin/__tests__/SectionNav.test.tsx`.
+ */
+export const GLOBAL_NAV_SECTION_HREFS: string[] = [
+  ...REPORTS_CHILDREN.map(page => page.href!),
+  ...ANALYTICS_CHILDREN.map(page => page.href!),
+];


### PR DESCRIPTION

The global nav was a hand-maintained second copy of the section navs, and it
had drifted. It still offered Patterns, Session length and Favourites — three
routes retired in #1474 R4 — so those were clicks into a redirect. It omitted
Needs attention, Games and the glossary, which were reachable only by typing
the URL. And Analytics, four pages live for weeks, was not in it at all.

WHAT CHANGES

Reports: drops the three retired entries, adds the three missing ones.

Analytics: a new section with all four pages, and a dashboard card beside
Reports. It sits beside Reports rather than inside it because it answers a
different question — reports say how players are behaving, analytics say
whether the material they are playing is any good — usually for a different
person, while they are writing content.

The two section lists move to `lib/global-nav.ts`. Not tidying: the guard has
to read the SAME array the nav renders, and a constant exported from a
component file breaks fast refresh (the lint rule that caught `Sparkline`).

A redirect chain, fixed in two places. `/user-hub/analytics` forwarded to
`/reports/favourites`, which itself forwards to `/reports/games` — two hops,
which costs a round trip, loses the permanent-cache benefit of the first hop,
and breaks outright the day the middle link is cleaned up. Both now point at
the final destination.

THE GUARD

`SectionNav.test.tsx` already guarded each section's own shortcuts. Nothing
guarded the global nav against the sections, which is why it could drift for
weeks without a failure. It now checks both directions: every global-nav
destination is real, and every real destination is offered.

One existing test had to change. It asserted `USER_HUB_NAV_TRAILING.href ===
'/reports/favourites'` — the middle hop — so the chain was not merely
unguarded, it was pinned in place by a passing test.

Mutation-tested: reintroducing `/reports/patterns` and dropping
`/analytics/lineups` each fail exactly one test.

Refs https://github.com/FootballExtraTime/App/issues/1474

🤖 Generated with [Claude Code](https://claude.com/claude-code)