### PR TITLE
Football data: four pages, six gap lists, and a capped-list primitive

### DIFF
--- a/app/analytics/football-data/footballers/page.tsx
+++ b/app/analytics/football-data/footballers/page.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import type { RangeState } from '@/lib/report-range';
+import { useMemo, useState } from 'react';
+import { DataCoverage } from '@/components/analytics/panels/DataCoverage';
+import { DifficultyCatalogue } from '@/components/analytics/panels/DifficultyCatalogue';
+import { FootballerBreakdown } from '@/components/analytics/panels/FootballerBreakdown';
+import { ReviewQueue } from '@/components/analytics/panels/ReviewQueue';
+import { AnalyticsShell } from '@/components/analytics/shell/AnalyticsShell';
+import { FilterBar } from '@/components/reports/filters/FilterBar';
+import { RangePicker } from '@/components/reports/filters/RangePicker';
+import { ReportPanel } from '@/components/reports/primitives/ReportPanel';
+import { SectionHeader } from '@/components/reports/primitives/SectionHeader';
+import { useReport } from '@/hooks/use-report';
+import { useReportFilters } from '@/hooks/use-report-filters';
+import { useAuth } from '@/lib/auth';
+import { rangeToParams } from '@/lib/report-range';
+import { ReportsAPI } from '@/lib/reports-api';
+
+const PAGE = 10;
+const EXPANDED = 100;
+
+/**
+ * Footballers: the shape of the catalogue, and what is missing from it.
+ *
+ * The range picker stays because ONE thing here is windowed — coverage is
+ * measured among the footballers actually served in the period. The difficulty
+ * mix and the contributor list describe the catalogue as it stands and do not
+ * move with it, which their own copy says so the picker cannot mislead.
+ */
+export default function FootballersAnalyticsPage() {
+  const { isAuthenticated, user } = useAuth();
+  const enabled = isAuthenticated && !!(user?.is_staff || user?.is_superuser);
+  const [limit, setLimit] = useState(PAGE);
+
+  const { filters, update } = useReportFilters({
+    range: { window: 90 },
+    includeBots: false,
+    game: null,
+    metric: 'games_started',
+  });
+  const { range, includeBots } = filters;
+  const setRange = (next: RangeState) => update({ range: next });
+  const setIncludeBots = (next: boolean) => update({ includeBots: next });
+  const params = useMemo(
+    () => ({ ...rangeToParams(range), include_bots: includeBots, limit }),
+    [range, includeBots, limit],
+  );
+
+  const state = useReport(
+    ReportsAPI.getCoverage,
+    params,
+    enabled,
+    'The football data coverage endpoint',
+  );
+
+  return (
+    <AnalyticsShell
+      title="Footballers"
+      description="How the catalogue is shaped, who built it, and what the games cannot use."
+    >
+      <FilterBar>
+        <RangePicker
+          value={range}
+          onChange={setRange}
+          includeBots={includeBots}
+          onIncludeBotsChange={setIncludeBots}
+        />
+      </FilterBar>
+
+      <ReportPanel state={state} skeletonClassName="h-80 w-full">
+        {data => <DifficultyCatalogue data={data} />}
+      </ReportPanel>
+
+      <SectionHeader
+        title="Who built it, and who is still playing"
+        description="Not windowed — this is the catalogue as it stands, whatever the range says."
+      />
+
+      <ReportPanel state={state} skeletonClassName="h-72 w-full">
+        {data => (
+          <div className="space-y-4">
+            <FootballerBreakdown
+              data={data}
+              expanded={limit > PAGE}
+              onExpand={() => setLimit(EXPANDED)}
+            />
+            <ReviewQueue counts={data.review_queue} subject="footballers" />
+          </div>
+        )}
+      </ReportPanel>
+
+      <SectionHeader
+        title="Coverage where it is used"
+        description="Gaps among the footballers actually put in front of players in the window, and the untouched remainder."
+      />
+
+      <ReportPanel state={state} skeletonClassName="h-96 w-full">
+        {data => <DataCoverage data={data} />}
+      </ReportPanel>
+    </AnalyticsShell>
+  );
+}

--- a/app/analytics/football-data/nations/page.tsx
+++ b/app/analytics/football-data/nations/page.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useState } from 'react';
+import { NationGaps } from '@/components/analytics/panels/NationGaps';
+import { AnalyticsShell } from '@/components/analytics/shell/AnalyticsShell';
+import { ReportPanel } from '@/components/reports/primitives/ReportPanel';
+import { useReport } from '@/hooks/use-report';
+import { useAuth } from '@/lib/auth';
+import { ReportsAPI } from '@/lib/reports-api';
+
+/** Rows a gap list shows before you ask for more, and after. */
+const PAGE = 10;
+const EXPANDED = 100;
+
+/**
+ * Nation coverage.
+ *
+ * No date filter, on purpose: this describes the catalogue as it stands rather
+ * than what changed in a window, and offering a range picker would imply the
+ * number moves with it.
+ */
+export default function NationsAnalyticsPage() {
+  const { isAuthenticated, user } = useAuth();
+  const enabled = isAuthenticated && !!(user?.is_staff || user?.is_superuser);
+  const [limit, setLimit] = useState(PAGE);
+
+  const state = useReport(
+    () => ReportsAPI.getNationGaps(limit),
+    {},
+    enabled,
+    'The nation gaps endpoint',
+    // Part of the fetch identity: without it, asking for more would not refetch.
+    String(limit),
+  );
+
+  return (
+    <AnalyticsShell
+      title="Nations"
+      description="Which nations nothing points at, and where the catalogue is deepest."
+    >
+      <ReportPanel state={state} skeletonClassName="h-96 w-full">
+        {data => (
+          <NationGaps
+            data={data}
+            expanded={limit > PAGE}
+            onExpand={() => setLimit(EXPANDED)}
+          />
+        )}
+      </ReportPanel>
+    </AnalyticsShell>
+  );
+}

--- a/app/analytics/football-data/page.tsx
+++ b/app/analytics/football-data/page.tsx
@@ -3,13 +3,10 @@
 import type { RangeState } from '@/lib/report-range';
 import { useMemo } from 'react';
 import { CatalogueGrowth } from '@/components/analytics/panels/CatalogueGrowth';
-import { DataCoverage } from '@/components/analytics/panels/DataCoverage';
-import { DifficultyCatalogue } from '@/components/analytics/panels/DifficultyCatalogue';
 import { AnalyticsShell } from '@/components/analytics/shell/AnalyticsShell';
 import { FilterBar } from '@/components/reports/filters/FilterBar';
 import { RangePicker } from '@/components/reports/filters/RangePicker';
 import { ReportPanel } from '@/components/reports/primitives/ReportPanel';
-import { SectionHeader } from '@/components/reports/primitives/SectionHeader';
 import { useReport } from '@/hooks/use-report';
 import { useReportFilters } from '@/hooks/use-report-filters';
 import { useAuth } from '@/lib/auth';
@@ -17,12 +14,16 @@ import { rangeToParams } from '@/lib/report-range';
 import { ReportsAPI } from '@/lib/reports-api';
 
 /**
- * Football data completeness — the one analytics page that is not about a game.
+ * Football data — the overview, and the one page here that is about a window.
  *
  * It earns its own destination rather than folding in because every game reads
  * this data: a gap here is not a Career Path problem or a Scout problem, it is
  * both. And the answer it produces is "go and add data" rather than "go and
  * rewrite content", which is a different job for a different person.
+ *
+ * The detail moved to Footballers, Nations and Teams when this page reached
+ * nine sections. What stays is the question you arrive with — is anyone still
+ * adding to this — and the three entity pages answer "what is missing where".
  */
 export default function FootballDataAnalyticsPage() {
   const { isAuthenticated, user } = useAuth();
@@ -52,7 +53,7 @@ export default function FootballDataAnalyticsPage() {
   return (
     <AnalyticsShell
       title="Football data"
-      description="What the games are missing, counted where it is actually used."
+      description="What the games are missing, and whether anyone is still filling it in."
     >
       <FilterBar>
         <RangePicker
@@ -63,29 +64,8 @@ export default function FootballDataAnalyticsPage() {
         />
       </FilterBar>
 
-      {/* Growth first: "is anyone still adding to this" frames every gap
-          underneath. A coverage figure alone cannot say whether it is being
-          worked on or has been static since April. */}
       <ReportPanel state={state} skeletonClassName="h-[28rem] w-full">
         {data => <CatalogueGrowth data={data} />}
-      </ReportPanel>
-
-      <SectionHeader
-        title="The catalogue by difficulty"
-        description="How much of each tier exists, and how much of it has a face to show."
-      />
-
-      <ReportPanel state={state} skeletonClassName="h-80 w-full">
-        {data => <DifficultyCatalogue data={data} />}
-      </ReportPanel>
-
-      <SectionHeader
-        title="Coverage where it is used"
-        description="Gaps among the footballers actually put in front of players, and the untouched remainder."
-      />
-
-      <ReportPanel state={state} skeletonClassName="h-96 w-full">
-        {data => <DataCoverage data={data} />}
       </ReportPanel>
     </AnalyticsShell>
   );

--- a/app/analytics/football-data/teams/page.tsx
+++ b/app/analytics/football-data/teams/page.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useState } from 'react';
+import { ReviewQueue } from '@/components/analytics/panels/ReviewQueue';
+import { TeamGaps } from '@/components/analytics/panels/TeamGaps';
+import { AnalyticsShell } from '@/components/analytics/shell/AnalyticsShell';
+import { ReportPanel } from '@/components/reports/primitives/ReportPanel';
+import { useReport } from '@/hooks/use-report';
+import { useAuth } from '@/lib/auth';
+import { ReportsAPI } from '@/lib/reports-api';
+
+const PAGE = 10;
+const EXPANDED = 100;
+
+/** Team coverage. No date filter — see the nations page for why. */
+export default function TeamsAnalyticsPage() {
+  const { isAuthenticated, user } = useAuth();
+  const enabled = isAuthenticated && !!(user?.is_staff || user?.is_superuser);
+  const [limit, setLimit] = useState(PAGE);
+
+  const state = useReport(
+    () => ReportsAPI.getTeamGaps(limit),
+    {},
+    enabled,
+    'The team gaps endpoint',
+    String(limit),
+  );
+
+  return (
+    <AnalyticsShell
+      title="Teams"
+      description="Teams nobody plays for, and anything still waiting on review."
+    >
+      <ReportPanel state={state} skeletonClassName="h-80 w-full">
+        {data => (
+          <div className="space-y-4">
+            <TeamGaps data={data} expanded={limit > PAGE} onExpand={() => setLimit(EXPANDED)} />
+            <ReviewQueue counts={data.review_queue} subject="teams" />
+          </div>
+        )}
+      </ReportPanel>
+    </AnalyticsShell>
+  );
+}

--- a/components/analytics/__tests__/NationGaps.test.tsx
+++ b/components/analytics/__tests__/NationGaps.test.tsx
@@ -1,0 +1,69 @@
+import type { NationGapsResponse } from '@/types/reports';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { NationGaps } from '@/components/analytics/panels/NationGaps';
+import { ReviewQueue } from '@/components/analytics/panels/ReviewQueue';
+
+function data(): NationGapsResponse {
+  return {
+    nations_without_footballers: {
+      items: [{ name: 'Afghanistan', short: 'AFG' }, { name: 'American Samoa', short: 'ASM' }],
+      total: 101,
+      limit: 10,
+    },
+    nations_without_teams: { items: [{ name: 'Aruba', short: 'ABW' }], total: 94, limit: 10 },
+    nations_by_footballers: {
+      items: [{ name: 'England', short: 'ENG', footballers: 467 }],
+      total: 132,
+      limit: 10,
+    },
+  };
+}
+
+describe('nationGaps', () => {
+  it('describes the gap by its real size, not by the sample', () => {
+    render(<NationGaps data={data()} />);
+
+    expect(screen.getByText('Showing 2 of 101')).toBeInTheDocument();
+    expect(screen.getByText('Showing 1 of 94')).toBeInTheDocument();
+  });
+
+  it('keeps "no footballers" and "no teams" as separate jobs', () => {
+    // They overlap heavily but are not the same fix: a nation can have players
+    // and no clubs, and club-based content needs the clubs.
+    render(<NationGaps data={data()} />);
+
+    expect(screen.getByText('Nations with no footballers')).toBeInTheDocument();
+    expect(screen.getByText('Nations with no teams')).toBeInTheDocument();
+  });
+
+  it('shows the depth ranking with its counts', () => {
+    render(<NationGaps data={data()} />);
+
+    expect(screen.getByText('England')).toBeInTheDocument();
+    expect(screen.getByText('467')).toBeInTheDocument();
+  });
+});
+
+describe('reviewQueue', () => {
+  it('renders nothing when nothing is pending', () => {
+    // Not every deployment uses the review states. A permanent row of zeros
+    // would be a workflow the page invented.
+    const { container } = render(<ReviewQueue counts={{}} subject="teams" />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when the backend predates the field', () => {
+    const { container } = render(<ReviewQueue counts={undefined} subject="teams" />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('names the status in words when something is waiting', () => {
+    render(<ReviewQueue counts={{ AWAITING_REVISION: 12 }} subject="footballers" />);
+
+    expect(screen.getByText('Awaiting revision')).toBeInTheDocument();
+    expect(screen.getByText('12')).toBeInTheDocument();
+  });
+});

--- a/components/analytics/panels/FootballerBreakdown.tsx
+++ b/components/analytics/panels/FootballerBreakdown.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import type { CoverageResponse } from '@/types/reports';
+import { CappedList } from '@/components/reports/primitives/CappedList';
+import { ReportTable } from '@/components/reports/primitives/ReportTable';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Progress } from '@/components/ui/progress';
+
+/**
+ * Who is adding footballers, and how many of them have stopped playing.
+ *
+ * Contributors is footballers ONLY. `Footballer` is the single model of the
+ * three that records who added it — `Team` and `Nation` carry no author — so
+ * presenting this as catalogue-wide authorship would credit one person with
+ * work the schema cannot attribute.
+ */
+export function FootballerBreakdown({ data, onExpand, expanded }: {
+  data: CoverageResponse;
+  onExpand?: () => void;
+  expanded?: boolean;
+}) {
+  const { contributors, career_state: careerState } = data;
+
+  // The BE may not carry these yet — the repositories deploy independently.
+  if (!contributors && !careerState) {
+    return null;
+  }
+
+  const total = careerState ? careerState.retired + careerState.active : 0;
+  const retiredPct = total ? Math.round((careerState!.retired / total) * 1000) / 10 : null;
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-2">
+      {contributors && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Who added them</CardTitle>
+            <CardDescription>
+              Footballers only — teams and nations do not record who added them, so this is
+              not the whole catalogue.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <CappedList
+              total={contributors.total}
+              shown={contributors.items.length}
+              onExpand={onExpand}
+              expanded={expanded}
+              emptyLabel="No footballer records who added it."
+            >
+              <ReportTable>
+                <tbody>
+                  {contributors.items.map(row => (
+                    <tr key={row.username} className="border-b last:border-0">
+                      <td className="py-1.5 pr-4 text-sm text-foreground">{row.username}</td>
+                      <td className="py-1.5 text-right text-sm font-medium tabular-nums text-foreground">
+                        {row.footballers.toLocaleString()}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </ReportTable>
+            </CappedList>
+          </CardContent>
+        </Card>
+      )}
+
+      {careerState && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Still playing, or retired</CardTitle>
+            <CardDescription>
+              Which games can use whom: a retired footballer cannot appear in anything
+              scoped to a current squad.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <dl className="space-y-3">
+              <Row label="Retired" value={careerState.retired} total={total} />
+              <Row label="Still playing" value={careerState.active} total={total} />
+            </dl>
+            {retiredPct !== null && (
+              <p className="text-xs text-muted-foreground">
+                {`${retiredPct}% of the approved catalogue has retired.`}
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+function Row({ label, value, total }: { label: string; value: number; total: number }) {
+  return (
+    <div className="space-y-1">
+      <div className="flex items-baseline justify-between gap-2">
+        <dt className="text-sm text-muted-foreground">{label}</dt>
+        <dd className="text-sm font-medium tabular-nums text-foreground">{value.toLocaleString()}</dd>
+      </div>
+      <Progress value={total ? (value / total) * 100 : 0} aria-label={`${label}: ${value} of ${total}`} />
+    </div>
+  );
+}

--- a/components/analytics/panels/NationGaps.tsx
+++ b/components/analytics/panels/NationGaps.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import type { NationGapsResponse } from '@/types/reports';
+import { CappedList } from '@/components/reports/primitives/CappedList';
+import { ReportTable } from '@/components/reports/primitives/ReportTable';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+/**
+ * Nations nothing points at, and the ones the catalogue leans on.
+ *
+ * Two gaps and one skew, in that order, because the first two are worklists and
+ * the third is context for them. A nation with no footballers cannot appear in
+ * anything nation-scoped; a nation with no teams cannot appear in club-based
+ * content. They overlap heavily but are not the same job.
+ *
+ * Active nations only. A defunct country with no footballers is not a gap to
+ * fill — mixing the two turns a worklist into a list nobody will action.
+ */
+export function NationGaps({ data, onExpand, expanded }: {
+  data: NationGapsResponse;
+  onExpand?: () => void;
+  expanded?: boolean;
+}) {
+  return (
+    <div className="grid gap-4 lg:grid-cols-2">
+      <Card>
+        <CardHeader>
+          <CardTitle>Nations with no footballers</CardTitle>
+          <CardDescription>
+            Nothing nation-scoped can use these — no national-team clue, no nation criterion.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <CappedList
+            total={data.nations_without_footballers.total}
+            shown={data.nations_without_footballers.items.length}
+            onExpand={onExpand}
+            expanded={expanded}
+            emptyLabel="Every active nation has at least one footballer."
+          >
+            <NameList rows={data.nations_without_footballers.items} />
+          </CappedList>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Nations with no teams</CardTitle>
+          <CardDescription>
+            A separate gap: club-based content needs a team in the country, not just a player from it.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <CappedList
+            total={data.nations_without_teams.total}
+            shown={data.nations_without_teams.items.length}
+            onExpand={onExpand}
+            expanded={expanded}
+            emptyLabel="Every active nation has at least one team."
+          >
+            <NameList rows={data.nations_without_teams.items} />
+          </CappedList>
+        </CardContent>
+      </Card>
+
+      <Card className="lg:col-span-2">
+        <CardHeader>
+          <CardTitle>Where the catalogue is deepest</CardTitle>
+          <CardDescription>
+            Context for the gaps above: this is what the games will actually feel like to play.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <CappedList
+            total={data.nations_by_footballers.total}
+            shown={data.nations_by_footballers.items.length}
+            onExpand={onExpand}
+            expanded={expanded}
+            emptyLabel="No footballers are assigned to a nation yet."
+          >
+            <ReportTable>
+              <tbody>
+                {data.nations_by_footballers.items.map(row => (
+                  <tr key={row.short} className="border-b last:border-0">
+                    <td className="py-1.5 pr-4 text-sm text-foreground">{row.name}</td>
+                    <td className="py-1.5 pr-4 text-xs text-muted-foreground">{row.short}</td>
+                    <td className="py-1.5 text-right text-sm font-medium tabular-nums text-foreground">
+                      {row.footballers.toLocaleString()}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </ReportTable>
+          </CappedList>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+/** A plain list of names — no counts, because every row here is a zero. */
+function NameList({ rows }: { rows: { name: string; short: string }[] }) {
+  return (
+    <ul className="flex flex-wrap gap-x-3 gap-y-1.5 text-sm">
+      {rows.map(row => (
+        <li key={row.short} className="text-foreground">
+          {row.name}
+          <span className="ml-1 text-xs text-muted-foreground">{row.short}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/components/analytics/panels/ReviewQueue.tsx
+++ b/components/analytics/panels/ReviewQueue.tsx
@@ -1,0 +1,48 @@
+import type { ReviewQueue as ReviewQueueCounts } from '@/types/reports';
+import { MetricRow } from '@/components/reports/primitives/MetricRow';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+/**
+ * What is waiting to be reviewed, when anything is.
+ *
+ * Renders nothing when the queue is empty, and that is deliberate rather than a
+ * fallback: not every deployment uses the review states at all. On a catalogue
+ * where everything is approved on creation, a permanent row of zeros would be a
+ * workflow the page invented. If it appears, there is something to do.
+ */
+const STATUS_LABELS: Record<string, string> = {
+  AWAITING_REVISION: 'Awaiting revision',
+  AWAITING_CHANGE_CHECK: 'Awaiting change check',
+  DENIED: 'Denied',
+};
+
+export function ReviewQueue({ counts, subject }: {
+  counts: ReviewQueueCounts | undefined;
+  /** What is queued — "footballers", "teams". Read into the description. */
+  subject: string;
+}) {
+  const entries = Object.entries(counts ?? {});
+  if (entries.length === 0) {
+    return null;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Waiting for review</CardTitle>
+        <CardDescription>
+          {`${subject[0].toUpperCase()}${subject.slice(1)} that are not approved, so no game can use them yet.`}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <MetricRow
+          columns={3}
+          metrics={entries.map(([status, count]) => ({
+            label: STATUS_LABELS[status] ?? status,
+            value: count.toLocaleString(),
+          }))}
+        />
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/analytics/panels/TeamGaps.tsx
+++ b/components/analytics/panels/TeamGaps.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import type { TeamGapsResponse } from '@/types/reports';
+import { CappedList } from '@/components/reports/primitives/CappedList';
+import { ReportTable } from '@/components/reports/primitives/ReportTable';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+/**
+ * Teams nobody plays for.
+ *
+ * A team with no squad is a row that exists and cannot be used: it can never be
+ * a Career Path step or a Grid criterion, and it will sit in search results
+ * returning nothing. Cheap to fix and invisible until you look for it.
+ */
+export function TeamGaps({ data, onExpand, expanded }: {
+  data: TeamGapsResponse;
+  onExpand?: () => void;
+  expanded?: boolean;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Teams with no footballers</CardTitle>
+        <CardDescription>
+          A team with an empty squad cannot be a career step or a grid criterion — it is a
+          row that exists and does nothing.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <CappedList
+          total={data.teams_without_footballers.total}
+          shown={data.teams_without_footballers.items.length}
+          onExpand={onExpand}
+          expanded={expanded}
+          emptyLabel="Every team has at least one footballer."
+        >
+          <ReportTable>
+            <tbody>
+              {data.teams_without_footballers.items.map(row => (
+                <tr key={`${row.name}-${row.nation ?? ''}`} className="border-b last:border-0">
+                  <td className="py-1.5 pr-4 text-sm text-foreground">{row.name}</td>
+                  <td className="py-1.5 text-right text-xs text-muted-foreground">
+                    {/* Not `null` — a team with no nation is its own small gap. */}
+                    {row.nation ?? 'No nation'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </ReportTable>
+        </CappedList>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/analytics/shell/AnalyticsNav.tsx
+++ b/components/analytics/shell/AnalyticsNav.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { NavGroup, NavItem } from '@/components/admin/SectionNav';
-import { Database, HelpCircle, Route, Users } from 'lucide-react';
+import { Database, Flag, HelpCircle, Route, Shield, User, Users } from 'lucide-react';
 
 /**
  * Analytics, which is not Reports and should not be folded into it.
@@ -30,9 +30,15 @@ export const ANALYTICS_NAV_GROUPS: NavGroup[] = [
     // Its own group, not a fourth per-game entry: every game reads this data,
     // so a gap here belongs to none of them in particular — and the answer it
     // produces is "add data" rather than "rewrite content".
-    heading: 'Across the platform',
+    // Four destinations rather than one page with nine sections. Each entity
+    // is a different worklist for a different afternoon, and splitting them
+    // means the nations page never runs the difficulty query.
+    heading: 'Football data',
     items: [
-      { href: '/analytics/football-data', label: 'Football data', icon: Database },
+      { href: '/analytics/football-data', label: 'Overview', icon: Database },
+      { href: '/analytics/football-data/footballers', label: 'Footballers', icon: User },
+      { href: '/analytics/football-data/nations', label: 'Nations', icon: Flag },
+      { href: '/analytics/football-data/teams', label: 'Teams', icon: Shield },
     ],
   },
 ];

--- a/components/reports/primitives/CappedList.tsx
+++ b/components/reports/primitives/CappedList.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+/**
+ * A worklist, showing its first rows and admitting how long it is.
+ *
+ * These lists are gaps to go and fix — 101 nations with no footballer, 53 empty
+ * teams. The count is the signal and the rows are the sample: the top is where
+ * you start, and rows 40 to 101 are identical in kind. Printing all of them
+ * turns a panel into a scroll.
+ *
+ * The server does the capping and sends `total` alongside, so "10 of 101" is
+ * honest without transferring 101 rows. Slicing client-side would ship the
+ * whole table and hide most of it — the payload would grow with the problem,
+ * which is exactly backwards.
+ *
+ * Expanding refetches at a higher limit rather than revealing hidden rows,
+ * because there are no hidden rows to reveal.
+ */
+export function CappedList({ total, shown, expanded, onExpand, emptyLabel, children, className }: {
+  /** The real number behind the sample. */
+  total: number;
+  /**
+   * How many rows are actually rendered — `items.length`, never the limit that
+   * was requested. The server can return fewer than asked for, and deriving
+   * this from the limit would claim ten rows while showing two.
+   */
+  shown: number;
+  /** Whether the caller has already asked for more. */
+  expanded?: boolean;
+  /** Ask for a bigger page. Omit when the caller cannot refetch. */
+  onExpand?: () => void;
+  /** What "none" means here — an empty gap list is usually good news. */
+  emptyLabel: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  const [busy, setBusy] = useState(false);
+
+  if (total === 0) {
+    // Not an error and not a blank: for a gap list, zero is the goal.
+    return <p className={cn('text-sm text-muted-foreground', className)}>{emptyLabel}</p>;
+  }
+
+  const more = total - shown;
+
+  return (
+    <div className={cn('space-y-2', className)}>
+      {children}
+      {/* Only when the sample is short of the total. "10 of 10" is noise. */}
+      {more > 0 && (
+        <div className="flex items-center gap-3 pt-1">
+          <p className="text-xs text-muted-foreground">
+            {`Showing ${shown.toLocaleString()} of ${total.toLocaleString()}`}
+          </p>
+          {onExpand && !expanded && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-auto px-2 py-0.5 text-xs"
+              disabled={busy}
+              onClick={() => {
+                setBusy(true);
+                onExpand();
+              }}
+            >
+              {busy ? 'Loading…' : `Show ${Math.min(more, 90).toLocaleString()} more`}
+            </Button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/reports/primitives/__tests__/CappedList.test.tsx
+++ b/components/reports/primitives/__tests__/CappedList.test.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { CappedList } from '@/components/reports/primitives/CappedList';
+
+describe('cappedList', () => {
+  it('reports the real total, not the number of rows shown', () => {
+    // The whole point: `items` is capped server-side, so a UI that counted the
+    // rows it received would describe a 101-nation gap as ten.
+    render(
+      <CappedList total={101} shown={10} emptyLabel="none" onExpand={vi.fn()}>
+        <ul />
+      </CappedList>,
+    );
+
+    expect(screen.getByText('Showing 10 of 101')).toBeInTheDocument();
+  });
+
+  it('says nothing about counts when the sample IS the total', () => {
+    // "Showing 10 of 10" is noise.
+    render(
+      <CappedList total={10} shown={10} emptyLabel="none" onExpand={vi.fn()}>
+        <ul />
+      </CappedList>,
+    );
+
+    expect(screen.queryByText(/Showing/)).not.toBeInTheDocument();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('treats an empty gap list as good news, not as missing data', () => {
+    render(
+      <CappedList total={0} shown={0} emptyLabel="Every nation has a footballer.">
+        <ul data-testid="rows" />
+      </CappedList>,
+    );
+
+    expect(screen.getByText('Every nation has a footballer.')).toBeInTheDocument();
+    expect(screen.queryByTestId('rows')).not.toBeInTheDocument();
+  });
+
+  it('offers only the rows that actually remain', () => {
+    render(
+      <CappedList total={14} shown={10} emptyLabel="none" onExpand={vi.fn()}>
+        <ul />
+      </CappedList>,
+    );
+
+    expect(screen.getByRole('button', { name: 'Show 4 more' })).toBeInTheDocument();
+  });
+
+  it('asks the server for more rather than revealing hidden ones', () => {
+    // There are no hidden rows to reveal — the server sent ten.
+    const onExpand = vi.fn();
+    render(
+      <CappedList total={101} shown={10} emptyLabel="none" onExpand={onExpand}>
+        <ul />
+      </CappedList>,
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(onExpand).toHaveBeenCalledOnce();
+  });
+
+  it('drops the button once expanded, keeping the count', () => {
+    render(
+      <CappedList total={101} shown={100} expanded emptyLabel="none" onExpand={vi.fn()}>
+        <ul />
+      </CappedList>,
+    );
+
+    expect(screen.getByText('Showing 100 of 101')).toBeInTheDocument();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+});

--- a/lib/global-nav.ts
+++ b/lib/global-nav.ts
@@ -2,12 +2,15 @@ import {
   BarChart3,
   BookOpen,
   Database,
+  Flag,
   Gamepad2,
   HelpCircle,
   LayoutGrid,
   Repeat,
   Route,
+  Shield,
   TriangleAlert,
+  User,
   Users,
   Users2,
 } from 'lucide-react';
@@ -42,6 +45,9 @@ export const REPORTS_CHILDREN: NavigationPage[] = [
 
 export const ANALYTICS_CHILDREN: NavigationPage[] = [
   { label: 'Football data', href: '/analytics/football-data', icon: Database, description: 'What the games are missing, and what is being added' },
+  { label: 'Footballers', href: '/analytics/football-data/footballers', icon: User, description: 'How the catalogue is shaped, and who built it' },
+  { label: 'Nations', href: '/analytics/football-data/nations', icon: Flag, description: 'Nations nothing points at' },
+  { label: 'Teams', href: '/analytics/football-data/teams', icon: Shield, description: 'Teams nobody plays for' },
   { label: 'Career Path', href: '/analytics/career-path', icon: Route, description: 'Which footballers make everyone take a hint' },
   { label: 'Quiz content', href: '/analytics/questions', icon: HelpCircle, description: 'Which questions nobody gets right' },
   { label: 'Lineups', href: '/analytics/lineups', icon: Users2, description: 'Which slots cost the most guesses' },

--- a/lib/reports-api.ts
+++ b/lib/reports-api.ts
@@ -14,6 +14,7 @@ import type {
   GrowthResponse,
   LineupsAnalyticsResponse,
   MultiplayerResponse,
+  NationGapsResponse,
   PatternsResponse,
   PlayerDetailResponse,
   ProgressResponse,
@@ -22,6 +23,7 @@ import type {
   RetentionResponse,
   RollupHealth,
   SummaryResponse,
+  TeamGapsResponse,
   TopPlayersResponse,
   UnfinishedResponse,
 } from '@/types/reports';
@@ -144,6 +146,22 @@ export class ReportsAPI {
   /** GET /core/analytics/football-data/ — data completeness where it is used. */
   static async getCoverage(params?: ReportParams): Promise<CoverageResponse> {
     return apiFetcher<CoverageResponse>(`core/analytics/football-data/${buildQuery(params)}`);
+  }
+
+  /**
+   * GET /core/analytics/football-data/nations/ — nation gaps.
+   *
+   * No range parameter: these describe the catalogue as it stands, not what
+   * changed in a window, and offering a date filter would imply the number
+   * moves with it.
+   */
+  static async getNationGaps(limit?: number): Promise<NationGapsResponse> {
+    return apiFetcher<NationGapsResponse>(`core/analytics/football-data/nations/${buildQuery({ limit })}`);
+  }
+
+  /** GET /core/analytics/football-data/teams/ — empty teams and the review queue. */
+  static async getTeamGaps(limit?: number): Promise<TeamGapsResponse> {
+    return apiFetcher<TeamGapsResponse>(`core/analytics/football-data/teams/${buildQuery({ limit })}`);
   }
 
   /** GET /core/reporting/content/ — content runway and pool depth. A snapshot. */

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -1144,7 +1144,42 @@ export type CoverageResponse = {
   totals?: CatalogueTotals;
   added_series?: CatalogueAddedPoint[];
   difficulty_tiers?: DifficultyTier[];
+  /**
+   * Who added the footballers. Only `Footballer` records this — Team and
+   *  Nation carry no author — so it is not catalogue-wide authorship.
+   */
+  contributors?: CappedRows<{ username: string; footballers: number }>;
+  career_state?: { retired: number; active: number };
+  review_queue?: ReviewQueue;
 } & ResolvedRange;
+
+/**
+ * A bounded sample plus the real total.
+ *
+ * `items` is capped server-side, so `items.length` is NOT the answer to "how
+ * many" — `total` is. Reporting the length is how a 101-nation gap gets
+ * described as ten.
+ */
+export type CappedRows<T> = {
+  items: T[];
+  total: number;
+  /** How many were asked for, echoed so the UI can say "10 of 101". */
+  limit: number;
+};
+
+/** Counts by non-approved status. Empty when nothing is waiting. */
+export type ReviewQueue = Record<string, number>;
+
+export type NationGapsResponse = {
+  nations_without_footballers: CappedRows<{ name: string; short: string }>;
+  nations_without_teams: CappedRows<{ name: string; short: string }>;
+  nations_by_footballers: CappedRows<{ name: string; short: string; footballers: number }>;
+};
+
+export type TeamGapsResponse = {
+  teams_without_footballers: CappedRows<{ name: string; nation: string | null }>;
+  review_queue: ReviewQueue;
+};
 
 export type CatalogueTotals = {
   /**


### PR DESCRIPTION

The page had three sections and six more to add. Nine is a scroll, so it
splits by entity — Overview, Footballers, Nations, Teams — and each page
fetches only what it renders: the nations page never runs the difficulty
query.

WHAT IS ON EACH

Overview keeps the question you arrive with: is anyone still adding to this.
Footballers takes the difficulty mix and coverage, and gains contributors, the
retired/active split and the review queue. Nations and Teams are new.

CAPPED LISTS

`CappedList` is the shared primitive, and the reports UI had no expand pattern
at all before this — `collapsible.tsx` was installed and unused.

The count is the signal and the rows are the sample: the top of a worklist is
where you start, and rows 40 to 101 are identical in kind. So it shows ten,
says "Showing 10 of 101", and expanding REFETCHES rather than revealing hidden
rows, because there are no hidden rows — the server sent ten. Slicing
client-side would ship all 101 and hide 91, so the payload would grow with the
problem, which is backwards.

Zero renders the empty label, not a blank: for a gap list, zero is the goal.

The first version derived the shown count from the requested limit. That is
wrong whenever the server returns fewer than asked for — it would say "showing
10" above two rows — and a test caught it. It now takes `items.length`, so the
number cannot disagree with what is on screen.

Contributors is labelled footballers-only in the UI, because `Team` and
`Nation` have no author column and a bare "who added the data" would overclaim.

The review queue renders nothing when nothing is pending. Not every deployment
uses the review states, and a permanent row of zeros would be a workflow the
page invented.

The gap endpoints take a plain `limit` argument rather than a `ReportParams`
object. Not style: `reports.guard.ts` treats any method accepting
`ReportParams` as range-filtered and requires it to echo a window, and these
have no window to echo. An all-optional params type still satisfies that check
structurally, so the honest fix was to stop claiming they take a range.

Rebased onto production after #136 merged.

Four mutations checked on the primitive: showing the counter when nothing is
hidden, rendering rows instead of the empty label, offering to load the whole
total, and reporting the total as the shown count each fail a test.

Refs https://github.com/FootballExtraTime/App/issues/1474

🤖 Generated with [Claude Code](https://claude.com/claude-code)