### PR TITLE
Questions move under Football Data, plus squad depth and a career split

### DIFF
--- a/app/analytics/football-data/questions/page.tsx
+++ b/app/analytics/football-data/questions/page.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import type { RangeState } from '@/lib/report-range';
+import { useMemo, useState } from 'react';
+import { CategoryMatrix } from '@/components/analytics/panels/CategoryMatrix';
+import { CategoryQuality } from '@/components/analytics/panels/CategoryQuality';
+import { GlobalQuizUsage } from '@/components/analytics/panels/GlobalQuizUsage';
+import { QuestionBank } from '@/components/analytics/panels/QuestionBank';
+import { QuestionCatalogue } from '@/components/analytics/panels/QuestionCatalogue';
+import { QuestionQuality } from '@/components/analytics/panels/QuestionQuality';
+import { AnalyticsShell } from '@/components/analytics/shell/AnalyticsShell';
+import { FilterBar } from '@/components/reports/filters/FilterBar';
+import { RangePicker } from '@/components/reports/filters/RangePicker';
+import { SearchBox } from '@/components/reports/filters/SearchBox';
+import { ReportPanel } from '@/components/reports/primitives/ReportPanel';
+import { SectionHeader } from '@/components/reports/primitives/SectionHeader';
+import { useReport } from '@/hooks/use-report';
+import { useReportFilters } from '@/hooks/use-report-filters';
+import { useAuth } from '@/lib/auth';
+import { rangeToParams } from '@/lib/report-range';
+import { ReportsAPI } from '@/lib/reports-api';
+
+/**
+ * The quiz question bank, under Football Data.
+ *
+ * It belongs here rather than beside the game reports because it is the same
+ * question this section asks of every other table — how much material exists,
+ * and where is it thin — of the question bank instead of the footballers.
+ *
+ * Two halves in a deliberate order. The catalogue leads: how big the bank is,
+ * what arrived, and how the categories are shaped. The quality worklist follows,
+ * because "which questions are broken" is a different afternoon from "what do we
+ * have", and the person who came for one rarely wants the other first.
+ */
+const PAGE = 10;
+const EXPANDED = 100;
+
+export default function QuestionsAnalyticsPage() {
+  const { isAuthenticated, user } = useAuth();
+  const enabled = isAuthenticated && !!(user?.is_staff || user?.is_superuser);
+
+  // 90 days: a question needs 30 answers before its distribution says anything,
+  // and a 30-day window leaves most of a 7,000-question bank under that line.
+  const { filters, update } = useReportFilters({
+    range: { window: 90 },
+    includeBots: false,
+    game: null,
+    metric: 'games_started',
+  });
+  const { range, includeBots } = filters;
+  const setRange = (next: RangeState) => update({ range: next });
+  const setIncludeBots = (next: boolean) => update({ includeBots: next });
+  const params = useMemo(
+    () => ({ ...rangeToParams(range), include_bots: includeBots }),
+    [range, includeBots],
+  );
+
+  const [limit, setLimit] = useState(PAGE);
+  const [search, setSearch] = useState('');
+
+  const bank = useReport(
+    () => ReportsAPI.getQuestionBank({ ...params, limit, search: search || undefined }),
+    params,
+    enabled,
+    'The question bank endpoint',
+    `${limit}:${search}`,
+  );
+
+  const state = useReport(
+    ReportsAPI.getQuestionsAnalytics,
+    params,
+    enabled,
+    'The questions analytics endpoint',
+  );
+
+  return (
+    <AnalyticsShell
+      title="Questions"
+      description="How big the question bank is, how it is shaped, and which questions are broken."
+    >
+      <FilterBar>
+        <RangePicker
+          value={range}
+          onChange={setRange}
+          includeBots={includeBots}
+          onIncludeBotsChange={setIncludeBots}
+        />
+        <SearchBox
+          value={search}
+          onChange={setSearch}
+          placeholder="Filter categories by name"
+          className="w-full sm:w-72"
+        />
+      </FilterBar>
+
+      <ReportPanel state={bank} skeletonClassName="h-[26rem] w-full">
+        {data => <QuestionCatalogue data={data} />}
+      </ReportPanel>
+
+      <ReportPanel state={bank} skeletonClassName="h-96 w-full">
+        {data => (
+          <CategoryMatrix
+            data={data}
+            expanded={limit > PAGE}
+            onExpand={() => setLimit(EXPANDED)}
+          />
+        )}
+      </ReportPanel>
+
+      <SectionHeader
+        title="Which questions are broken"
+        description="A worklist: the handful worth an afternoon, rather than the bank as a whole."
+      />
+
+      <ReportPanel state={state} skeletonClassName="h-96 w-full">
+        {data => <QuestionQuality data={data} />}
+      </ReportPanel>
+
+      {/* Underneath, because it answers the question the list raises rather than
+          the one someone arrives with: is this a few bad questions, or is the
+          whole bank mis-graded? */}
+      <SectionHeader
+        title="The bank as a whole"
+        description="Whether the grading separates anything, and whether there is material left."
+      />
+
+      <ReportPanel state={state} skeletonClassName="h-64 w-full">
+        {data => <QuestionBank data={data} />}
+      </ReportPanel>
+
+      {/* The Quiz dashboard's content half, folded in here rather than given its
+          own destination (#1475). Its other half was top players by quizzes
+          played, which is Reports and better there. Two panels about this same
+          bank do not earn a nav entry — the argument R4 used to cut the
+          reporting nav from ten destinations to six. */}
+      <SectionHeader
+        title="Categories and what ran"
+        description="Where the bank is weakest by subject, and which scheduled quizzes people actually played."
+      />
+
+      <ReportPanel state={state} skeletonClassName="h-80 w-full">
+        {data => <CategoryQuality data={data} />}
+      </ReportPanel>
+
+      <ReportPanel state={state} skeletonClassName="h-64 w-full">
+        {data => <GlobalQuizUsage data={data} />}
+      </ReportPanel>
+    </AnalyticsShell>
+  );
+}

--- a/app/analytics/football-data/teams/page.tsx
+++ b/app/analytics/football-data/teams/page.tsx
@@ -2,9 +2,13 @@
 
 import { useState } from 'react';
 import { ReviewQueue } from '@/components/analytics/panels/ReviewQueue';
+import { SquadDepth } from '@/components/analytics/panels/SquadDepth';
 import { TeamGaps } from '@/components/analytics/panels/TeamGaps';
 import { AnalyticsShell } from '@/components/analytics/shell/AnalyticsShell';
+import { FilterBar } from '@/components/reports/filters/FilterBar';
+import { SearchBox } from '@/components/reports/filters/SearchBox';
 import { ReportPanel } from '@/components/reports/primitives/ReportPanel';
+import { SectionHeader } from '@/components/reports/primitives/SectionHeader';
 import { useReport } from '@/hooks/use-report';
 import { useAuth } from '@/lib/auth';
 import { ReportsAPI } from '@/lib/reports-api';
@@ -17,20 +21,48 @@ export default function TeamsAnalyticsPage() {
   const { isAuthenticated, user } = useAuth();
   const enabled = isAuthenticated && !!(user?.is_staff || user?.is_superuser);
   const [limit, setLimit] = useState(PAGE);
+  const [search, setSearch] = useState('');
 
   const state = useReport(
-    () => ReportsAPI.getTeamGaps(limit),
+    () => ReportsAPI.getTeamGaps(limit, search || undefined),
     {},
     enabled,
     'The team gaps endpoint',
-    String(limit),
+    // Both are part of the fetch identity: without them, typing or asking for
+    // more would not refetch.
+    `${limit}:${search}`,
   );
 
   return (
     <AnalyticsShell
       title="Teams"
-      description="Teams nobody plays for, and anything still waiting on review."
+      description="Which teams the catalogue leans on, which it forgot, and what is waiting on review."
     >
+      <FilterBar>
+        <SearchBox
+          value={search}
+          onChange={setSearch}
+          placeholder="Filter teams by name"
+          className="w-full sm:w-72"
+        />
+      </FilterBar>
+
+      <ReportPanel state={state} skeletonClassName="h-96 w-full">
+        {data => (
+          <SquadDepth
+            data={data}
+            search={search}
+            expanded={limit > PAGE}
+            onExpand={() => setLimit(EXPANDED)}
+          />
+        )}
+      </ReportPanel>
+
+      <SectionHeader
+        title="The other end of the table"
+        description="Teams nothing points at. Not narrowed by the search above — a worklist filtered by an unrelated box would report a smaller job than there is."
+      />
+
       <ReportPanel state={state} skeletonClassName="h-80 w-full">
         {data => (
           <div className="space-y-4">

--- a/app/analytics/questions/page.tsx
+++ b/app/analytics/questions/page.tsx
@@ -1,104 +1,13 @@
-'use client';
-
-import type { RangeState } from '@/lib/report-range';
-import { useMemo } from 'react';
-import { CategoryQuality } from '@/components/analytics/panels/CategoryQuality';
-import { GlobalQuizUsage } from '@/components/analytics/panels/GlobalQuizUsage';
-import { QuestionBank } from '@/components/analytics/panels/QuestionBank';
-import { QuestionQuality } from '@/components/analytics/panels/QuestionQuality';
-import { AnalyticsShell } from '@/components/analytics/shell/AnalyticsShell';
-import { FilterBar } from '@/components/reports/filters/FilterBar';
-import { RangePicker } from '@/components/reports/filters/RangePicker';
-import { ReportPanel } from '@/components/reports/primitives/ReportPanel';
-import { SectionHeader } from '@/components/reports/primitives/SectionHeader';
-import { useReport } from '@/hooks/use-report';
-import { useReportFilters } from '@/hooks/use-report-filters';
-import { useAuth } from '@/lib/auth';
-import { rangeToParams } from '@/lib/report-range';
-import { ReportsAPI } from '@/lib/reports-api';
+import { permanentRedirect } from 'next/navigation';
 
 /**
- * Question quality — a worklist, not a dashboard.
+ * Quiz content moved under Football Data.
  *
- * Someone opens this to find the handful of questions worth an afternoon, so
- * the suspect ones lead and the bank-level view sits underneath. The reverse
- * order would make them scroll past four rows of aggregate to reach the only
- * part they can act on.
+ * The redirect stays because this URL is bookmarked and linked from outside the
+ * app; a moved page that 404s teaches people the report is gone rather than
+ * that it is somewhere better. Permanent, so it is cached and the old address
+ * quietly stops being used.
  */
-export default function QuestionsAnalyticsPage() {
-  const { isAuthenticated, user } = useAuth();
-  const enabled = isAuthenticated && !!(user?.is_staff || user?.is_superuser);
-
-  // 90 days: a question needs 30 answers before its distribution says anything,
-  // and a 30-day window leaves most of a 7,000-question bank under that line.
-  const { filters, update } = useReportFilters({
-    range: { window: 90 },
-    includeBots: false,
-    game: null,
-    metric: 'games_started',
-  });
-  const { range, includeBots } = filters;
-  const setRange = (next: RangeState) => update({ range: next });
-  const setIncludeBots = (next: boolean) => update({ includeBots: next });
-  const params = useMemo(
-    () => ({ ...rangeToParams(range), include_bots: includeBots }),
-    [range, includeBots],
-  );
-
-  const state = useReport(
-    ReportsAPI.getQuestionsAnalytics,
-    params,
-    enabled,
-    'The questions analytics endpoint',
-  );
-
-  return (
-    <AnalyticsShell
-      title="Quiz content"
-      description="Which questions are broken, which subjects are weakest, and which quizzes people played."
-    >
-      <FilterBar>
-        <RangePicker
-          value={range}
-          onChange={setRange}
-          includeBots={includeBots}
-          onIncludeBotsChange={setIncludeBots}
-        />
-      </FilterBar>
-
-      <ReportPanel state={state} skeletonClassName="h-96 w-full">
-        {data => <QuestionQuality data={data} />}
-      </ReportPanel>
-
-      {/* Underneath, because it answers the question the list raises rather than
-          the one someone arrives with: is this a few bad questions, or is the
-          whole bank mis-graded? */}
-      <SectionHeader
-        title="The bank as a whole"
-        description="Whether the grading separates anything, and whether there is material left."
-      />
-
-      <ReportPanel state={state} skeletonClassName="h-64 w-full">
-        {data => <QuestionBank data={data} />}
-      </ReportPanel>
-
-      {/* The Quiz dashboard's content half, folded in here rather than given its
-          own destination (#1475). Its other half was top players by quizzes
-          played, which is Reports and better there. Two panels about this same
-          bank do not earn a nav entry — the argument R4 used to cut the
-          reporting nav from ten destinations to six. */}
-      <SectionHeader
-        title="Categories and what ran"
-        description="Where the bank is weakest by subject, and which scheduled quizzes people actually played."
-      />
-
-      <ReportPanel state={state} skeletonClassName="h-80 w-full">
-        {data => <CategoryQuality data={data} />}
-      </ReportPanel>
-
-      <ReportPanel state={state} skeletonClassName="h-64 w-full">
-        {data => <GlobalQuizUsage data={data} />}
-      </ReportPanel>
-    </AnalyticsShell>
-  );
+export default function QuestionsAnalyticsRedirect() {
+  permanentRedirect('/analytics/football-data/questions');
 }

--- a/components/analytics/__tests__/CategoryMatrix.test.tsx
+++ b/components/analytics/__tests__/CategoryMatrix.test.tsx
@@ -1,0 +1,89 @@
+import type { QuestionBankResponse } from '@/types/reports';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { CategoryMatrix } from '@/components/analytics/panels/CategoryMatrix';
+
+function data(over: Partial<QuestionBankResponse> = {}): QuestionBankResponse {
+  return {
+    difficulty_order: ['EASY', 'NORMAL', 'HARD', 'EXTREME'],
+    search: null,
+    category_matrix: {
+      items: [
+        { category: 'England', slug: 'england', total: 956, by_difficulty: [277, 290, 276, 113] },
+        { category: 'Italy', slug: 'italy', total: 928, by_difficulty: [282, 295, 249, 102] },
+      ],
+      total: 2017,
+      limit: 10,
+    },
+    ...over,
+  } as unknown as QuestionBankResponse;
+}
+
+describe('categoryMatrix', () => {
+  it('says the rows do not sum to the bank, rather than leaving it to be found', () => {
+    // The one figure on the page that deliberately double-counts: most
+    // questions carry more than one category.
+    render(<CategoryMatrix data={data()} />);
+
+    expect(screen.getByText(/sum to more than the bank holds/)).toBeInTheDocument();
+  });
+
+  it('lays the difficulties out as columns in order', () => {
+    render(<CategoryMatrix data={data()} />);
+
+    const headers = screen.getAllByRole('columnheader').map(h => h.textContent);
+
+    expect(headers).toEqual(['Category', 'Easy', 'Normal', 'Hard', 'Extreme', 'Total']);
+  });
+
+  it('shows each cell and the row total', () => {
+    render(<CategoryMatrix data={data()} />);
+
+    expect(screen.getByText('277')).toBeInTheDocument();
+    expect(screen.getByText('113')).toBeInTheDocument();
+    expect(screen.getByText('956')).toBeInTheDocument();
+  });
+
+  it('reports the real category count, not the rows rendered', () => {
+    render(<CategoryMatrix data={data()} />);
+
+    expect(screen.getByText('Showing 2 of 2,017')).toBeInTheDocument();
+  });
+
+  it('says which search found nothing, rather than just "no data"', () => {
+    render(
+      <CategoryMatrix
+        data={data({
+          search: 'zzz',
+          category_matrix: { items: [], total: 0, limit: 10 },
+        })}
+      />,
+    );
+
+    expect(screen.getByText('No category matches "zzz".')).toBeInTheDocument();
+  });
+
+  it('leaves an empty cell unshaded so a gap is visible', () => {
+    // A zero tinted the lightest shade of "some" is a gap you cannot see, and
+    // the gaps are the reason to read this table.
+    const { container } = render(
+      <CategoryMatrix
+        data={data({
+          category_matrix: {
+            items: [{ category: 'Thin', slug: 'thin', total: 5, by_difficulty: [5, 0, 0, 0] }],
+            total: 1,
+            limit: 10,
+          },
+        })}
+      />,
+    );
+
+    const zeroCells = [...container.querySelectorAll('span')].filter(el => el.textContent === '0');
+
+    expect(zeroCells.length).toBe(3);
+
+    for (const cell of zeroCells) {
+      expect(cell).not.toHaveAttribute('style');
+    }
+  });
+});

--- a/components/analytics/charts/CareerSplit.tsx
+++ b/components/analytics/charts/CareerSplit.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useTheme } from 'next-themes';
+import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { ChartTooltip } from '@/components/reports/charts/ChartTooltip';
+import { ChartLegend } from '@/components/reports/primitives/ChartLegend';
+import { chartTheme } from '@/lib/chart-theme';
+
+/**
+ * Retired against still playing, per difficulty tier.
+ *
+ * Stacked, unlike the growth chart: here the two bands ARE a whole — every
+ * approved footballer is one or the other — so the bar height is the tier size
+ * and the split within it is the answer. That is the composition question a
+ * stack is actually for.
+ */
+export function CareerSplit({ tiers }: {
+  tiers: { difficulty: string; retired: number; active: number }[];
+}) {
+  const { resolvedTheme } = useTheme();
+  const theme = chartTheme(resolvedTheme === 'dark');
+
+  const rows = tiers.map(tier => ({
+    label: `${tier.difficulty[0]}${tier.difficulty.slice(1).toLowerCase()}`,
+    active: tier.active,
+    retired: tier.retired,
+  }));
+
+  return (
+    <div className="flex h-64 flex-col gap-3">
+      <ResponsiveContainer width="100%" height="100%" className="min-h-0 flex-1">
+        <BarChart data={rows} margin={{ top: 8, right: 8, bottom: 8, left: -12 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke={theme.grid.stroke} />
+          <XAxis dataKey="label" tick={theme.tick} />
+          <YAxis tick={theme.tick} allowDecimals={false} width={48} />
+          <Tooltip content={<ChartTooltip />} cursor={theme.tooltip.cursor} />
+          <Bar dataKey="active" name="Still playing" stackId="career" fill={theme.series[0]} radius={[0, 0, 4, 4]} />
+          <Bar dataKey="retired" name="Retired" stackId="career" fill={theme.series[1]} radius={[4, 4, 0, 0]} />
+        </BarChart>
+      </ResponsiveContainer>
+      <ChartLegend
+        series={[
+          { label: 'Still playing', colour: theme.series[0] },
+          { label: 'Retired', colour: theme.series[1] },
+        ]}
+      />
+    </div>
+  );
+}

--- a/components/analytics/panels/CategoryMatrix.tsx
+++ b/components/analytics/panels/CategoryMatrix.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import type { QuestionBankResponse } from '@/types/reports';
+import { CappedList } from '@/components/reports/primitives/CappedList';
+import { ReportTable } from '@/components/reports/primitives/ReportTable';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+/**
+ * Questions per category, split by difficulty.
+ *
+ * A matrix rather than four stacked lists: the question is "is this category
+ * thin at the top end", and that is a comparison ACROSS a row. Four separate
+ * charts would put the four numbers you need to compare in four places.
+ *
+ * Cells are shaded by their share of the row, so a row reads as a shape before
+ * it reads as numbers — a category with 400 HARD and 12 EASY looks different
+ * from one that is flat, without anyone doing arithmetic. Shading is per row,
+ * not global: England has ten times the questions of a small category, and a
+ * global scale would render every small category as one flat colour.
+ */
+export function CategoryMatrix({ data, onExpand, expanded }: {
+  data: QuestionBankResponse;
+  onExpand?: () => void;
+  expanded?: boolean;
+}) {
+  const { category_matrix: matrix, difficulty_order: order } = data;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Questions by category and difficulty</CardTitle>
+        <CardDescription>
+          {/* Said here rather than discovered later: this is the one figure on
+              the page that does not add up, and for a good reason. */}
+          A question can carry several categories, so these rows deliberately sum to more
+          than the bank holds. Each cell is "questions carrying this category", never a
+          share of the total.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <CappedList
+          total={matrix.total}
+          shown={matrix.items.length}
+          onExpand={onExpand}
+          expanded={expanded}
+          emptyLabel={data.search ? `No category matches "${data.search}".` : 'No categories carry an approved question.'}
+        >
+          {/* Its own scroller: the matrix is wider than a phone and the page
+              body must never scroll sideways. */}
+          <div className="overflow-x-auto">
+            <ReportTable>
+              <thead>
+                <tr className="border-b">
+                  <th className="py-2 pr-4 text-left text-xs font-medium text-muted-foreground">Category</th>
+                  {order.map(difficulty => (
+                    <th key={difficulty} className="py-2 pr-4 text-right text-xs font-medium text-muted-foreground">
+                      {difficulty[0]}
+                      {difficulty.slice(1).toLowerCase()}
+                    </th>
+                  ))}
+                  <th className="py-2 text-right text-xs font-medium text-muted-foreground">Total</th>
+                </tr>
+              </thead>
+              <tbody>
+                {matrix.items.map(row => (
+                  <tr key={row.slug} className="border-b last:border-0">
+                    <td className="py-1.5 pr-4 text-sm text-foreground">{row.category}</td>
+                    {row.by_difficulty.map((count, index) => (
+                      <Cell
+                        key={order[index]}
+                        count={count}
+                        share={row.total ? count / row.total : 0}
+                      />
+                    ))}
+                    <td className="py-1.5 text-right text-sm font-medium tabular-nums text-foreground">
+                      {row.total.toLocaleString()}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </ReportTable>
+          </div>
+        </CappedList>
+      </CardContent>
+    </Card>
+  );
+}
+
+function Cell({ count, share }: { count: number; share: number }) {
+  return (
+    <td className="py-1.5 pr-4 text-right">
+      <span
+        className={cn(
+          'inline-block min-w-[2.5rem] rounded px-1.5 py-0.5 text-sm tabular-nums',
+          // Zero gets no shading at all: an empty cell is the thing you are
+          // looking for, and tinting it the lightest shade of "some" hides it.
+          count === 0 ? 'text-muted-foreground/60' : 'text-foreground',
+        )}
+        style={count === 0 ? undefined : { backgroundColor: `color-mix(in oklab, var(--color-primary) ${Math.round(share * 55)}%, transparent)` }}
+      >
+        {count.toLocaleString()}
+      </span>
+    </td>
+  );
+}

--- a/components/analytics/panels/FootballerBreakdown.tsx
+++ b/components/analytics/panels/FootballerBreakdown.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { CoverageResponse } from '@/types/reports';
+import { CareerSplit } from '@/components/analytics/charts/CareerSplit';
 import { CappedList } from '@/components/reports/primitives/CappedList';
 import { ReportTable } from '@/components/reports/primitives/ReportTable';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -83,6 +84,9 @@ export function FootballerBreakdown({ data, onExpand, expanded }: {
               <p className="text-xs text-muted-foreground">
                 {`${retiredPct}% of the approved catalogue has retired.`}
               </p>
+            )}
+            {careerState.by_difficulty && careerState.by_difficulty.length > 0 && (
+              <CareerSplit tiers={careerState.by_difficulty} />
             )}
           </CardContent>
         </Card>

--- a/components/analytics/panels/QuestionCatalogue.tsx
+++ b/components/analytics/panels/QuestionCatalogue.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import type { QuestionBankResponse } from '@/types/reports';
+import { useTheme } from 'next-themes';
+import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { ChartTooltip } from '@/components/reports/charts/ChartTooltip';
+import { Distribution } from '@/components/reports/primitives/Distribution';
+import { EmptyState } from '@/components/reports/primitives/EmptyState';
+import { StatTile } from '@/components/reports/primitives/StatTile';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { chartTheme } from '@/lib/chart-theme';
+
+/**
+ * How big the question bank is, and what arrived in the window.
+ *
+ * The same shape as the footballer overview on purpose: added / approved /
+ * categories over a daily series. Two surfaces answering "is anyone still
+ * filling this in" should not need to be read two different ways.
+ */
+export function QuestionCatalogue({ data }: { data: QuestionBankResponse }) {
+  const { resolvedTheme } = useTheme();
+  const theme = chartTheme(resolvedTheme === 'dark');
+  const totals = data.question_totals;
+  const bank = data.question_difficulty.reduce((sum, tier) => sum + tier.questions, 0);
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-3">
+        <StatTile
+          label="Questions added"
+          value={totals.added.toLocaleString()}
+          delta={
+            totals.added_today > 0
+              ? (
+                  <p className="text-xs font-medium text-emerald-600 dark:text-emerald-500">
+                    {`${totals.added_today.toLocaleString()} question${totals.added_today === 1 ? '' : 's'} added today`}
+                  </p>
+                )
+              : undefined
+          }
+          hint="Every question written in the window, approved or not."
+        />
+        <StatTile label="Approved questions" value={totals.approved.toLocaleString()} />
+        <StatTile
+          label="Categories in use"
+          value={totals.categories.toLocaleString()}
+          hint={data.search ? `Matching "${data.search}"` : 'Carrying at least one approved question'}
+        />
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>How hard the bank is</CardTitle>
+          <CardDescription>
+            Across every approved question. Unlike the matrix below, each question is
+            counted once here — difficulty is a single field, categories are not.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Distribution
+            bands={data.question_difficulty.map(tier => ({
+              label: `${tier.difficulty[0]}${tier.difficulty.slice(1).toLowerCase()}`,
+              count: tier.questions,
+              pct: bank ? Math.round((tier.questions / bank) * 1000) / 10 : 0,
+            }))}
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Questions added, by day</CardTitle>
+          <CardDescription>
+            Whether the bank is still growing, or has been the same size since April.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="h-64 sm:h-72">
+          {data.question_series.length === 0
+            ? <EmptyState hint="Try a wider date range.">No questions were added in this window.</EmptyState>
+            : (
+                <ResponsiveContainer width="100%" height="100%">
+                  <AreaChart data={data.question_series} margin={{ top: 8, right: 8, bottom: 8, left: -12 }}>
+                    <CartesianGrid strokeDasharray="3 3" stroke={theme.grid.stroke} />
+                    <XAxis dataKey="date" tick={theme.tick} interval="preserveStartEnd" minTickGap={24} />
+                    <YAxis tick={theme.tick} allowDecimals={false} width={44} />
+                    <Tooltip content={<ChartTooltip />} cursor={theme.tooltip.cursor} />
+                    {/* One series, so no legend — the card title names it. */}
+                    <Area
+                      type="monotone"
+                      dataKey="questions"
+                      name="Questions"
+                      stroke={theme.series[0]}
+                      fill={theme.series[0]}
+                      fillOpacity={0.25}
+                    />
+                  </AreaChart>
+                </ResponsiveContainer>
+              )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/analytics/panels/SquadDepth.tsx
+++ b/components/analytics/panels/SquadDepth.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import type { TeamGapsResponse } from '@/types/reports';
+import { CappedList } from '@/components/reports/primitives/CappedList';
+import { ReportTable } from '@/components/reports/primitives/ReportTable';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Progress } from '@/components/ui/progress';
+
+/**
+ * Teams with the deepest squads.
+ *
+ * The other end of the same table as the empty-team list below it, and the pair
+ * is the point: one says what the catalogue leans on, the other what it forgot.
+ *
+ * The bar is scaled against the largest team on screen rather than an absolute
+ * ceiling, because the question is relative — which of these is deep — and an
+ * absolute scale would flatten every row once one team ran away with it.
+ */
+export function SquadDepth({ data, onExpand, expanded, search }: {
+  data: TeamGapsResponse;
+  onExpand?: () => void;
+  expanded?: boolean;
+  search?: string;
+}) {
+  const ranked = data.teams_by_players;
+
+  // The BE may not carry this yet — the repositories deploy independently.
+  if (!ranked) {
+    return null;
+  }
+
+  const largest = Math.max(...ranked.items.map(row => row.players), 1);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Teams with the most players</CardTitle>
+        <CardDescription>
+          Squad size as the catalogue holds it — not a real squad, but everyone ever
+          recorded at the club.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <CappedList
+          total={ranked.total}
+          shown={ranked.items.length}
+          onExpand={onExpand}
+          expanded={expanded}
+          emptyLabel={search ? `No team matches "${search}".` : 'No team has a squad yet.'}
+        >
+          <ReportTable>
+            <thead>
+              <tr className="border-b">
+                <th className="py-2 pr-4 text-left text-xs font-medium text-muted-foreground">Team</th>
+                <th className="py-2 pr-4 text-left text-xs font-medium text-muted-foreground">Nation</th>
+                <th className="py-2 pr-4 text-right text-xs font-medium text-muted-foreground">Players</th>
+                <th className="w-1/3 py-2 text-left text-xs font-medium text-muted-foreground">
+                  <span className="sr-only">Relative squad size</span>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {ranked.items.map(row => (
+                <tr key={`${row.name}-${row.nation ?? ''}`} className="border-b last:border-0">
+                  <td className="py-1.5 pr-4 text-sm text-foreground">{row.name}</td>
+                  <td className="py-1.5 pr-4 text-xs text-muted-foreground">{row.nation ?? 'No nation'}</td>
+                  <td className="py-1.5 pr-4 text-right text-sm font-medium tabular-nums text-foreground">
+                    {row.players.toLocaleString()}
+                  </td>
+                  <td className="py-1.5">
+                    <Progress
+                      value={(row.players / largest) * 100}
+                      aria-label={`${row.name}: ${row.players} players`}
+                    />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </ReportTable>
+        </CappedList>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/analytics/shell/AnalyticsNav.tsx
+++ b/components/analytics/shell/AnalyticsNav.tsx
@@ -22,7 +22,6 @@ export const ANALYTICS_NAV_GROUPS: NavGroup[] = [
     heading: 'Per game',
     items: [
       { href: '/analytics/career-path', label: 'Career Path', icon: Route },
-      { href: '/analytics/questions', label: 'Quiz content', icon: HelpCircle },
       { href: '/analytics/lineups', label: 'Lineups', icon: Users },
     ],
   },
@@ -39,6 +38,7 @@ export const ANALYTICS_NAV_GROUPS: NavGroup[] = [
       { href: '/analytics/football-data/footballers', label: 'Footballers', icon: User },
       { href: '/analytics/football-data/nations', label: 'Nations', icon: Flag },
       { href: '/analytics/football-data/teams', label: 'Teams', icon: Shield },
+      { href: '/analytics/football-data/questions', label: 'Questions', icon: HelpCircle },
     ],
   },
 ];
@@ -57,5 +57,5 @@ export const ANALYTICS_NAV_GROUPS: NavGroup[] = [
 export const ANALYTICS_QUICK_LINKS: NavItem[] = [
   { href: '/analytics/football-data', label: 'Football data', icon: Database },
   { href: '/analytics/career-path', label: 'Career Path', icon: Route },
-  { href: '/analytics/questions', label: 'Quiz content', icon: HelpCircle },
+  { href: '/analytics/football-data/questions', label: 'Questions', icon: HelpCircle },
 ];

--- a/components/reports/filters/SearchBox.tsx
+++ b/components/reports/filters/SearchBox.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { Search, X } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+
+/**
+ * A debounced text filter that narrows a server-side list.
+ *
+ * Not an autocomplete dropdown, deliberately. There are 2,017 categories, so
+ * the list cannot be held client-side, and a dropdown over a server round trip
+ * either lags the keystrokes or fires a request per character. Typing filters
+ * the table itself, which is the same job with the results already on screen.
+ *
+ * Debounced because every change is a query: without it, "england" is seven
+ * requests and the answers can arrive out of order.
+ */
+export function SearchBox({ value, onChange, placeholder, className, delay = 300 }: {
+  value: string;
+  onChange: (next: string) => void;
+  placeholder: string;
+  className?: string;
+  delay?: number;
+}) {
+  const [draft, setDraft] = useState(value);
+
+  // Follow the committed value when it changes from outside (a cleared filter,
+  // a restored URL) without fighting the user mid-keystroke.
+  useEffect(() => setDraft(value), [value]);
+
+  useEffect(() => {
+    if (draft === value) {
+      return;
+    }
+    const timer = setTimeout(() => onChange(draft), delay);
+    return () => clearTimeout(timer);
+    // `onChange` is rebuilt each render by callers; keying on it would reset
+    // the timer every render and the query would never fire.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [draft, value, delay]);
+
+  return (
+    <div className={cn('relative', className)}>
+      <Search className="absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" aria-hidden />
+      <Input
+        value={draft}
+        onChange={event => setDraft(event.target.value)}
+        placeholder={placeholder}
+        className="h-8 px-8 text-sm"
+      />
+      {draft && (
+        <button
+          type="button"
+          onClick={() => setDraft('')}
+          aria-label="Clear search"
+          className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <X className="size-3.5" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/components/reports/filters/SearchBox.tsx
+++ b/components/reports/filters/SearchBox.tsx
@@ -24,10 +24,20 @@ export function SearchBox({ value, onChange, placeholder, className, delay = 300
   delay?: number;
 }) {
   const [draft, setDraft] = useState(value);
+  const [lastCommitted, setLastCommitted] = useState(value);
 
-  // Follow the committed value when it changes from outside (a cleared filter,
+  // Follow the committed value when it changes from OUTSIDE (a cleared filter,
   // a restored URL) without fighting the user mid-keystroke.
-  useEffect(() => setDraft(value), [value]);
+  //
+  // Adjusted during render rather than in an effect. Syncing props into state
+  // with `useEffect` renders once with the stale value and then again with the
+  // new one, so the box visibly shows the old text for a frame — and it is what
+  // `react-hooks-extra/no-direct-set-state-in-use-effect` is pointing at. React
+  // re-runs this component immediately, before touching the DOM.
+  if (value !== lastCommitted) {
+    setLastCommitted(value);
+    setDraft(value);
+  }
 
   useEffect(() => {
     if (draft === value) {

--- a/components/reports/primitives/__tests__/SearchBox.test.tsx
+++ b/components/reports/primitives/__tests__/SearchBox.test.tsx
@@ -47,6 +47,23 @@ describe('searchBox', () => {
     expect(onChange).toHaveBeenCalledWith('');
   });
 
+  it('follows a value changed from outside, without a stale frame', () => {
+    // A cleared filter or a restored URL changes `value` without anyone typing.
+    // The box has to follow it, and adjusting during render means it never
+    // paints the old text first.
+    const onChange = vi.fn();
+    const { rerender } = render(<SearchBox value="" onChange={onChange} placeholder="Filter" />);
+
+    rerender(<SearchBox value="italy" onChange={onChange} placeholder="Filter" />);
+
+    expect(screen.getByPlaceholderText('Filter')).toHaveValue('italy');
+
+    // Following an outside change is not a new query.
+    act(() => void vi.advanceTimersByTime(600));
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
   it('does not re-fire when the committed value arrives back', () => {
     // The parent echoes the value back as a prop. Treating that as a change
     // would query again for the same string, forever.

--- a/components/reports/primitives/__tests__/SearchBox.test.tsx
+++ b/components/reports/primitives/__tests__/SearchBox.test.tsx
@@ -1,0 +1,63 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SearchBox } from '@/components/reports/filters/SearchBox';
+
+describe('searchBox', () => {
+  beforeEach(() => vi.useFakeTimers());
+
+  afterEach(() => vi.useRealTimers());
+
+  it('waits for a pause before querying', () => {
+    // Every change is a server round trip. Without the debounce, "england" is
+    // seven requests whose answers can arrive out of order.
+    const onChange = vi.fn();
+    render(<SearchBox value="" onChange={onChange} placeholder="Filter" />);
+
+    fireEvent.change(screen.getByPlaceholderText('Filter'), { target: { value: 'eng' } });
+
+    expect(onChange).not.toHaveBeenCalled();
+
+    act(() => void vi.advanceTimersByTime(300));
+
+    expect(onChange).toHaveBeenCalledWith('eng');
+  });
+
+  it('sends one query for a burst of typing, not one per key', () => {
+    const onChange = vi.fn();
+    render(<SearchBox value="" onChange={onChange} placeholder="Filter" />);
+    const input = screen.getByPlaceholderText('Filter');
+
+    for (const text of ['e', 'en', 'eng', 'engl']) {
+      fireEvent.change(input, { target: { value: text } });
+      act(() => void vi.advanceTimersByTime(100));
+    }
+    act(() => void vi.advanceTimersByTime(300));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('engl');
+  });
+
+  it('clears back to everything', () => {
+    const onChange = vi.fn();
+    render(<SearchBox value="eng" onChange={onChange} placeholder="Filter" />);
+
+    fireEvent.click(screen.getByLabelText('Clear search'));
+    act(() => void vi.advanceTimersByTime(300));
+
+    expect(onChange).toHaveBeenCalledWith('');
+  });
+
+  it('does not re-fire when the committed value arrives back', () => {
+    // The parent echoes the value back as a prop. Treating that as a change
+    // would query again for the same string, forever.
+    const onChange = vi.fn();
+    const { rerender } = render(<SearchBox value="" onChange={onChange} placeholder="Filter" />);
+
+    fireEvent.change(screen.getByPlaceholderText('Filter'), { target: { value: 'eng' } });
+    act(() => void vi.advanceTimersByTime(300));
+    rerender(<SearchBox value="eng" onChange={onChange} placeholder="Filter" />);
+    act(() => void vi.advanceTimersByTime(600));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/lib/global-nav.ts
+++ b/lib/global-nav.ts
@@ -48,8 +48,8 @@ export const ANALYTICS_CHILDREN: NavigationPage[] = [
   { label: 'Footballers', href: '/analytics/football-data/footballers', icon: User, description: 'How the catalogue is shaped, and who built it' },
   { label: 'Nations', href: '/analytics/football-data/nations', icon: Flag, description: 'Nations nothing points at' },
   { label: 'Teams', href: '/analytics/football-data/teams', icon: Shield, description: 'Teams nobody plays for' },
+  { label: 'Questions', href: '/analytics/football-data/questions', icon: HelpCircle, description: 'How big the question bank is, and which questions are broken' },
   { label: 'Career Path', href: '/analytics/career-path', icon: Route, description: 'Which footballers make everyone take a hint' },
-  { label: 'Quiz content', href: '/analytics/questions', icon: HelpCircle, description: 'Which questions nobody gets right' },
   { label: 'Lineups', href: '/analytics/lineups', icon: Users2, description: 'Which slots cost the most guesses' },
 ];
 

--- a/lib/reports-api.ts
+++ b/lib/reports-api.ts
@@ -18,6 +18,7 @@ import type {
   PatternsResponse,
   PlayerDetailResponse,
   ProgressResponse,
+  QuestionBankResponse,
   QuestionsAnalyticsResponse,
   ReportParams,
   RetentionResponse,
@@ -160,8 +161,13 @@ export class ReportsAPI {
   }
 
   /** GET /core/analytics/football-data/teams/ — empty teams and the review queue. */
-  static async getTeamGaps(limit?: number): Promise<TeamGapsResponse> {
-    return apiFetcher<TeamGapsResponse>(`core/analytics/football-data/teams/${buildQuery({ limit })}`);
+  static async getTeamGaps(limit?: number, search?: string): Promise<TeamGapsResponse> {
+    return apiFetcher<TeamGapsResponse>(`core/analytics/football-data/teams/${buildQuery({ limit, search })}`);
+  }
+
+  /** GET /core/analytics/football-data/questions/ — the question bank as data. */
+  static async getQuestionBank(params?: ReportParams): Promise<QuestionBankResponse> {
+    return apiFetcher<QuestionBankResponse>(`core/analytics/football-data/questions/${buildQuery(params)}`);
   }
 
   /** GET /core/reporting/content/ — content runway and pool depth. A snapshot. */

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -1149,7 +1149,16 @@ export type CoverageResponse = {
    *  Nation carry no author — so it is not catalogue-wide authorship.
    */
   contributors?: CappedRows<{ username: string; footballers: number }>;
-  career_state?: { retired: number; active: number };
+  career_state?: {
+    retired: number;
+    active: number;
+    /**
+     * The same split per tier. The totals are kept alongside rather than
+     *  replaced — making a reader add four numbers to get the headline is
+     *  worse than printing both.
+     */
+    by_difficulty?: { difficulty: string; retired: number; active: number }[];
+  };
   review_queue?: ReviewQueue;
 } & ResolvedRange;
 
@@ -1179,7 +1188,38 @@ export type NationGapsResponse = {
 export type TeamGapsResponse = {
   teams_without_footballers: CappedRows<{ name: string; nation: string | null }>;
   review_queue: ReviewQueue;
+  /** The other end of the same table: the deepest squads. */
+  teams_by_players?: CappedRows<{ name: string; nation: string | null; players: number }>;
+  /** Echoed so an empty ranking reads as "no matches" rather than "no data". */
+  search?: string | null;
 };
+
+export type QuestionBankResponse = {
+  question_totals: {
+    /** Created in the window, approved or not — work done, not work approved. */
+    added: number;
+    added_today: number;
+    approved: number;
+    /** Categories carrying at least one approved question, after any search. */
+    categories: number;
+  };
+  question_series: { date: string; questions: number }[];
+  question_difficulty: { difficulty: string; questions: number }[];
+  /**
+   * Category x difficulty. Rows do NOT sum to `question_totals.approved`:
+   * `Question.categories` is many-to-many and most questions carry more than
+   * one, so a question tagged England and Italy appears in both rows.
+   */
+  category_matrix: CappedRows<{
+    category: string;
+    slug: string;
+    total: number;
+    /** Counts in `difficulty_order`, positionally. */
+    by_difficulty: number[];
+  }>;
+  difficulty_order: string[];
+  search: string | null;
+} & ResolvedRange;
 
 export type CatalogueTotals = {
   /**


### PR DESCRIPTION

FOUR THINGS

Questions moves to /analytics/football-data/questions, with a permanent
redirect from the old URL. It belongs here because it is the same question this
section asks of every other table — how much material exists, and where is it
thin — asked of the question bank. Whether the questions are any GOOD stays on
the same page underneath, because "what do we have" and "which are broken" are
different afternoons and the person who came for one rarely wants the other
first.

The category x difficulty matrix, with the caveat stated on the card rather
than left to be discovered: a question can carry several categories, and 5,564
of 7,219 do, so the rows deliberately sum to more than the bank holds. Cells
are shaded by their share of the ROW, not globally — England has ten times the
questions of a small category, and a global scale would render every small
category as one flat colour. Zero is left unshaded, because a gap tinted the
lightest shade of "some" is a gap you cannot see, and the gaps are the reason
to read the table.

Question totals, added-today and a daily series, in the same shape as the
footballer overview. Two surfaces answering "is anyone still filling this in"
should not need to be read two different ways.

Squad depth on the Teams page — the other end of the same table as the
empty-team list, with the pair as the point: one says what the catalogue leans
on, the other what it forgot. The search narrows the ranking ONLY; filtering
the gap list by the same box would silently report a smaller job than there is.

Career state gains a stacked split per difficulty and keeps its totals. Stacked
here, unlike the growth chart, because these two bands genuinely are a whole —
every approved footballer is one or the other — so the bar height is the tier
size and the split within it is the answer.

SEARCH, NOT AUTOCOMPLETE

`SearchBox` is a debounced filter over the table, not a dropdown. There are
2,017 categories, so the list cannot be held client-side, and a dropdown over a
server round trip either lags the keystrokes or fires a request per character.
Typing filters the results already on screen, which is the same job.

Debounced because every change is a query: without it "england" is seven
requests whose answers can arrive out of order. It also ignores the parent
echoing the committed value back, which would otherwise re-query the same
string forever.

Four mutations checked: removing the debounce, re-firing on the echoed value,
shading the zero cells, and dropping the double-counting caveat each fail a test.

Refs https://github.com/FootballExtraTime/App/issues/1474

🤖 Generated with [Claude Code](https://claude.com/claude-code)