### PR TITLE
Stop drawing data with a loading bar

### DIFF
--- a/components/analytics/charts/CareerSplit.tsx
+++ b/components/analytics/charts/CareerSplit.tsx
@@ -5,6 +5,7 @@ import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxi
 import { ChartTooltip } from '@/components/reports/charts/ChartTooltip';
 import { ChartLegend } from '@/components/reports/primitives/ChartLegend';
 import { chartTheme } from '@/lib/chart-theme';
+import { CAREER_STATE } from '@/lib/data-colours';
 
 /**
  * Retired against still playing, per difficulty tier.
@@ -34,14 +35,16 @@ export function CareerSplit({ tiers }: {
           <XAxis dataKey="label" tick={theme.tick} />
           <YAxis tick={theme.tick} allowDecimals={false} width={48} />
           <Tooltip content={<ChartTooltip />} cursor={theme.tooltip.cursor} />
-          <Bar dataKey="active" name="Still playing" stackId="career" fill={theme.series[0]} radius={[0, 0, 4, 4]} />
-          <Bar dataKey="retired" name="Retired" stackId="career" fill={theme.series[1]} radius={[4, 4, 0, 0]} />
+          {/* The same hexes the bars above use — a chart and a bar describing
+              the same thing in different colours is worse than either alone. */}
+          <Bar dataKey="active" name={CAREER_STATE.active.label} stackId="career" fill={CAREER_STATE.active.hex} radius={[0, 0, 4, 4]} />
+          <Bar dataKey="retired" name={CAREER_STATE.retired.label} stackId="career" fill={CAREER_STATE.retired.hex} radius={[4, 4, 0, 0]} />
         </BarChart>
       </ResponsiveContainer>
       <ChartLegend
         series={[
-          { label: 'Still playing', colour: theme.series[0] },
-          { label: 'Retired', colour: theme.series[1] },
+          { label: CAREER_STATE.active.label, colour: CAREER_STATE.active.hex },
+          { label: CAREER_STATE.retired.label, colour: CAREER_STATE.retired.hex },
         ]}
       />
     </div>

--- a/components/analytics/panels/CategoryMatrix.tsx
+++ b/components/analytics/panels/CategoryMatrix.tsx
@@ -4,6 +4,7 @@ import type { QuestionBankResponse } from '@/types/reports';
 import { SearchBox } from '@/components/reports/filters/SearchBox';
 import { CappedList } from '@/components/reports/primitives/CappedList';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { difficultyTier as tier } from '@/lib/data-colours';
 import { cn } from '@/lib/utils';
 
 /**
@@ -23,49 +24,6 @@ import { cn } from '@/lib/utils';
  * render every small category as one flat colour — which is exactly the row you
  * most need to see the shape of.
  */
-
-/**
- * The ordinal ramp, cool to hot.
- *
- * Fixed Tailwind class strings rather than interpolated ones: Tailwind scans
- * source text for complete class names, so a computed `bg-${hue}-500` is not
- * emitted at all and the cell renders unstyled.
- */
-const TIERS: Record<string, { label: string; head: string; cell: string; dot: string }> = {
-  EASY: {
-    label: 'Easy',
-    head: 'text-emerald-700 dark:text-emerald-400',
-    cell: 'bg-emerald-500/[var(--tint)] text-emerald-950 dark:text-emerald-50',
-    dot: 'bg-emerald-500',
-  },
-  NORMAL: {
-    label: 'Normal',
-    head: 'text-sky-700 dark:text-sky-400',
-    cell: 'bg-sky-500/[var(--tint)] text-sky-950 dark:text-sky-50',
-    dot: 'bg-sky-500',
-  },
-  HARD: {
-    label: 'Hard',
-    head: 'text-amber-700 dark:text-amber-400',
-    cell: 'bg-amber-500/[var(--tint)] text-amber-950 dark:text-amber-50',
-    dot: 'bg-amber-500',
-  },
-  EXTREME: {
-    label: 'Extreme',
-    head: 'text-rose-700 dark:text-rose-400',
-    cell: 'bg-rose-500/[var(--tint)] text-rose-950 dark:text-rose-50',
-    dot: 'bg-rose-500',
-  },
-};
-
-function tier(difficulty: string) {
-  return TIERS[difficulty] ?? {
-    label: difficulty,
-    head: 'text-muted-foreground',
-    cell: 'bg-muted text-foreground',
-    dot: 'bg-muted-foreground',
-  };
-}
 
 export function CategoryMatrix({ data, onExpand, expanded, search, onSearchChange }: {
   data: QuestionBankResponse;
@@ -180,7 +138,7 @@ function Cell({ difficulty, count, share }: { difficulty: string; count: number;
   return (
     <td className="p-1 text-center">
       <span
-        className={cn('inline-block min-w-[3.25rem] rounded-md px-2 py-1 font-medium tabular-nums', style.cell)}
+        className={cn('inline-block min-w-[3.25rem] rounded-md px-2 py-1 font-medium tabular-nums', style.chip)}
         // Floored so the faintest real value is still visibly a box rather than
         // an empty rectangle, and capped so a 100%-of-row cell stays readable.
         style={{ '--tint': `${Math.max(12, Math.min(70, Math.round(share * 90)))}%` } as React.CSSProperties}

--- a/components/analytics/panels/DifficultyCatalogue.tsx
+++ b/components/analytics/panels/DifficultyCatalogue.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import type { CoverageResponse, DifficultyTier } from '@/types/reports';
+import { DataBar } from '@/components/reports/primitives/DataBar';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Progress } from '@/components/ui/progress';
+import { difficultyTier } from '@/lib/data-colours';
 import { cn } from '@/lib/utils';
 
 /**
@@ -17,15 +18,8 @@ import { cn } from '@/lib/utils';
  * Not scoped to the date range. This is the state of the catalogue now, not what
  * changed in it, and a range filter here would answer neither question.
  */
-const TIER_LABELS: Record<string, string> = {
-  EASY: 'Easy',
-  NORMAL: 'Normal',
-  HARD: 'Hard',
-  EXTREME: 'Extreme',
-};
-
 function tierLabel(difficulty: string) {
-  return TIER_LABELS[difficulty] ?? difficulty;
+  return difficultyTier(difficulty).label || difficulty;
 }
 
 export function DifficultyCatalogue({ data }: { data: CoverageResponse }) {
@@ -61,9 +55,11 @@ export function DifficultyCatalogue({ data }: { data: CoverageResponse }) {
                     question here is which tier is biggest, and a share-of-total
                     bar answers a question nobody asked of four bars that sum
                     to one. */}
-                <Progress
-                  value={(tier.footballers / largest) * 100}
-                  aria-label={`${tierLabel(tier.difficulty)}: ${tier.footballers} footballers`}
+                <DataBar
+                  value={tier.footballers}
+                  max={largest}
+                  colour={difficultyTier(tier.difficulty).bar}
+                  label={`${tierLabel(tier.difficulty)}: ${tier.footballers} footballers`}
                 />
               </div>
             ))}
@@ -120,9 +116,11 @@ function PictureRow({ tier }: { tier: DifficultyTier }) {
               )}
         </dd>
       </div>
-      <Progress
+      <DataBar
         value={pct ?? 0}
-        aria-label={
+        max={100}
+        colour={difficultyTier(tier.difficulty).bar}
+        label={
           empty
             ? `${tierLabel(tier.difficulty)}: no footballers`
             : `${tierLabel(tier.difficulty)}: ${tier.with_picture} of ${tier.footballers} have a picture`

--- a/components/analytics/panels/FootballerBreakdown.tsx
+++ b/components/analytics/panels/FootballerBreakdown.tsx
@@ -3,9 +3,10 @@
 import type { CoverageResponse } from '@/types/reports';
 import { CareerSplit } from '@/components/analytics/charts/CareerSplit';
 import { CappedList } from '@/components/reports/primitives/CappedList';
+import { DataBar } from '@/components/reports/primitives/DataBar';
 import { ReportTable } from '@/components/reports/primitives/ReportTable';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Progress } from '@/components/ui/progress';
+import { CAREER_STATE } from '@/lib/data-colours';
 
 /**
  * Who is adding footballers, and how many of them have stopped playing.
@@ -77,8 +78,10 @@ export function FootballerBreakdown({ data, onExpand, expanded }: {
           </CardHeader>
           <CardContent className="space-y-3">
             <dl className="space-y-3">
-              <Row label="Retired" value={careerState.retired} total={total} />
-              <Row label="Still playing" value={careerState.active} total={total} />
+              {/* Playing first: the chart below stacks it at the bottom, and
+                  a legend order that disagrees with the stack is a puzzle. */}
+              <Row label={CAREER_STATE.active.label} value={careerState.active} total={total} colour={CAREER_STATE.active.bar} />
+              <Row label={CAREER_STATE.retired.label} value={careerState.retired} total={total} colour={CAREER_STATE.retired.bar} />
             </dl>
             {retiredPct !== null && (
               <p className="text-xs text-muted-foreground">
@@ -95,14 +98,14 @@ export function FootballerBreakdown({ data, onExpand, expanded }: {
   );
 }
 
-function Row({ label, value, total }: { label: string; value: number; total: number }) {
+function Row({ label, value, total, colour }: { label: string; value: number; total: number; colour: string }) {
   return (
     <div className="space-y-1">
       <div className="flex items-baseline justify-between gap-2">
         <dt className="text-sm text-muted-foreground">{label}</dt>
         <dd className="text-sm font-medium tabular-nums text-foreground">{value.toLocaleString()}</dd>
       </div>
-      <Progress value={total ? (value / total) * 100 : 0} aria-label={`${label}: ${value} of ${total}`} />
+      <DataBar value={value} max={total} colour={colour} label={`${label}: ${value} of ${total}`} />
     </div>
   );
 }

--- a/components/analytics/panels/SquadDepth.tsx
+++ b/components/analytics/panels/SquadDepth.tsx
@@ -2,9 +2,10 @@
 
 import type { TeamGapsResponse } from '@/types/reports';
 import { CappedList } from '@/components/reports/primitives/CappedList';
+import { DataBar } from '@/components/reports/primitives/DataBar';
 import { ReportTable } from '@/components/reports/primitives/ReportTable';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Progress } from '@/components/ui/progress';
+import { MAGNITUDE_BAR } from '@/lib/data-colours';
 
 /**
  * Teams with the deepest squads.
@@ -68,9 +69,11 @@ export function SquadDepth({ data, onExpand, expanded, search }: {
                     {row.players.toLocaleString()}
                   </td>
                   <td className="py-1.5">
-                    <Progress
-                      value={(row.players / largest) * 100}
-                      aria-label={`${row.name}: ${row.players} players`}
+                    <DataBar
+                      value={row.players}
+                      max={largest}
+                      colour={MAGNITUDE_BAR}
+                      label={`${row.name}: ${row.players} players`}
                     />
                   </td>
                 </tr>

--- a/components/reports/primitives/DataBar.tsx
+++ b/components/reports/primitives/DataBar.tsx
@@ -1,0 +1,57 @@
+import { cn } from '@/lib/utils';
+
+/**
+ * One value as a horizontal bar.
+ *
+ * Replaces `ui/progress` everywhere a bar carries DATA rather than completion.
+ * That component is a loading indicator and behaves like one: `h-4` of chunky
+ * track, `rounded-full` at both ends so the bar floats free of its own
+ * baseline, an opaque `bg-muted` rail that reads as "percent complete", and a
+ * hardcoded emerald gradient. Four different measurements — difficulty mix,
+ * picture coverage, career state, squad size — all arrived as the same emerald,
+ * which is a bar that encodes nothing.
+ *
+ * The differences here are the whole point:
+ *
+ * THIN. 6px, not 16. A data bar is read by length; height past a few pixels is
+ * ink spent saying nothing, and at 16px four stacked rows read as a form.
+ *
+ * SQUARE AT THE BASELINE, rounded only at the data end. Every bar starts on the
+ * same line, so lengths compare; a rounded start pulls the eye off that line
+ * and shortens short bars visually more than long ones.
+ *
+ * NO GRADIENT. A gradient makes the same value look different at different
+ * lengths, and it is the single thing that dates a chart most.
+ *
+ * A HAIRLINE TRACK, not a filled rail — present enough to show the full extent,
+ * quiet enough that the data is the dark thing on the page.
+ */
+export function DataBar({ value, max, colour, label, className }: {
+  value: number;
+  /** What a full bar means. Bars sharing a max are comparable; that is the point. */
+  max: number;
+  /** Tailwind background class from `lib/data-colours`, never an ad-hoc hue. */
+  colour: string;
+  /** Read to anyone who cannot see the bar. The number alone is not a sentence. */
+  label: string;
+  className?: string;
+}) {
+  // Clamped rather than trusted: one bad row should not render a bar through
+  // the side of the card, and a negative width silently disappears.
+  const pct = max > 0 ? Math.max(0, Math.min(100, (value / max) * 100)) : 0;
+
+  return (
+    <div
+      role="img"
+      aria-label={label}
+      className={cn('h-1.5 w-full overflow-hidden rounded-[2px] bg-foreground/[0.06]', className)}
+    >
+      <div
+        // Rounded on the data end only. `rounded-r-[3px]` with a square left
+        // edge is what anchors it to the baseline.
+        className={cn('h-full rounded-r-[3px] transition-[width] duration-300 ease-out', colour)}
+        style={{ width: `${pct}%` }}
+      />
+    </div>
+  );
+}

--- a/components/reports/primitives/__tests__/DataBar.test.tsx
+++ b/components/reports/primitives/__tests__/DataBar.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { DataBar } from '@/components/reports/primitives/DataBar';
+import { CAREER_STATE, DIFFICULTY_TIERS, difficultyTier } from '@/lib/data-colours';
+
+function fill(container: HTMLElement) {
+  return container.querySelector('[role="img"] > div') as HTMLElement;
+}
+
+describe('dataBar', () => {
+  it('encodes the value as length against the shared max', () => {
+    const { container } = render(<DataBar value={25} max={100} colour="bg-primary" label="quarter" />);
+
+    expect(fill(container)).toHaveStyle({ width: '25%' });
+  });
+
+  it('clamps a value past the max instead of overflowing the card', () => {
+    const { container } = render(<DataBar value={150} max={100} colour="bg-primary" label="over" />);
+
+    expect(fill(container)).toHaveStyle({ width: '100%' });
+  });
+
+  it('draws nothing rather than dividing by zero', () => {
+    const { container } = render(<DataBar value={5} max={0} colour="bg-primary" label="empty" />);
+
+    expect(fill(container)).toHaveStyle({ width: '0%' });
+  });
+
+  it('is announced, because a bar with no text is silent', () => {
+    render(<DataBar value={3} max={10} colour="bg-primary" label="Hard: 3 of 10 have a picture" />);
+
+    expect(screen.getByRole('img', { name: 'Hard: 3 of 10 have a picture' })).toBeInTheDocument();
+  });
+
+  it('rounds only the data end, so every bar starts on one line', () => {
+    // A rounded start pulls the eye off the baseline and shortens short bars
+    // visually more than long ones, which is the comparison the bar is for.
+    const { container } = render(<DataBar value={5} max={10} colour="bg-primary" label="half" />);
+
+    expect(fill(container).className).toContain('rounded-r-');
+    expect(fill(container).className).not.toContain('rounded-full');
+  });
+
+  it('carries no gradient', () => {
+    // The single thing that dated the old bars: a gradient makes the same value
+    // look different at different lengths.
+    const { container } = render(<DataBar value={5} max={10} colour="bg-emerald-500" label="half" />);
+
+    expect(fill(container).className).not.toContain('gradient');
+  });
+});
+
+describe('data colours', () => {
+  it('gives every difficulty its own hue', () => {
+    // The bug this replaces: all four tiers rendered in one emerald gradient,
+    // so Extreme and Easy were the same bar.
+    const bars = Object.values(DIFFICULTY_TIERS).map(t => t.bar);
+
+    expect(new Set(bars).size).toBe(bars.length);
+  });
+
+  it('runs difficulty cool to hot, in scale order', () => {
+    expect(Object.keys(DIFFICULTY_TIERS)).toEqual(['EASY', 'NORMAL', 'HARD', 'EXTREME']);
+  });
+
+  it('names an unknown tier rather than dropping it', () => {
+    expect(difficultyTier('LEGENDARY').label).toBe('LEGENDARY');
+  });
+
+  it('keeps the two career-state colours apart', () => {
+    // They sit in one stacked bar; identical hues would make the split invisible.
+    expect(CAREER_STATE.active.hex).not.toBe(CAREER_STATE.retired.hex);
+  });
+});

--- a/lib/data-colours.ts
+++ b/lib/data-colours.ts
@@ -1,0 +1,102 @@
+/**
+ * The colours data wears on this surface, in one place.
+ *
+ * These were previously invented per panel, and the panels disagreed: the
+ * category matrix gave difficulty an ordinal ramp while the two difficulty bar
+ * panels rendered every tier in the same emerald gradient — so "Hard" was one
+ * colour in a table and another below it, and "Extreme" was indistinguishable
+ * from "Easy" in both bar panels.
+ *
+ * Two vocabularies, because they answer different questions:
+ *
+ * DIFFICULTY is ORDINAL — four points on one scale — so it runs cool to hot.
+ * Not four categorical hues, which would claim they are four unrelated kinds of
+ * thing, and not a single-hue lightness ramp, which loses to the surface tint
+ * at the pale end.
+ *
+ * CAREER STATE is a two-way split of a whole, so it takes two hues that read as
+ * "here" and "gone" rather than as a scale.
+ *
+ * Both carry a Tailwind class (for bars and chips, which live in the class
+ * layer) and a hex (for recharts, which writes colours into SVG presentation
+ * attributes where `var()` is not reliable). The two must name the same colour:
+ * a bar and the chart above it describing the same thing in different colours
+ * is worse than either choice alone.
+ */
+export type DataTier = {
+  label: string;
+  /** Fill for a bar or chip. */
+  bar: string;
+  /** Tinted background for a matrix cell; `--tint` sets the opacity. */
+  chip: string;
+  /** Text colour for a column header. */
+  head: string;
+  /** Solid dot carrying the colour into a legend or header. */
+  dot: string;
+  /** The same colour for recharts. Tailwind 500-weight. */
+  hex: string;
+};
+
+/** Cool to hot. Order is the scale — do not sort these alphabetically. */
+export const DIFFICULTY_TIERS: Record<string, DataTier> = {
+  EASY: {
+    label: 'Easy',
+    bar: 'bg-emerald-500',
+    chip: 'bg-emerald-500/[var(--tint)] text-emerald-950 dark:text-emerald-50',
+    head: 'text-emerald-700 dark:text-emerald-400',
+    dot: 'bg-emerald-500',
+    hex: '#10b981',
+  },
+  NORMAL: {
+    label: 'Normal',
+    bar: 'bg-sky-500',
+    chip: 'bg-sky-500/[var(--tint)] text-sky-950 dark:text-sky-50',
+    head: 'text-sky-700 dark:text-sky-400',
+    dot: 'bg-sky-500',
+    hex: '#0ea5e9',
+  },
+  HARD: {
+    label: 'Hard',
+    bar: 'bg-amber-500',
+    chip: 'bg-amber-500/[var(--tint)] text-amber-950 dark:text-amber-50',
+    head: 'text-amber-700 dark:text-amber-400',
+    dot: 'bg-amber-500',
+    hex: '#f59e0b',
+  },
+  EXTREME: {
+    label: 'Extreme',
+    bar: 'bg-rose-500',
+    chip: 'bg-rose-500/[var(--tint)] text-rose-950 dark:text-rose-50',
+    head: 'text-rose-700 dark:text-rose-400',
+    dot: 'bg-rose-500',
+    hex: '#f43f5e',
+  },
+};
+
+/** An unknown tier still renders, in a colour that claims nothing. */
+const UNKNOWN_TIER: DataTier = {
+  label: '',
+  bar: 'bg-muted-foreground/40',
+  chip: 'bg-muted text-foreground',
+  head: 'text-muted-foreground',
+  dot: 'bg-muted-foreground',
+  hex: '#94a3b8',
+};
+
+export function difficultyTier(difficulty: string): DataTier {
+  return DIFFICULTY_TIERS[difficulty] ?? { ...UNKNOWN_TIER, label: difficulty };
+}
+
+/** Still playing against retired: two states of a whole, not a scale. */
+export const CAREER_STATE = {
+  active: { label: 'Still playing', bar: 'bg-teal-500', hex: '#14b8a6' },
+  retired: { label: 'Retired', bar: 'bg-slate-400 dark:bg-slate-500', hex: '#94a3b8' },
+} as const;
+
+/**
+ * Magnitude with no category behind it — squad size, row counts.
+ *
+ * One colour, deliberately: shading these by value would imply a threshold
+ * ("amber means concerning") that a squad size does not have.
+ */
+export const MAGNITUDE_BAR = 'bg-primary/70';


### PR DESCRIPTION

The three panels that looked stale — squad depth, both difficulty columns, and
still-playing-or-retired — were exactly the three drawing data with
`ui/progress`. The ones that looked fine were the recharts panels. That is the
whole diagnosis.

`Progress` is a loading indicator and behaves like one:

  h-4                                  16px of chunky track
  rounded-full                         both ends, so the bar floats off its
                                       own baseline
  bg-muted                             an opaque rail that reads "% complete"
  from-emerald-500 to-emerald-600      a hardcoded gradient

So difficulty mix, picture coverage, career state and squad size — four
different measurements — all arrived as the same emerald gradient. A bar that
is the same colour whatever it encodes is a bar that encodes nothing, and the
gradient is the single thing that dated them most: it makes one value look
different at different lengths.

`DataBar` replaces it wherever a bar carries data. 6px, not 16 — a data bar is
read by length, and height past a few pixels is ink spent saying nothing.
Square at the baseline and rounded only at the data end, so every bar starts on
one line and lengths compare; a rounded start shortens short bars visually more
than long ones. A hairline track rather than a filled rail. No gradient.

`lib/data-colours` gives the surface one colour vocabulary, because the panels
had been disagreeing: the category matrix gave difficulty an ordinal ramp while
the bar panels rendered every tier the same emerald, so Hard was one colour in
a table and another directly below it.

Two vocabularies, because they answer different questions. DIFFICULTY is
ordinal — four points on one scale — so it runs cool to hot (emerald, sky,
amber, rose), not four categorical hues, which would claim they are unrelated
kinds of thing. CAREER STATE is a two-way split of a whole, so it takes two
hues that read as "here" and "gone" rather than as a scale.

Each carries a Tailwind class and a hex naming the same colour, so the stacked
career chart and the bars above it finally agree — they were drawing the same
two states in different colours.

Colour is never the only signal: every bar is labelled in text and announced to
assistive tech, and every tier is named beside it.

Four mutations checked: removing the clamp, rounding both ends again, dropping
the accessible label, and returning a difficulty to the shared emerald each
fail a test.

Refs https://github.com/FootballExtraTime/App/issues/1474

🤖 Generated with [Claude Code](https://claude.com/claude-code)