### PR TITLE
Solid colours, visible bars, and the motion that was asked for

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -184,4 +184,44 @@
   .animate-shimmer {
     animation: shimmer 2s infinite;
   }
+
+  /* Data entrances. A cell or a bar arrives rather than appearing, so a table
+     that has just refetched reads as "this is new" instead of blinking. */
+  @keyframes data-rise {
+    from {
+      opacity: 0;
+      transform: translateY(4px) scale(0.96);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+    }
+  }
+
+  @keyframes data-grow {
+    from {
+      transform: scaleX(0);
+    }
+    to {
+      transform: scaleX(1);
+    }
+  }
+
+  .animate-data-rise {
+    animation: data-rise 320ms cubic-bezier(0.2, 0.8, 0.2, 1) backwards;
+  }
+
+  .animate-data-grow {
+    transform-origin: left center;
+    animation: data-grow 520ms cubic-bezier(0.2, 0.8, 0.2, 1) backwards;
+  }
+
+  /* Motion is decoration here — the number and the length carry the meaning, so
+     switching it off costs nothing. */
+  @media (prefers-reduced-motion: reduce) {
+    .animate-data-rise,
+    .animate-data-grow {
+      animation: none;
+    }
+  }
 }

--- a/components/analytics/__tests__/CategoryMatrix.test.tsx
+++ b/components/analytics/__tests__/CategoryMatrix.test.tsx
@@ -68,6 +68,26 @@ describe('categoryMatrix', () => {
     expect(headers).toEqual(['Category', 'Easy', 'Normal', 'Hard', 'Extreme', 'Total']);
   });
 
+  it('gives every cell a visible solid fill, not an opacity tint', () => {
+    const { container } = render(<CategoryMatrix data={data()} search="" onSearchChange={vi.fn()} />);
+
+    const cells = [...container.querySelectorAll('td span')].filter(el => !el.className.includes('border-dashed'));
+
+    expect(cells.length).toBeGreaterThan(0);
+
+    for (const cell of cells) {
+      // No `--tint` custom property: the old cells set their opacity inline.
+      expect(cell.getAttribute('style') ?? '').not.toContain('--tint');
+      expect(cell.className).toMatch(/bg-(green|blue|orange|red)-\d{3}/);
+    }
+  });
+
+  it('animates the cells in rather than blinking them', () => {
+    const { container } = render(<CategoryMatrix data={data()} search="" onSearchChange={vi.fn()} />);
+
+    expect(container.querySelectorAll('.animate-data-rise').length).toBeGreaterThan(0);
+  });
+
   it('says which search found nothing, rather than just "no data"', () => {
     render(
       <CategoryMatrix

--- a/components/analytics/panels/CategoryMatrix.tsx
+++ b/components/analytics/panels/CategoryMatrix.tsx
@@ -103,7 +103,7 @@ export function CategoryMatrix({ data, onExpand, expanded, search, onSearchChang
                         key={order[index]}
                         difficulty={order[index]}
                         count={count}
-                        share={row.total ? count / row.total : 0}
+                        index={index}
                       />
                     ))}
                     <td className="py-1 pl-3 text-right font-semibold tabular-nums text-foreground">
@@ -120,15 +120,15 @@ export function CategoryMatrix({ data, onExpand, expanded, search, onSearchChang
   );
 }
 
-function Cell({ difficulty, count, share }: { difficulty: string; count: number; share: number }) {
+function Cell({ difficulty, count, index }: { difficulty: string; count: number; index: number }) {
   const style = tier(difficulty);
 
-  // A dash, not a tinted zero. An empty cell is the thing you are looking for,
-  // and the lightest shade of "some" is a gap you cannot see.
+  // A dash, not a zero. An empty cell is the thing you are looking for, and the
+  // gaps are the reason to read this table.
   if (count === 0) {
     return (
       <td className="p-1 text-center">
-        <span className="inline-block min-w-[3.25rem] rounded-md border border-dashed border-border px-2 py-1 text-xs text-muted-foreground/50">
+        <span className="inline-block min-w-14 rounded-md border border-dashed border-border px-2 py-1.5 text-xs text-muted-foreground/50">
           —
         </span>
       </td>
@@ -138,10 +138,15 @@ function Cell({ difficulty, count, share }: { difficulty: string; count: number;
   return (
     <td className="p-1 text-center">
       <span
-        className={cn('inline-block min-w-[3.25rem] rounded-md px-2 py-1 font-medium tabular-nums', style.chip)}
-        // Floored so the faintest real value is still visibly a box rather than
-        // an empty rectangle, and capped so a 100%-of-row cell stays readable.
-        style={{ '--tint': `${Math.max(12, Math.min(70, Math.round(share * 90)))}%` } as React.CSSProperties}
+        className={cn(
+          'inline-block min-w-[3.5rem] rounded-md px-2 py-1.5 text-sm font-semibold tabular-nums shadow-sm',
+          'animate-data-rise transition-transform duration-150 hover:scale-105',
+          style.chip,
+        )}
+        // Staggered across the row so a refetched table reads left to right
+        // rather than flashing all at once. Capped so a wide row still finishes
+        // promptly.
+        style={{ animationDelay: `${Math.min(index, 5) * 45}ms` }}
       >
         {count.toLocaleString()}
       </span>

--- a/components/reports/primitives/DataBar.tsx
+++ b/components/reports/primitives/DataBar.tsx
@@ -13,8 +13,9 @@ import { cn } from '@/lib/utils';
  *
  * The differences here are the whole point:
  *
- * THIN. 6px, not 16. A data bar is read by length; height past a few pixels is
- * ink spent saying nothing, and at 16px four stacked rows read as a form.
+ * THIN, BUT NOT INVISIBLE. 10px against 16. The first attempt at this went to
+ * 6px with a 6%-opacity track, which is thin enough that the bar stops reading
+ * as a bar — "read by length" still needs something to see.
  *
  * SQUARE AT THE BASELINE, rounded only at the data end. Every bar starts on the
  * same line, so lengths compare; a rounded start pulls the eye off that line
@@ -44,12 +45,12 @@ export function DataBar({ value, max, colour, label, className }: {
     <div
       role="img"
       aria-label={label}
-      className={cn('h-1.5 w-full overflow-hidden rounded-[2px] bg-foreground/[0.06]', className)}
+      className={cn('h-2.5 w-full overflow-hidden rounded-full bg-foreground/[0.09]', className)}
     >
       <div
         // Rounded on the data end only. `rounded-r-[3px]` with a square left
         // edge is what anchors it to the baseline.
-        className={cn('h-full rounded-r-[3px] transition-[width] duration-300 ease-out', colour)}
+        className={cn('h-full rounded-r-full animate-data-grow transition-[width] duration-300 ease-out', colour)}
         style={{ width: `${pct}%` }}
       />
     </div>

--- a/components/reports/primitives/__tests__/DataBar.test.tsx
+++ b/components/reports/primitives/__tests__/DataBar.test.tsx
@@ -41,6 +41,19 @@ describe('dataBar', () => {
     expect(fill(container).className).not.toContain('rounded-full');
   });
 
+  it('keeps the track visible enough to show the full extent', () => {
+    // The first version used a 6% track at 6px tall and the bars read as
+    // nothing at all. A bar you cannot find is not a thinner bar.
+    const { container } = render(<DataBar value={5} max={10} colour="bg-primary" label="half" />);
+    const track = container.querySelector('[role="img"]') as HTMLElement;
+
+    const opacity = Number(/bg-foreground\/\[([\d.]+)\]/.exec(track.className)?.[1] ?? 0);
+
+    expect(opacity).toBeGreaterThanOrEqual(0.08);
+    // And tall enough to be a bar rather than a rule.
+    expect(track.className).toMatch(/h-2(\.5)?|h-3/);
+  });
+
   it('carries no gradient', () => {
     // The single thing that dated the old bars: a gradient makes the same value
     // look different at different lengths.
@@ -65,6 +78,24 @@ describe('data colours', () => {
 
   it('names an unknown tier rather than dropping it', () => {
     expect(difficultyTier('LEGENDARY').label).toBe('LEGENDARY');
+  });
+
+  it('uses the agreed hues: green, blue, orange, red', () => {
+    // Pinned because they were chosen by eye and the previous set was
+    // unreadable — amber especially. A silent repaint should fail here.
+    expect(DIFFICULTY_TIERS.EASY.bar).toContain('green');
+    expect(DIFFICULTY_TIERS.NORMAL.bar).toContain('blue');
+    expect(DIFFICULTY_TIERS.HARD.bar).toContain('orange');
+    expect(DIFFICULTY_TIERS.EXTREME.bar).toContain('red');
+  });
+
+  it('fills matrix cells solidly rather than by opacity', () => {
+    // The bug this replaces: cells were tinted by their share of the row and
+    // floored at 12% opacity, so a real value could render nearly invisible.
+    for (const tier of Object.values(DIFFICULTY_TIERS)) {
+      expect(tier.chip).not.toContain('/[var(--tint)]');
+      expect(tier.chip).toMatch(/text-(white|\w+-\d{2,3})/);
+    }
   });
 
   it('keeps the two career-state colours apart', () => {

--- a/lib/data-colours.ts
+++ b/lib/data-colours.ts
@@ -27,7 +27,7 @@ export type DataTier = {
   label: string;
   /** Fill for a bar or chip. */
   bar: string;
-  /** Tinted background for a matrix cell; `--tint` sets the opacity. */
+  /** Solid background for a matrix cell, with text that contrasts against it. */
   chip: string;
   /** Text colour for a column header. */
   head: string;
@@ -37,39 +37,48 @@ export type DataTier = {
   hex: string;
 };
 
-/** Cool to hot. Order is the scale — do not sort these alphabetically. */
+/**
+ * Green, blue, orange, red.
+ *
+ * The previous version tinted each cell by its share of the row, floored at
+ * 12% opacity — which meant a genuine value could render at a twelfth of its
+ * colour and simply not be visible, worst of all in amber. Encoding magnitude
+ * in the fill was not worth a table you cannot read: the number is already
+ * printed in the box, so the colour's only job is to say which difficulty this
+ * is, and it does that best at full strength.
+ */
 export const DIFFICULTY_TIERS: Record<string, DataTier> = {
   EASY: {
     label: 'Easy',
-    bar: 'bg-emerald-500',
-    chip: 'bg-emerald-500/[var(--tint)] text-emerald-950 dark:text-emerald-50',
-    head: 'text-emerald-700 dark:text-emerald-400',
-    dot: 'bg-emerald-500',
-    hex: '#10b981',
+    bar: 'bg-green-500',
+    chip: 'bg-green-600 text-white dark:bg-green-500 dark:text-green-950',
+    head: 'text-green-700 dark:text-green-400',
+    dot: 'bg-green-500',
+    hex: '#22c55e',
   },
   NORMAL: {
     label: 'Normal',
-    bar: 'bg-sky-500',
-    chip: 'bg-sky-500/[var(--tint)] text-sky-950 dark:text-sky-50',
-    head: 'text-sky-700 dark:text-sky-400',
-    dot: 'bg-sky-500',
-    hex: '#0ea5e9',
+    bar: 'bg-blue-500',
+    chip: 'bg-blue-600 text-white dark:bg-blue-500 dark:text-blue-950',
+    head: 'text-blue-700 dark:text-blue-400',
+    dot: 'bg-blue-500',
+    hex: '#3b82f6',
   },
   HARD: {
     label: 'Hard',
-    bar: 'bg-amber-500',
-    chip: 'bg-amber-500/[var(--tint)] text-amber-950 dark:text-amber-50',
-    head: 'text-amber-700 dark:text-amber-400',
-    dot: 'bg-amber-500',
-    hex: '#f59e0b',
+    bar: 'bg-orange-500',
+    chip: 'bg-orange-600 text-white dark:bg-orange-500 dark:text-orange-950',
+    head: 'text-orange-700 dark:text-orange-400',
+    dot: 'bg-orange-500',
+    hex: '#f97316',
   },
   EXTREME: {
     label: 'Extreme',
-    bar: 'bg-rose-500',
-    chip: 'bg-rose-500/[var(--tint)] text-rose-950 dark:text-rose-50',
-    head: 'text-rose-700 dark:text-rose-400',
-    dot: 'bg-rose-500',
-    hex: '#f43f5e',
+    bar: 'bg-red-500',
+    chip: 'bg-red-600 text-white dark:bg-red-500 dark:text-red-950',
+    head: 'text-red-700 dark:text-red-400',
+    dot: 'bg-red-500',
+    hex: '#ef4444',
   },
 };
 
@@ -90,7 +99,9 @@ export function difficultyTier(difficulty: string): DataTier {
 /** Still playing against retired: two states of a whole, not a scale. */
 export const CAREER_STATE = {
   active: { label: 'Still playing', bar: 'bg-teal-500', hex: '#14b8a6' },
-  retired: { label: 'Retired', bar: 'bg-slate-400 dark:bg-slate-500', hex: '#94a3b8' },
+  // Deliberately not grey: at bar heights a neutral reads as "no data" rather
+  // than as a value, and this is half the catalogue.
+  retired: { label: 'Retired', bar: 'bg-violet-500', hex: '#8b5cf6' },
 } as const;
 
 /**
@@ -99,4 +110,4 @@ export const CAREER_STATE = {
  * One colour, deliberately: shading these by value would imply a threshold
  * ("amber means concerning") that a squad size does not have.
  */
-export const MAGNITUDE_BAR = 'bg-primary/70';
+export const MAGNITUDE_BAR = 'bg-primary';


### PR DESCRIPTION

The last pass got this wrong in two ways and both are fixed here.

CELLS WERE TINTED BY VALUE, FLOORED AT 12% OPACITY

Shading each cell by its share of the row meant a real number could render at a
twelfth of its colour. Amber was the worst of it, but Easy and Hard were both
effectively invisible. Encoding magnitude in the fill was not worth a table you
cannot read — the number is printed in the box already, so the colour's only
job is to say which difficulty this is, and it does that at full strength.

Cells are now solid boxes with contrasting text, in the requested palette:

  Easy     green
  Normal   blue
  Hard     orange
  Extreme  red

BARS WERE 6px WITH A 6% TRACK

"Thin marks" taken far enough that the bar stopped reading as a bar. A bar you
cannot find is not a thinner bar. Now 10px with a 9% track — still quiet
against a chart, but present.

MOTION INSTEAD OF CLEVERNESS WITH COLOUR

Cells rise and fade in, staggered 45ms across a row so a refetched table reads
left to right rather than flashing all at once, capped at five steps so a wide
row still finishes promptly. Bars grow from their baseline. Both are decoration
— the number and the length carry the meaning — so both are switched off
entirely under `prefers-reduced-motion`.

Retired moves from slate to violet: at bar height a neutral reads as "no data"
rather than as a value, and this is half the catalogue.

GUARDED, BECAUSE THIS REGRESSED ONCE

The palette is pinned by test — Easy green, Normal blue, Hard orange, Extreme
red — so a silent repaint fails. So is the absence of opacity tinting on cells,
the presence of the entrance animation, and the track being visible at all:
reverting Hard to amber, restoring the tint, removing the animation, thinning
the bar to 1px, or fading the track to 1% each fail a test.

Refs https://github.com/FootballExtraTime/App/issues/1474

🤖 Generated with [Claude Code](https://claude.com/claude-code)