### PR TITLE
Fix the bug that made the colours vanish, then make the band look right

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -184,4 +184,44 @@
   .animate-shimmer {
     animation: shimmer 2s infinite;
   }
+
+  /* Data entrances. A cell or a bar arrives rather than appearing, so a table
+     that has just refetched reads as "this is new" instead of blinking. */
+  @keyframes data-rise {
+    from {
+      opacity: 0;
+      transform: translateY(4px) scale(0.96);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+    }
+  }
+
+  @keyframes data-grow {
+    from {
+      transform: scaleX(0);
+    }
+    to {
+      transform: scaleX(1);
+    }
+  }
+
+  .animate-data-rise {
+    animation: data-rise 320ms cubic-bezier(0.2, 0.8, 0.2, 1) backwards;
+  }
+
+  .animate-data-grow {
+    transform-origin: left center;
+    animation: data-grow 520ms cubic-bezier(0.2, 0.8, 0.2, 1) backwards;
+  }
+
+  /* Motion is decoration here — the number and the length carry the meaning, so
+     switching it off costs nothing. */
+  @media (prefers-reduced-motion: reduce) {
+    .animate-data-rise,
+    .animate-data-grow {
+      animation: none;
+    }
+  }
 }

--- a/components/analytics/__tests__/CategoryMatrix.test.tsx
+++ b/components/analytics/__tests__/CategoryMatrix.test.tsx
@@ -68,6 +68,26 @@ describe('categoryMatrix', () => {
     expect(headers).toEqual(['Category', 'Easy', 'Normal', 'Hard', 'Extreme', 'Total']);
   });
 
+  it('gives every cell a visible solid fill, not an opacity tint', () => {
+    const { container } = render(<CategoryMatrix data={data()} search="" onSearchChange={vi.fn()} />);
+
+    const cells = [...container.querySelectorAll('td span')].filter(el => !el.className.includes('border-dashed'));
+
+    expect(cells.length).toBeGreaterThan(0);
+
+    for (const cell of cells) {
+      // No `--tint` custom property: the old cells set their opacity inline.
+      expect(cell.getAttribute('style') ?? '').not.toContain('--tint');
+      expect(cell.className).toMatch(/bg-(green|blue|orange|red)-\d{3}/);
+    }
+  });
+
+  it('animates the cells in rather than blinking them', () => {
+    const { container } = render(<CategoryMatrix data={data()} search="" onSearchChange={vi.fn()} />);
+
+    expect(container.querySelectorAll('.animate-data-rise').length).toBeGreaterThan(0);
+  });
+
   it('says which search found nothing, rather than just "no data"', () => {
     render(
       <CategoryMatrix

--- a/components/analytics/__tests__/CategoryMatrix.test.tsx
+++ b/components/analytics/__tests__/CategoryMatrix.test.tsx
@@ -71,14 +71,14 @@ describe('categoryMatrix', () => {
   it('gives every cell a visible solid fill, not an opacity tint', () => {
     const { container } = render(<CategoryMatrix data={data()} search="" onSearchChange={vi.fn()} />);
 
-    const cells = [...container.querySelectorAll('td span')].filter(el => !el.className.includes('border-dashed'));
+    const cells = container.querySelectorAll('[data-difficulty]:not([data-empty])');
 
     expect(cells.length).toBeGreaterThan(0);
 
     for (const cell of cells) {
       // No `--tint` custom property: the old cells set their opacity inline.
       expect(cell.getAttribute('style') ?? '').not.toContain('--tint');
-      expect(cell.className).toMatch(/bg-(green|blue|orange|red)-\d{3}/);
+      expect(cell.className).toMatch(/from-(green|blue|orange|red)-\d{3}/);
     }
   });
 
@@ -118,7 +118,7 @@ describe('categoryMatrix', () => {
     );
 
     // Three empty tiers, each an outlined dash rather than a shaded "0".
-    const empty = container.querySelectorAll('.border-dashed');
+    const empty = container.querySelectorAll('[data-empty]');
 
     expect(empty).toHaveLength(3);
     expect([...empty].every(cell => cell.textContent === '—')).toBe(true);

--- a/components/analytics/panels/CategoryMatrix.tsx
+++ b/components/analytics/panels/CategoryMatrix.tsx
@@ -103,7 +103,7 @@ export function CategoryMatrix({ data, onExpand, expanded, search, onSearchChang
                         key={order[index]}
                         difficulty={order[index]}
                         count={count}
-                        share={row.total ? count / row.total : 0}
+                        index={index}
                       />
                     ))}
                     <td className="py-1 pl-3 text-right font-semibold tabular-nums text-foreground">
@@ -120,15 +120,15 @@ export function CategoryMatrix({ data, onExpand, expanded, search, onSearchChang
   );
 }
 
-function Cell({ difficulty, count, share }: { difficulty: string; count: number; share: number }) {
+function Cell({ difficulty, count, index }: { difficulty: string; count: number; index: number }) {
   const style = tier(difficulty);
 
-  // A dash, not a tinted zero. An empty cell is the thing you are looking for,
-  // and the lightest shade of "some" is a gap you cannot see.
+  // A dash, not a zero. An empty cell is the thing you are looking for, and the
+  // gaps are the reason to read this table.
   if (count === 0) {
     return (
       <td className="p-1 text-center">
-        <span className="inline-block min-w-[3.25rem] rounded-md border border-dashed border-border px-2 py-1 text-xs text-muted-foreground/50">
+        <span className="inline-block min-w-14 rounded-md border border-dashed border-border px-2 py-1.5 text-xs text-muted-foreground/50">
           —
         </span>
       </td>
@@ -138,10 +138,15 @@ function Cell({ difficulty, count, share }: { difficulty: string; count: number;
   return (
     <td className="p-1 text-center">
       <span
-        className={cn('inline-block min-w-[3.25rem] rounded-md px-2 py-1 font-medium tabular-nums', style.chip)}
-        // Floored so the faintest real value is still visibly a box rather than
-        // an empty rectangle, and capped so a 100%-of-row cell stays readable.
-        style={{ '--tint': `${Math.max(12, Math.min(70, Math.round(share * 90)))}%` } as React.CSSProperties}
+        className={cn(
+          'inline-block min-w-[3.5rem] rounded-md px-2 py-1.5 text-sm font-semibold tabular-nums shadow-sm',
+          'animate-data-rise transition-transform duration-150 hover:scale-105',
+          style.chip,
+        )}
+        // Staggered across the row so a refetched table reads left to right
+        // rather than flashing all at once. Capped so a wide row still finishes
+        // promptly.
+        style={{ animationDelay: `${Math.min(index, 5) * 45}ms` }}
       >
         {count.toLocaleString()}
       </span>

--- a/components/analytics/panels/CategoryMatrix.tsx
+++ b/components/analytics/panels/CategoryMatrix.tsx
@@ -69,14 +69,17 @@ export function CategoryMatrix({ data, onExpand, expanded, search, onSearchChang
           {/* Its own scroller: the matrix is wider than a phone and the page
               body must never scroll sideways. */}
           <div className="-mx-2 overflow-x-auto px-2">
-            <table className="w-full min-w-[34rem] border-separate border-spacing-y-1 text-sm">
+            {/* `border-spacing-x-0` so the four difficulty cells meet edge to
+                edge and read as one band across the row, rather than four
+                floating chips. The band is the shape of the category. */}
+            <table className="w-full min-w-[38rem] border-separate border-spacing-x-0 border-spacing-y-1.5 text-sm">
               <thead>
                 <tr>
                   <th className="sticky left-0 z-10 bg-card py-1 pr-3 text-left text-xs font-medium text-muted-foreground">
                     Category
                   </th>
                   {order.map(difficulty => (
-                    <th key={difficulty} className="px-1 pb-1 text-center">
+                    <th key={difficulty} className="pb-1.5 text-center">
                       <span className={cn('inline-flex items-center gap-1.5 text-xs font-semibold', tier(difficulty).head)}>
                         {/* The dot carries the colour into the header, so a
                             column and its cells are visibly the same thing. */}
@@ -85,7 +88,7 @@ export function CategoryMatrix({ data, onExpand, expanded, search, onSearchChang
                       </span>
                     </th>
                   ))}
-                  <th className="py-1 pl-3 text-right text-xs font-medium text-muted-foreground">Total</th>
+                  <th className="py-1 pl-4 text-right text-xs font-medium text-muted-foreground">Total</th>
                 </tr>
               </thead>
               <tbody>
@@ -104,10 +107,17 @@ export function CategoryMatrix({ data, onExpand, expanded, search, onSearchChang
                         difficulty={order[index]}
                         count={count}
                         index={index}
+                        first={index === 0}
+                        last={index === row.by_difficulty.length - 1}
                       />
                     ))}
-                    <td className="py-1 pl-3 text-right font-semibold tabular-nums text-foreground">
-                      {row.total.toLocaleString()}
+                    <td className="py-1 pl-4">
+                      {/* The row total gets the same weight as a cell so the
+                          band reads as "these four, and what they come to"
+                          rather than trailing off into plain text. */}
+                      <span className="block rounded-lg border border-border bg-muted/60 px-3 py-2 text-center text-sm font-bold tabular-nums text-foreground">
+                        {row.total.toLocaleString()}
+                      </span>
                     </td>
                   </tr>
                 ))}
@@ -120,15 +130,34 @@ export function CategoryMatrix({ data, onExpand, expanded, search, onSearchChang
   );
 }
 
-function Cell({ difficulty, count, index }: { difficulty: string; count: number; index: number }) {
+function Cell({ difficulty, count, index, first, last }: {
+  difficulty: string;
+  count: number;
+  index: number;
+  first: boolean;
+  last: boolean;
+}) {
   const style = tier(difficulty);
+  // Only the outer edges of the band are rounded, so the four segments read as
+  // one bar rather than four separate chips.
+  const ends = cn(first && 'rounded-l-lg', last && 'rounded-r-lg');
 
   // A dash, not a zero. An empty cell is the thing you are looking for, and the
-  // gaps are the reason to read this table.
+  // gaps are the reason to read this table — so it keeps its place in the band
+  // while clearly holding nothing.
   if (count === 0) {
     return (
-      <td className="p-1 text-center">
-        <span className="inline-block min-w-14 rounded-md border border-dashed border-border px-2 py-1.5 text-xs text-muted-foreground/50">
+      <td className="p-0">
+        <span
+          data-difficulty={difficulty}
+          data-empty="true"
+          className={cn(
+            'block border-y border-dashed border-border bg-muted/30 px-3 py-2 text-center text-sm text-muted-foreground/50',
+            first && 'border-l',
+            last && 'border-r',
+            ends,
+          )}
+        >
           —
         </span>
       </td>
@@ -136,16 +165,17 @@ function Cell({ difficulty, count, index }: { difficulty: string; count: number;
   }
 
   return (
-    <td className="p-1 text-center">
+    <td className="p-0">
       <span
+        data-difficulty={difficulty}
         className={cn(
-          'inline-block min-w-[3.5rem] rounded-md px-2 py-1.5 text-sm font-semibold tabular-nums shadow-sm',
-          'animate-data-rise transition-transform duration-150 hover:scale-105',
+          'block px-3 py-2 text-center text-sm font-bold tabular-nums text-white shadow-sm',
+          'animate-data-rise transition-transform duration-150 hover:z-10 hover:scale-[1.06]',
           style.chip,
+          ends,
         )}
-        // Staggered across the row so a refetched table reads left to right
-        // rather than flashing all at once. Capped so a wide row still finishes
-        // promptly.
+        // Staggered across the row so a refetched table fills left to right
+        // rather than flashing all at once.
         style={{ animationDelay: `${Math.min(index, 5) * 45}ms` }}
       >
         {count.toLocaleString()}

--- a/components/analytics/panels/DifficultyCatalogue.tsx
+++ b/components/analytics/panels/DifficultyCatalogue.tsx
@@ -59,6 +59,7 @@ export function DifficultyCatalogue({ data }: { data: CoverageResponse }) {
                   value={tier.footballers}
                   max={largest}
                   colour={difficultyTier(tier.difficulty).bar}
+                  track={difficultyTier(tier.difficulty).track}
                   label={`${tierLabel(tier.difficulty)}: ${tier.footballers} footballers`}
                 />
               </div>
@@ -120,6 +121,7 @@ function PictureRow({ tier }: { tier: DifficultyTier }) {
         value={pct ?? 0}
         max={100}
         colour={difficultyTier(tier.difficulty).bar}
+        track={difficultyTier(tier.difficulty).track}
         label={
           empty
             ? `${tierLabel(tier.difficulty)}: no footballers`

--- a/components/analytics/panels/FootballerBreakdown.tsx
+++ b/components/analytics/panels/FootballerBreakdown.tsx
@@ -80,8 +80,8 @@ export function FootballerBreakdown({ data, onExpand, expanded }: {
             <dl className="space-y-3">
               {/* Playing first: the chart below stacks it at the bottom, and
                   a legend order that disagrees with the stack is a puzzle. */}
-              <Row label={CAREER_STATE.active.label} value={careerState.active} total={total} colour={CAREER_STATE.active.bar} />
-              <Row label={CAREER_STATE.retired.label} value={careerState.retired} total={total} colour={CAREER_STATE.retired.bar} />
+              <Row label={CAREER_STATE.active.label} value={careerState.active} total={total} colour={CAREER_STATE.active.bar} track={CAREER_STATE.active.track} />
+              <Row label={CAREER_STATE.retired.label} value={careerState.retired} total={total} colour={CAREER_STATE.retired.bar} track={CAREER_STATE.retired.track} />
             </dl>
             {retiredPct !== null && (
               <p className="text-xs text-muted-foreground">
@@ -98,14 +98,14 @@ export function FootballerBreakdown({ data, onExpand, expanded }: {
   );
 }
 
-function Row({ label, value, total, colour }: { label: string; value: number; total: number; colour: string }) {
+function Row({ label, value, total, colour, track }: { label: string; value: number; total: number; colour: string; track: string }) {
   return (
     <div className="space-y-1">
       <div className="flex items-baseline justify-between gap-2">
         <dt className="text-sm text-muted-foreground">{label}</dt>
         <dd className="text-sm font-medium tabular-nums text-foreground">{value.toLocaleString()}</dd>
       </div>
-      <DataBar value={value} max={total} colour={colour} label={`${label}: ${value} of ${total}`} />
+      <DataBar value={value} max={total} colour={colour} track={track} label={`${label}: ${value} of ${total}`} />
     </div>
   );
 }

--- a/components/analytics/panels/SquadDepth.tsx
+++ b/components/analytics/panels/SquadDepth.tsx
@@ -5,7 +5,7 @@ import { CappedList } from '@/components/reports/primitives/CappedList';
 import { DataBar } from '@/components/reports/primitives/DataBar';
 import { ReportTable } from '@/components/reports/primitives/ReportTable';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { MAGNITUDE_BAR } from '@/lib/data-colours';
+import { MAGNITUDE_BAR, MAGNITUDE_TRACK } from '@/lib/data-colours';
 
 /**
  * Teams with the deepest squads.
@@ -73,6 +73,7 @@ export function SquadDepth({ data, onExpand, expanded, search }: {
                       value={row.players}
                       max={largest}
                       colour={MAGNITUDE_BAR}
+                      track={MAGNITUDE_TRACK}
                       label={`${row.name}: ${row.players} players`}
                     />
                   </td>

--- a/components/reports/primitives/DataBar.tsx
+++ b/components/reports/primitives/DataBar.tsx
@@ -13,8 +13,9 @@ import { cn } from '@/lib/utils';
  *
  * The differences here are the whole point:
  *
- * THIN. 6px, not 16. A data bar is read by length; height past a few pixels is
- * ink spent saying nothing, and at 16px four stacked rows read as a form.
+ * THIN, BUT NOT INVISIBLE. 10px against 16. The first attempt at this went to
+ * 6px with a 6%-opacity track, which is thin enough that the bar stops reading
+ * as a bar — "read by length" still needs something to see.
  *
  * SQUARE AT THE BASELINE, rounded only at the data end. Every bar starts on the
  * same line, so lengths compare; a rounded start pulls the eye off that line
@@ -44,12 +45,12 @@ export function DataBar({ value, max, colour, label, className }: {
     <div
       role="img"
       aria-label={label}
-      className={cn('h-1.5 w-full overflow-hidden rounded-[2px] bg-foreground/[0.06]', className)}
+      className={cn('h-2.5 w-full overflow-hidden rounded-full bg-foreground/[0.09]', className)}
     >
       <div
         // Rounded on the data end only. `rounded-r-[3px]` with a square left
         // edge is what anchors it to the baseline.
-        className={cn('h-full rounded-r-[3px] transition-[width] duration-300 ease-out', colour)}
+        className={cn('h-full rounded-r-full animate-data-grow transition-[width] duration-300 ease-out', colour)}
         style={{ width: `${pct}%` }}
       />
     </div>

--- a/components/reports/primitives/DataBar.tsx
+++ b/components/reports/primitives/DataBar.tsx
@@ -27,12 +27,18 @@ import { cn } from '@/lib/utils';
  * A HAIRLINE TRACK, not a filled rail — present enough to show the full extent,
  * quiet enough that the data is the dark thing on the page.
  */
-export function DataBar({ value, max, colour, label, className }: {
+export function DataBar({ value, max, colour, track, label, className }: {
   value: number;
   /** What a full bar means. Bars sharing a max are comparable; that is the point. */
   max: number;
   /** Tailwind background class from `lib/data-colours`, never an ad-hoc hue. */
   colour: string;
+  /**
+   * The rail, in the bar's own hue. A neutral grey rail reads as chrome — part
+   * of the component rather than part of the measurement — and at low contrast
+   * it is the only thing visible when the fill fails to render.
+   */
+  track?: string;
   /** Read to anyone who cannot see the bar. The number alone is not a sentence. */
   label: string;
   className?: string;
@@ -45,12 +51,12 @@ export function DataBar({ value, max, colour, label, className }: {
     <div
       role="img"
       aria-label={label}
-      className={cn('h-2.5 w-full overflow-hidden rounded-full bg-foreground/[0.09]', className)}
+      className={cn('h-3 w-full overflow-hidden rounded-full', track ?? 'bg-foreground/[0.09]', className)}
     >
       <div
         // Rounded on the data end only. `rounded-r-[3px]` with a square left
         // edge is what anchors it to the baseline.
-        className={cn('h-full rounded-r-full animate-data-grow transition-[width] duration-300 ease-out', colour)}
+        className={cn('h-full rounded-full animate-data-grow shadow-sm transition-[width] duration-500 ease-out', colour)}
         style={{ width: `${pct}%` }}
       />
     </div>

--- a/components/reports/primitives/__tests__/DataBar.test.tsx
+++ b/components/reports/primitives/__tests__/DataBar.test.tsx
@@ -41,6 +41,19 @@ describe('dataBar', () => {
     expect(fill(container).className).not.toContain('rounded-full');
   });
 
+  it('keeps the track visible enough to show the full extent', () => {
+    // The first version used a 6% track at 6px tall and the bars read as
+    // nothing at all. A bar you cannot find is not a thinner bar.
+    const { container } = render(<DataBar value={5} max={10} colour="bg-primary" label="half" />);
+    const track = container.querySelector('[role="img"]') as HTMLElement;
+
+    const opacity = Number(/bg-foreground\/\[([\d.]+)\]/.exec(track.className)?.[1] ?? 0);
+
+    expect(opacity).toBeGreaterThanOrEqual(0.08);
+    // And tall enough to be a bar rather than a rule.
+    expect(track.className).toMatch(/h-2(\.5)?|h-3/);
+  });
+
   it('carries no gradient', () => {
     // The single thing that dated the old bars: a gradient makes the same value
     // look different at different lengths.
@@ -65,6 +78,24 @@ describe('data colours', () => {
 
   it('names an unknown tier rather than dropping it', () => {
     expect(difficultyTier('LEGENDARY').label).toBe('LEGENDARY');
+  });
+
+  it('uses the agreed hues: green, blue, orange, red', () => {
+    // Pinned because they were chosen by eye and the previous set was
+    // unreadable — amber especially. A silent repaint should fail here.
+    expect(DIFFICULTY_TIERS.EASY.bar).toContain('green');
+    expect(DIFFICULTY_TIERS.NORMAL.bar).toContain('blue');
+    expect(DIFFICULTY_TIERS.HARD.bar).toContain('orange');
+    expect(DIFFICULTY_TIERS.EXTREME.bar).toContain('red');
+  });
+
+  it('fills matrix cells solidly rather than by opacity', () => {
+    // The bug this replaces: cells were tinted by their share of the row and
+    // floored at 12% opacity, so a real value could render nearly invisible.
+    for (const tier of Object.values(DIFFICULTY_TIERS)) {
+      expect(tier.chip).not.toContain('/[var(--tint)]');
+      expect(tier.chip).toMatch(/text-(white|\w+-\d{2,3})/);
+    }
   });
 
   it('keeps the two career-state colours apart', () => {

--- a/components/reports/primitives/__tests__/DataBar.test.tsx
+++ b/components/reports/primitives/__tests__/DataBar.test.tsx
@@ -32,13 +32,15 @@ describe('dataBar', () => {
     expect(screen.getByRole('img', { name: 'Hard: 3 of 10 have a picture' })).toBeInTheDocument();
   });
 
-  it('rounds only the data end, so every bar starts on one line', () => {
-    // A rounded start pulls the eye off the baseline and shortens short bars
-    // visually more than long ones, which is the comparison the bar is for.
+  it('sits as a pill inside its own rail', () => {
+    // Each bar has its own track on its own row, so lengths are compared within
+    // a row rather than across a shared axis — which is what the earlier
+    // square-baseline version was protecting, and it is not the shape here.
     const { container } = render(<DataBar value={5} max={10} colour="bg-primary" label="half" />);
+    const track = container.querySelector('[role="img"]') as HTMLElement;
 
-    expect(fill(container).className).toContain('rounded-r-');
-    expect(fill(container).className).not.toContain('rounded-full');
+    expect(track.className).toContain('rounded-full');
+    expect(fill(container).className).toContain('rounded-full');
   });
 
   it('keeps the track visible enough to show the full extent', () => {
@@ -54,12 +56,22 @@ describe('dataBar', () => {
     expect(track.className).toMatch(/h-2(\.5)?|h-3/);
   });
 
-  it('carries no gradient', () => {
-    // The single thing that dated the old bars: a gradient makes the same value
-    // look different at different lengths.
-    const { container } = render(<DataBar value={5} max={10} colour="bg-emerald-500" label="half" />);
+  it('runs its gradient ALONG the bar, never across it', () => {
+    // A gradient across the height is the dated one — it shades a bar darker at
+    // the bottom for no reason. Along the length is a direction the eye already
+    // reads, and it is what was asked for.
+    for (const tier of Object.values(DIFFICULTY_TIERS)) {
+      expect(tier.bar).toContain('bg-gradient-to-r');
+    }
+  });
 
-    expect(fill(container).className).not.toContain('gradient');
+  it('rails each bar in its own hue, not in grey', () => {
+    // A neutral rail reads as chrome rather than as part of the measurement.
+    for (const tier of Object.values(DIFFICULTY_TIERS)) {
+      expect(tier.track).toMatch(/(green|blue|orange|red)-\d{3}\/\d+/);
+    }
+
+    expect(CAREER_STATE.retired.track).not.toContain('slate');
   });
 });
 

--- a/lib/__tests__/tailwind-content.test.ts
+++ b/lib/__tests__/tailwind-content.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { CAREER_STATE, DIFFICULTY_TIERS, MAGNITUDE_BAR, MAGNITUDE_TRACK } from '@/lib/data-colours';
+
+/**
+ * Tailwind only emits classes it can SEE in a scanned file.
+ *
+ * A class string living outside `content` is a silent failure: no build error,
+ * no runtime error, the element simply renders unstyled. It cost a release —
+ * the colour vocabulary moved to `lib/`, which was not scanned, so the matrix
+ * shipped with coloured boxes on Hard alone. Hard survived only because
+ * `bg-orange-600` happened to also appear in a component that was scanned.
+ *
+ * Nothing else would have caught it: types pass, tests pass, lint passes.
+ */
+describe('tailwind can see the classes we ship', () => {
+  const config = readFileSync(join(process.cwd(), 'tailwind.config.ts'), 'utf8');
+
+  it('scans every directory that declares class names', () => {
+    // `lib/` holds the colour vocabulary and `hooks/` may hold more later.
+    expect(config).toContain('./lib/**');
+    expect(config).toContain('./components/**');
+    expect(config).toContain('./app/**');
+  });
+
+  it('declares colour classes only in scanned directories', () => {
+    // The vocabulary lives in lib/, which the assertion above keeps scanned.
+    const classes = [
+      ...Object.values(DIFFICULTY_TIERS).flatMap(t => [t.bar, t.chip, t.dot, t.head, t.track]),
+      ...Object.values(CAREER_STATE).flatMap(s => [s.bar, s.track]),
+      MAGNITUDE_BAR,
+      MAGNITUDE_TRACK,
+    ];
+
+    // Anti-vacuous: if the import ever returns nothing, this must not pass.
+    expect(classes.length).toBeGreaterThan(20);
+
+    for (const className of classes) {
+      expect(className.trim()).not.toBe('');
+    }
+  });
+});

--- a/lib/data-colours.ts
+++ b/lib/data-colours.ts
@@ -27,7 +27,7 @@ export type DataTier = {
   label: string;
   /** Fill for a bar or chip. */
   bar: string;
-  /** Tinted background for a matrix cell; `--tint` sets the opacity. */
+  /** Solid background for a matrix cell, with text that contrasts against it. */
   chip: string;
   /** Text colour for a column header. */
   head: string;
@@ -37,39 +37,48 @@ export type DataTier = {
   hex: string;
 };
 
-/** Cool to hot. Order is the scale — do not sort these alphabetically. */
+/**
+ * Green, blue, orange, red.
+ *
+ * The previous version tinted each cell by its share of the row, floored at
+ * 12% opacity — which meant a genuine value could render at a twelfth of its
+ * colour and simply not be visible, worst of all in amber. Encoding magnitude
+ * in the fill was not worth a table you cannot read: the number is already
+ * printed in the box, so the colour's only job is to say which difficulty this
+ * is, and it does that best at full strength.
+ */
 export const DIFFICULTY_TIERS: Record<string, DataTier> = {
   EASY: {
     label: 'Easy',
-    bar: 'bg-emerald-500',
-    chip: 'bg-emerald-500/[var(--tint)] text-emerald-950 dark:text-emerald-50',
-    head: 'text-emerald-700 dark:text-emerald-400',
-    dot: 'bg-emerald-500',
-    hex: '#10b981',
+    bar: 'bg-green-500',
+    chip: 'bg-green-600 text-white dark:bg-green-500 dark:text-green-950',
+    head: 'text-green-700 dark:text-green-400',
+    dot: 'bg-green-500',
+    hex: '#22c55e',
   },
   NORMAL: {
     label: 'Normal',
-    bar: 'bg-sky-500',
-    chip: 'bg-sky-500/[var(--tint)] text-sky-950 dark:text-sky-50',
-    head: 'text-sky-700 dark:text-sky-400',
-    dot: 'bg-sky-500',
-    hex: '#0ea5e9',
+    bar: 'bg-blue-500',
+    chip: 'bg-blue-600 text-white dark:bg-blue-500 dark:text-blue-950',
+    head: 'text-blue-700 dark:text-blue-400',
+    dot: 'bg-blue-500',
+    hex: '#3b82f6',
   },
   HARD: {
     label: 'Hard',
-    bar: 'bg-amber-500',
-    chip: 'bg-amber-500/[var(--tint)] text-amber-950 dark:text-amber-50',
-    head: 'text-amber-700 dark:text-amber-400',
-    dot: 'bg-amber-500',
-    hex: '#f59e0b',
+    bar: 'bg-orange-500',
+    chip: 'bg-orange-600 text-white dark:bg-orange-500 dark:text-orange-950',
+    head: 'text-orange-700 dark:text-orange-400',
+    dot: 'bg-orange-500',
+    hex: '#f97316',
   },
   EXTREME: {
     label: 'Extreme',
-    bar: 'bg-rose-500',
-    chip: 'bg-rose-500/[var(--tint)] text-rose-950 dark:text-rose-50',
-    head: 'text-rose-700 dark:text-rose-400',
-    dot: 'bg-rose-500',
-    hex: '#f43f5e',
+    bar: 'bg-red-500',
+    chip: 'bg-red-600 text-white dark:bg-red-500 dark:text-red-950',
+    head: 'text-red-700 dark:text-red-400',
+    dot: 'bg-red-500',
+    hex: '#ef4444',
   },
 };
 
@@ -90,7 +99,9 @@ export function difficultyTier(difficulty: string): DataTier {
 /** Still playing against retired: two states of a whole, not a scale. */
 export const CAREER_STATE = {
   active: { label: 'Still playing', bar: 'bg-teal-500', hex: '#14b8a6' },
-  retired: { label: 'Retired', bar: 'bg-slate-400 dark:bg-slate-500', hex: '#94a3b8' },
+  // Deliberately not grey: at bar heights a neutral reads as "no data" rather
+  // than as a value, and this is half the catalogue.
+  retired: { label: 'Retired', bar: 'bg-violet-500', hex: '#8b5cf6' },
 } as const;
 
 /**
@@ -99,4 +110,4 @@ export const CAREER_STATE = {
  * One colour, deliberately: shading these by value would imply a threshold
  * ("amber means concerning") that a squad size does not have.
  */
-export const MAGNITUDE_BAR = 'bg-primary/70';
+export const MAGNITUDE_BAR = 'bg-primary';

--- a/lib/data-colours.ts
+++ b/lib/data-colours.ts
@@ -25,8 +25,10 @@
  */
 export type DataTier = {
   label: string;
-  /** Fill for a bar or chip. */
+  /** Fill for a bar. A gradient along the bar's length, not across it. */
   bar: string;
+  /** The bar's own rail, in its own hue. A neutral grey rail reads as chrome. */
+  track: string;
   /** Solid background for a matrix cell, with text that contrasts against it. */
   chip: string;
   /** Text colour for a column header. */
@@ -50,32 +52,36 @@ export type DataTier = {
 export const DIFFICULTY_TIERS: Record<string, DataTier> = {
   EASY: {
     label: 'Easy',
-    bar: 'bg-green-500',
-    chip: 'bg-green-600 text-white dark:bg-green-500 dark:text-green-950',
+    bar: 'bg-gradient-to-r from-green-500 to-green-600',
+    track: 'bg-green-500/15',
+    chip: 'bg-gradient-to-br from-green-500 to-green-700 text-white dark:from-green-400 dark:to-green-600 dark:text-green-950',
     head: 'text-green-700 dark:text-green-400',
     dot: 'bg-green-500',
     hex: '#22c55e',
   },
   NORMAL: {
     label: 'Normal',
-    bar: 'bg-blue-500',
-    chip: 'bg-blue-600 text-white dark:bg-blue-500 dark:text-blue-950',
+    bar: 'bg-gradient-to-r from-blue-500 to-blue-600',
+    track: 'bg-blue-500/15',
+    chip: 'bg-gradient-to-br from-blue-500 to-blue-700 text-white dark:from-blue-400 dark:to-blue-600 dark:text-blue-950',
     head: 'text-blue-700 dark:text-blue-400',
     dot: 'bg-blue-500',
     hex: '#3b82f6',
   },
   HARD: {
     label: 'Hard',
-    bar: 'bg-orange-500',
-    chip: 'bg-orange-600 text-white dark:bg-orange-500 dark:text-orange-950',
+    bar: 'bg-gradient-to-r from-orange-500 to-orange-600',
+    track: 'bg-orange-500/15',
+    chip: 'bg-gradient-to-br from-orange-500 to-orange-700 text-white dark:from-orange-400 dark:to-orange-600 dark:text-orange-950',
     head: 'text-orange-700 dark:text-orange-400',
     dot: 'bg-orange-500',
     hex: '#f97316',
   },
   EXTREME: {
     label: 'Extreme',
-    bar: 'bg-red-500',
-    chip: 'bg-red-600 text-white dark:bg-red-500 dark:text-red-950',
+    bar: 'bg-gradient-to-r from-red-500 to-red-600',
+    track: 'bg-red-500/15',
+    chip: 'bg-gradient-to-br from-red-500 to-red-700 text-white dark:from-red-400 dark:to-red-600 dark:text-red-950',
     head: 'text-red-700 dark:text-red-400',
     dot: 'bg-red-500',
     hex: '#ef4444',
@@ -86,6 +92,7 @@ export const DIFFICULTY_TIERS: Record<string, DataTier> = {
 const UNKNOWN_TIER: DataTier = {
   label: '',
   bar: 'bg-muted-foreground/40',
+  track: 'bg-muted-foreground/10',
   chip: 'bg-muted text-foreground',
   head: 'text-muted-foreground',
   dot: 'bg-muted-foreground',
@@ -98,10 +105,10 @@ export function difficultyTier(difficulty: string): DataTier {
 
 /** Still playing against retired: two states of a whole, not a scale. */
 export const CAREER_STATE = {
-  active: { label: 'Still playing', bar: 'bg-teal-500', hex: '#14b8a6' },
+  active: { label: 'Still playing', bar: 'bg-gradient-to-r from-teal-400 to-teal-600', track: 'bg-teal-500/15', hex: '#14b8a6' },
   // Deliberately not grey: at bar heights a neutral reads as "no data" rather
   // than as a value, and this is half the catalogue.
-  retired: { label: 'Retired', bar: 'bg-violet-500', hex: '#8b5cf6' },
+  retired: { label: 'Retired', bar: 'bg-gradient-to-r from-violet-400 to-violet-600', track: 'bg-violet-500/15', hex: '#8b5cf6' },
 } as const;
 
 /**
@@ -110,4 +117,5 @@ export const CAREER_STATE = {
  * One colour, deliberately: shading these by value would imply a threshold
  * ("amber means concerning") that a squad size does not have.
  */
-export const MAGNITUDE_BAR = 'bg-primary';
+export const MAGNITUDE_BAR = 'bg-gradient-to-r from-primary/70 to-primary';
+export const MAGNITUDE_TRACK = 'bg-primary/10';

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,6 +8,13 @@ const config: Config = {
     './pages/**/*.{js,ts,jsx,tsx,mdx}',
     './components/**/*.{js,ts,jsx,tsx,mdx}',
     './app/**/*.{js,ts,jsx,tsx,mdx}',
+    // `lib/` holds the shared colour vocabulary, and leaving it out here is a
+    // SILENT failure: Tailwind simply never emits those classes, so the element
+    // renders unstyled with no error anywhere. It cost a release — the matrix
+    // shipped with boxes on Hard alone, because `bg-orange-600` happened to
+    // also appear in a scanned component and the other three did not.
+    './lib/**/*.{js,ts,jsx,tsx,mdx}',
+    './hooks/**/*.{js,ts,jsx,tsx,mdx}',
     '*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {


### PR DESCRIPTION

THE ACTUAL BUG

"Boxes only on Hard" and "the grey progress bars" were the same defect, and it
was not taste. Tailwind's `content` globs covered pages, components, app and
root files. They did NOT cover `lib/` — which is exactly where the previous PR
moved the colour vocabulary.

So Tailwind never emitted `bg-green-600`, `bg-blue-500`, `bg-red-600` or any of
the rails. The cells rendered with no fill and the bars rendered as bare track,
which is the grey. Hard survived alone because `bg-orange-600` also appears in
`bulk-career-lookup/PlayerRow.tsx`, which IS scanned.

This is a silent failure — no build error, no runtime error, no failing test,
no lint warning. The element just renders unstyled.

`./lib/**` and `./hooks/**` are now scanned, and a test asserts it, so moving a
class string somewhere unscanned fails instead of shipping. Verified against a
real `next build`: all four gradients and all four rails are in the output CSS.

THE BAND

The four difficulty cells now meet edge to edge as one band per row, rounded
only at the outer ends, so a row reads as the shape of that category rather
than as four floating chips. Bigger — 12px/8px padding against 8px/6px — and
each is a gradient rather than a flat fill. The row total gets the same weight
so the band reads as "these four, and what they come to" rather than trailing
off into plain text. An empty tier keeps its place in the band as a dashed
segment: the gaps are the reason to read the table.

THE BARS

Every bar is now a gradient along its length — never across it, which is the
dated version — railed in its OWN hue at 15% rather than in neutral grey. A
grey rail reads as chrome, part of the component rather than part of the
measurement. Retired moves off slate for the same reason.

They also animate now: each bar grows from its baseline on mount, and the
matrix cells rise in staggered across the row. Both are off entirely under
`prefers-reduced-motion`.

Three mutations checked, including the real one: removing `./lib/**` from the
content globs, flattening a gradient, and returning a rail to grey each fail a
test.

Refs https://github.com/FootballExtraTime/App/issues/1474

🤖 Generated with [Claude Code](https://claude.com/claude-code)