### PR TITLE
Soften the matrix cells and let them breathe

### DIFF
--- a/components/analytics/__tests__/CategoryMatrix.test.tsx
+++ b/components/analytics/__tests__/CategoryMatrix.test.tsx
@@ -78,8 +78,23 @@ describe('categoryMatrix', () => {
     for (const cell of cells) {
       // No `--tint` custom property: the old cells set their opacity inline.
       expect(cell.getAttribute('style') ?? '').not.toContain('--tint');
-      expect(cell.className).toMatch(/from-(green|blue|orange|red)-\d{3}/);
+      // The light-mode shade specifically — matching only `dark:from-…-950`
+      // would let a light theme regress unnoticed.
+      expect(cell.className).toMatch(/(^| )from-(green|blue|orange|red)-\d+/);
+      // And the number is written in the hue, not in white on a block of it.
+      expect(cell.className).toMatch(/(^| )text-(green|blue|orange|red)-\d+/);
     }
+  });
+
+  it('leaves air between the cells', () => {
+    // Welded edge to edge they read as one solid block and the eye has to hunt
+    // for the boundaries; this is enough to make each a box without breaking
+    // the row into four separate things.
+    const { container } = render(<CategoryMatrix data={data()} search="" onSearchChange={vi.fn()} />);
+    const table = container.querySelector('table') as HTMLElement;
+
+    expect(table.className).toContain('border-spacing-x-1');
+    expect(container.querySelector('[data-difficulty]')?.className).toContain('rounded-lg');
   });
 
   it('animates the cells in rather than blinking them', () => {

--- a/components/analytics/panels/CategoryMatrix.tsx
+++ b/components/analytics/panels/CategoryMatrix.tsx
@@ -69,10 +69,11 @@ export function CategoryMatrix({ data, onExpand, expanded, search, onSearchChang
           {/* Its own scroller: the matrix is wider than a phone and the page
               body must never scroll sideways. */}
           <div className="-mx-2 overflow-x-auto px-2">
-            {/* `border-spacing-x-0` so the four difficulty cells meet edge to
-                edge and read as one band across the row, rather than four
-                floating chips. The band is the shape of the category. */}
-            <table className="w-full min-w-[38rem] border-separate border-spacing-x-0 border-spacing-y-1.5 text-sm">
+            {/* A hair of space between cells — 4px. Welded edge to edge they
+                read as one solid block and the eye has to hunt for the
+                boundaries; fully separated they float. This is enough to make
+                each a box without breaking the row into four. */}
+            <table className="w-full min-w-[38rem] border-separate border-spacing-x-1 border-spacing-y-1.5 text-sm">
               <thead>
                 <tr>
                   <th className="sticky left-0 z-10 bg-card py-1 pr-3 text-left text-xs font-medium text-muted-foreground">
@@ -107,15 +108,16 @@ export function CategoryMatrix({ data, onExpand, expanded, search, onSearchChang
                         difficulty={order[index]}
                         count={count}
                         index={index}
-                        first={index === 0}
-                        last={index === row.by_difficulty.length - 1}
                       />
                     ))}
                     <td className="py-1 pl-4">
                       {/* The row total gets the same weight as a cell so the
                           band reads as "these four, and what they come to"
                           rather than trailing off into plain text. */}
-                      <span className="block rounded-lg border border-border bg-muted/60 px-3 py-2 text-center text-sm font-bold tabular-nums text-foreground">
+                      {/* The total is the one figure here that is not a
+                          difficulty, so it stays neutral — and reads as the sum
+                          rather than as a fifth tier. */}
+                      <span className="block rounded-lg bg-muted/70 px-3 py-2 text-center text-sm font-bold tabular-nums text-foreground ring-1 ring-inset ring-border">
                         {row.total.toLocaleString()}
                       </span>
                     </td>
@@ -130,20 +132,15 @@ export function CategoryMatrix({ data, onExpand, expanded, search, onSearchChang
   );
 }
 
-function Cell({ difficulty, count, index, first, last }: {
+function Cell({ difficulty, count, index }: {
   difficulty: string;
   count: number;
   index: number;
-  first: boolean;
-  last: boolean;
 }) {
   const style = tier(difficulty);
-  // Only the outer edges of the band are rounded, so the four segments read as
-  // one bar rather than four separate chips.
-  const ends = cn(first && 'rounded-l-lg', last && 'rounded-r-lg');
 
   // A dash, not a zero. An empty cell is the thing you are looking for, and the
-  // gaps are the reason to read this table — so it keeps its place in the band
+  // gaps are the reason to read this table — so it keeps its shape in the row
   // while clearly holding nothing.
   if (count === 0) {
     return (
@@ -151,12 +148,7 @@ function Cell({ difficulty, count, index, first, last }: {
         <span
           data-difficulty={difficulty}
           data-empty="true"
-          className={cn(
-            'block border-y border-dashed border-border bg-muted/30 px-3 py-2 text-center text-sm text-muted-foreground/50',
-            first && 'border-l',
-            last && 'border-r',
-            ends,
-          )}
+          className="block rounded-lg border border-dashed border-border/70 px-3 py-2 text-center text-sm text-muted-foreground/40"
         >
           —
         </span>
@@ -169,10 +161,9 @@ function Cell({ difficulty, count, index, first, last }: {
       <span
         data-difficulty={difficulty}
         className={cn(
-          'block px-3 py-2 text-center text-sm font-bold tabular-nums text-white shadow-sm',
-          'animate-data-rise transition-transform duration-150 hover:z-10 hover:scale-[1.06]',
+          'block rounded-lg px-3 py-2 text-center text-sm font-semibold tabular-nums',
+          'animate-data-rise transition-transform duration-150 hover:scale-[1.04]',
           style.chip,
-          ends,
         )}
         // Staggered across the row so a refetched table fills left to right
         // rather than flashing all at once.

--- a/lib/data-colours.ts
+++ b/lib/data-colours.ts
@@ -40,6 +40,16 @@ export type DataTier = {
    *
    * A real light shade, not an opacity of a dark one. That distinction is the
    * whole reason the earlier tinted version disappeared.
+   *
+   * The fill sits at 50-100 with a 200 ring — enough hue to identify the
+   * column at a glance, not enough for four in a row to compete with the
+   * numbers they carry. The TEXT stays at 700 rather than dropping to 400-500
+   * with everything else: on a fill this pale those shades fall under the
+   * contrast floor, and an unreadable number is the one thing this table
+   * cannot afford.
+   *
+   * TO DIAL IT FURTHER, this line is the only knob — raise the fill toward 200
+   * for more colour, or drop the ring to 100 for less.
    */
   chip: string;
   /** Text colour for a column header. */
@@ -63,38 +73,38 @@ export type DataTier = {
 export const DIFFICULTY_TIERS: Record<string, DataTier> = {
   EASY: {
     label: 'Easy',
-    bar: 'bg-gradient-to-r from-green-500 to-green-600',
-    track: 'bg-green-500/15',
-    chip: 'bg-gradient-to-br from-green-50 to-green-100 text-green-800 ring-1 ring-inset ring-green-200 dark:from-green-950 dark:to-green-900 dark:text-green-200 dark:ring-green-800',
-    head: 'text-green-700 dark:text-green-400',
-    dot: 'bg-green-500',
+    bar: 'bg-gradient-to-r from-green-400 to-green-500',
+    track: 'bg-green-400/20',
+    chip: 'bg-gradient-to-br from-green-50 to-green-100 text-green-700 ring-1 ring-inset ring-green-200 dark:from-green-900/60 dark:to-green-800/60 dark:text-green-200 dark:ring-green-700/60',
+    head: 'text-green-600 dark:text-green-400',
+    dot: 'bg-green-400',
     hex: '#22c55e',
   },
   NORMAL: {
     label: 'Normal',
-    bar: 'bg-gradient-to-r from-blue-500 to-blue-600',
-    track: 'bg-blue-500/15',
-    chip: 'bg-gradient-to-br from-blue-50 to-blue-100 text-blue-800 ring-1 ring-inset ring-blue-200 dark:from-blue-950 dark:to-blue-900 dark:text-blue-200 dark:ring-blue-800',
-    head: 'text-blue-700 dark:text-blue-400',
-    dot: 'bg-blue-500',
+    bar: 'bg-gradient-to-r from-blue-400 to-blue-500',
+    track: 'bg-blue-400/20',
+    chip: 'bg-gradient-to-br from-blue-50 to-blue-100 text-blue-700 ring-1 ring-inset ring-blue-200 dark:from-blue-900/60 dark:to-blue-800/60 dark:text-blue-200 dark:ring-blue-700/60',
+    head: 'text-blue-600 dark:text-blue-400',
+    dot: 'bg-blue-400',
     hex: '#3b82f6',
   },
   HARD: {
     label: 'Hard',
-    bar: 'bg-gradient-to-r from-orange-500 to-orange-600',
-    track: 'bg-orange-500/15',
-    chip: 'bg-gradient-to-br from-orange-50 to-orange-100 text-orange-800 ring-1 ring-inset ring-orange-200 dark:from-orange-950 dark:to-orange-900 dark:text-orange-200 dark:ring-orange-800',
-    head: 'text-orange-700 dark:text-orange-400',
-    dot: 'bg-orange-500',
+    bar: 'bg-gradient-to-r from-orange-400 to-orange-500',
+    track: 'bg-orange-400/20',
+    chip: 'bg-gradient-to-br from-orange-50 to-orange-100 text-orange-700 ring-1 ring-inset ring-orange-200 dark:from-orange-900/60 dark:to-orange-800/60 dark:text-orange-200 dark:ring-orange-700/60',
+    head: 'text-orange-600 dark:text-orange-400',
+    dot: 'bg-orange-400',
     hex: '#f97316',
   },
   EXTREME: {
     label: 'Extreme',
-    bar: 'bg-gradient-to-r from-red-500 to-red-600',
-    track: 'bg-red-500/15',
-    chip: 'bg-gradient-to-br from-red-50 to-red-100 text-red-800 ring-1 ring-inset ring-red-200 dark:from-red-950 dark:to-red-900 dark:text-red-200 dark:ring-red-800',
-    head: 'text-red-700 dark:text-red-400',
-    dot: 'bg-red-500',
+    bar: 'bg-gradient-to-r from-red-400 to-red-500',
+    track: 'bg-red-400/20',
+    chip: 'bg-gradient-to-br from-red-50 to-red-100 text-red-700 ring-1 ring-inset ring-red-200 dark:from-red-900/60 dark:to-red-800/60 dark:text-red-200 dark:ring-red-700/60',
+    head: 'text-red-600 dark:text-red-400',
+    dot: 'bg-red-400',
     hex: '#ef4444',
   },
 };
@@ -116,10 +126,10 @@ export function difficultyTier(difficulty: string): DataTier {
 
 /** Still playing against retired: two states of a whole, not a scale. */
 export const CAREER_STATE = {
-  active: { label: 'Still playing', bar: 'bg-gradient-to-r from-teal-400 to-teal-600', track: 'bg-teal-500/15', hex: '#14b8a6' },
+  active: { label: 'Still playing', bar: 'bg-gradient-to-r from-teal-400 to-teal-500', track: 'bg-teal-400/20', hex: '#2dd4bf' },
   // Deliberately not grey: at bar heights a neutral reads as "no data" rather
   // than as a value, and this is half the catalogue.
-  retired: { label: 'Retired', bar: 'bg-gradient-to-r from-violet-400 to-violet-600', track: 'bg-violet-500/15', hex: '#8b5cf6' },
+  retired: { label: 'Retired', bar: 'bg-gradient-to-r from-violet-400 to-violet-500', track: 'bg-violet-400/20', hex: '#a78bfa' },
 } as const;
 
 /**
@@ -128,5 +138,5 @@ export const CAREER_STATE = {
  * One colour, deliberately: shading these by value would imply a threshold
  * ("amber means concerning") that a squad size does not have.
  */
-export const MAGNITUDE_BAR = 'bg-gradient-to-r from-primary/70 to-primary';
+export const MAGNITUDE_BAR = 'bg-gradient-to-r from-primary/55 to-primary/80';
 export const MAGNITUDE_TRACK = 'bg-primary/10';

--- a/lib/data-colours.ts
+++ b/lib/data-colours.ts
@@ -29,7 +29,18 @@ export type DataTier = {
   bar: string;
   /** The bar's own rail, in its own hue. A neutral grey rail reads as chrome. */
   track: string;
-  /** Solid background for a matrix cell, with text that contrasts against it. */
+  /**
+   * A matrix cell: a soft tint of the hue, with the number in a strong shade of
+   * the SAME hue and a hairline ring around it.
+   *
+   * The saturated version read as shouting — four blocks of full-strength
+   * colour side by side, competing with the numbers they were meant to carry.
+   * The colour only has to say which difficulty this is; the number is the
+   * content, so the fill steps back and the text does the identifying.
+   *
+   * A real light shade, not an opacity of a dark one. That distinction is the
+   * whole reason the earlier tinted version disappeared.
+   */
   chip: string;
   /** Text colour for a column header. */
   head: string;
@@ -54,7 +65,7 @@ export const DIFFICULTY_TIERS: Record<string, DataTier> = {
     label: 'Easy',
     bar: 'bg-gradient-to-r from-green-500 to-green-600',
     track: 'bg-green-500/15',
-    chip: 'bg-gradient-to-br from-green-500 to-green-700 text-white dark:from-green-400 dark:to-green-600 dark:text-green-950',
+    chip: 'bg-gradient-to-br from-green-50 to-green-100 text-green-800 ring-1 ring-inset ring-green-200 dark:from-green-950 dark:to-green-900 dark:text-green-200 dark:ring-green-800',
     head: 'text-green-700 dark:text-green-400',
     dot: 'bg-green-500',
     hex: '#22c55e',
@@ -63,7 +74,7 @@ export const DIFFICULTY_TIERS: Record<string, DataTier> = {
     label: 'Normal',
     bar: 'bg-gradient-to-r from-blue-500 to-blue-600',
     track: 'bg-blue-500/15',
-    chip: 'bg-gradient-to-br from-blue-500 to-blue-700 text-white dark:from-blue-400 dark:to-blue-600 dark:text-blue-950',
+    chip: 'bg-gradient-to-br from-blue-50 to-blue-100 text-blue-800 ring-1 ring-inset ring-blue-200 dark:from-blue-950 dark:to-blue-900 dark:text-blue-200 dark:ring-blue-800',
     head: 'text-blue-700 dark:text-blue-400',
     dot: 'bg-blue-500',
     hex: '#3b82f6',
@@ -72,7 +83,7 @@ export const DIFFICULTY_TIERS: Record<string, DataTier> = {
     label: 'Hard',
     bar: 'bg-gradient-to-r from-orange-500 to-orange-600',
     track: 'bg-orange-500/15',
-    chip: 'bg-gradient-to-br from-orange-500 to-orange-700 text-white dark:from-orange-400 dark:to-orange-600 dark:text-orange-950',
+    chip: 'bg-gradient-to-br from-orange-50 to-orange-100 text-orange-800 ring-1 ring-inset ring-orange-200 dark:from-orange-950 dark:to-orange-900 dark:text-orange-200 dark:ring-orange-800',
     head: 'text-orange-700 dark:text-orange-400',
     dot: 'bg-orange-500',
     hex: '#f97316',
@@ -81,7 +92,7 @@ export const DIFFICULTY_TIERS: Record<string, DataTier> = {
     label: 'Extreme',
     bar: 'bg-gradient-to-r from-red-500 to-red-600',
     track: 'bg-red-500/15',
-    chip: 'bg-gradient-to-br from-red-500 to-red-700 text-white dark:from-red-400 dark:to-red-600 dark:text-red-950',
+    chip: 'bg-gradient-to-br from-red-50 to-red-100 text-red-800 ring-1 ring-inset ring-red-200 dark:from-red-950 dark:to-red-900 dark:text-red-200 dark:ring-red-800',
     head: 'text-red-700 dark:text-red-400',
     dot: 'bg-red-500',
     hex: '#ef4444',


### PR DESCRIPTION

Two corrections to the last pass, both of it overshooting.

LESS ON THE NOSE

The cells were full-strength gradients with white text — four blocks of
saturated colour side by side, competing with the numbers they were meant to
carry. The colour only has to say which difficulty a cell is; the number is the
content. So the fill steps back to a soft tint of the hue and the NUMBER takes
the strong shade, with a hairline ring to hold the shape.

Still a real light shade, not an opacity of a dark one — that distinction is
the entire reason the first tinted version disappeared, and it is guarded.

AIR BETWEEN THEM

Welded edge to edge, the four cells read as one solid block and the eye has to
hunt for the boundaries. 4px of spacing and their own rounding makes each a box
without breaking the row into four unrelated things.

The row total stays neutral rather than taking a fifth hue: it is the one
figure in the row that is not a difficulty, and it should read as the sum
rather than as another tier.

The hue assertion was tightened while doing this. It matched
`from-(green|blue|orange|red)-\d{3}` — which the light shades (`from-green-50`)
do not satisfy, so it had been passing only via the dark-mode class in the same
string. A light-theme regression would have gone unnoticed. It now checks the
light shade and the text colour separately.

Verified against a real build again: every new shade is in the output CSS.

Two mutations checked: welding the cells back together and returning to
white-on-saturated each fail a test.

Refs https://github.com/FootballExtraTime/App/issues/1474

🤖 Generated with [Claude Code](https://claude.com/claude-code)