### PR TITLE
Tile matrix, category growth, era, and per-game pools

### DIFF
--- a/app/analytics/football-data/footballers/page.tsx
+++ b/app/analytics/football-data/footballers/page.tsx
@@ -4,7 +4,9 @@ import type { RangeState } from '@/lib/report-range';
 import { useMemo, useState } from 'react';
 import { DataCoverage } from '@/components/analytics/panels/DataCoverage';
 import { DifficultyCatalogue } from '@/components/analytics/panels/DifficultyCatalogue';
+import { EraAndPools } from '@/components/analytics/panels/EraAndPools';
 import { FootballerBreakdown } from '@/components/analytics/panels/FootballerBreakdown';
+import { FootballerMatrix } from '@/components/analytics/panels/FootballerMatrix';
 import { ReviewQueue } from '@/components/analytics/panels/ReviewQueue';
 import { AnalyticsShell } from '@/components/analytics/shell/AnalyticsShell';
 import { FilterBar } from '@/components/reports/filters/FilterBar';
@@ -31,7 +33,10 @@ const EXPANDED = 100;
 export default function FootballersAnalyticsPage() {
   const { isAuthenticated, user } = useAuth();
   const enabled = isAuthenticated && !!(user?.is_staff || user?.is_superuser);
-  const [limit, setLimit] = useState(PAGE);
+  const [dimension, setDimension] = useState('nation');
+  const [matrixSearch, setMatrixSearch] = useState('');
+  const [matrixDifficulty, setMatrixDifficulty] = useState<string | null>(null);
+  const [matrixLimit, setMatrixLimit] = useState(PAGE);
 
   const { filters, update } = useReportFilters({
     range: { window: 90 },
@@ -43,8 +48,16 @@ export default function FootballersAnalyticsPage() {
   const setRange = (next: RangeState) => update({ range: next });
   const setIncludeBots = (next: boolean) => update({ includeBots: next });
   const params = useMemo(
-    () => ({ ...rangeToParams(range), include_bots: includeBots, limit }),
-    [range, includeBots, limit],
+    () => ({ ...rangeToParams(range), include_bots: includeBots }),
+    [range, includeBots],
+  );
+
+  const matrix = useReport(
+    () => ReportsAPI.getDifficultyMatrix(dimension, matrixLimit, matrixSearch || undefined, matrixDifficulty ?? undefined),
+    {},
+    enabled,
+    'The difficulty matrix endpoint',
+    `${dimension}:${matrixLimit}:${matrixSearch}:${matrixDifficulty ?? ''}`,
   );
 
   const state = useReport(
@@ -73,20 +86,45 @@ export default function FootballersAnalyticsPage() {
       </ReportPanel>
 
       <SectionHeader
-        title="Who built it, and who is still playing"
+        title="Who is still playing, and what each game can use"
         description="Not windowed — this is the catalogue as it stands, whatever the range says."
       />
 
       <ReportPanel state={state} skeletonClassName="h-72 w-full">
         {data => (
           <div className="space-y-4">
-            <FootballerBreakdown
-              data={data}
-              expanded={limit > PAGE}
-              onExpand={() => setLimit(EXPANDED)}
-            />
+            <FootballerBreakdown data={data} />
+            <EraAndPools data={data} />
             <ReviewQueue counts={data.review_queue} subject="footballers" />
           </div>
+        )}
+      </ReportPanel>
+
+      <SectionHeader
+        title="The catalogue by nation and team"
+        description="Which rows the catalogue leans on, and where it thins out at the top end."
+      />
+
+      <ReportPanel state={matrix} skeletonClassName="h-[30rem] w-full">
+        {matrixData => (
+          <FootballerMatrix
+            data={matrixData}
+            dimension={dimension}
+            onDimensionChange={(next) => {
+              // Reset the row filters: a search for an Italian club means
+              // nothing once the rows are nations.
+              setDimension(next);
+              setMatrixSearch('');
+              setMatrixDifficulty(null);
+              setMatrixLimit(PAGE);
+            }}
+            search={matrixSearch}
+            onSearchChange={setMatrixSearch}
+            difficulty={matrixDifficulty}
+            onDifficultyChange={setMatrixDifficulty}
+            expanded={matrixLimit > PAGE}
+            onExpand={() => setMatrixLimit(EXPANDED)}
+          />
         )}
       </ReportPanel>
 

--- a/app/analytics/football-data/questions/page.tsx
+++ b/app/analytics/football-data/questions/page.tsx
@@ -56,13 +56,14 @@ export default function QuestionsAnalyticsPage() {
 
   const [limit, setLimit] = useState(PAGE);
   const [search, setSearch] = useState('');
+  const [difficulty, setDifficulty] = useState<string | null>(null);
 
   const bank = useReport(
-    () => ReportsAPI.getQuestionBank({ ...params, limit, search: search || undefined }),
+    () => ReportsAPI.getQuestionBank({ ...params, limit, search: search || undefined, difficulty: difficulty ?? undefined }),
     params,
     enabled,
     'The question bank endpoint',
-    `${limit}:${search}`,
+    `${limit}:${search}:${difficulty ?? ''}`,
   );
 
   const state = useReport(
@@ -96,6 +97,8 @@ export default function QuestionsAnalyticsPage() {
             data={data}
             search={search}
             onSearchChange={setSearch}
+            difficulty={difficulty}
+            onDifficultyChange={setDifficulty}
             expanded={limit > PAGE}
             onExpand={() => setLimit(EXPANDED)}
           />

--- a/components/analytics/__tests__/CategoryMatrix.test.tsx
+++ b/components/analytics/__tests__/CategoryMatrix.test.tsx
@@ -33,7 +33,7 @@ describe('categoryMatrix', () => {
 
     const headers = screen.getAllByRole('columnheader').map(h => h.textContent);
 
-    expect(headers).toEqual(['Category', 'Easy', 'Normal', 'Hard', 'Extreme', 'Total']);
+    expect(headers).toEqual(['Category', 'Easy', 'Normal', 'Hard', 'Extreme', 'Total', 'Added']);
   });
 
   it('shows each cell and the row total', () => {
@@ -65,7 +65,7 @@ describe('categoryMatrix', () => {
 
     const headers = screen.getAllByRole('columnheader').map(h => h.textContent);
 
-    expect(headers).toEqual(['Category', 'Easy', 'Normal', 'Hard', 'Extreme', 'Total']);
+    expect(headers).toEqual(['Category', 'Easy', 'Normal', 'Hard', 'Extreme', 'Total', 'Added']);
   });
 
   it('gives every cell a visible solid fill, not an opacity tint', () => {
@@ -116,7 +116,7 @@ describe('categoryMatrix', () => {
     );
 
     expect(screen.getAllByRole('columnheader').map(h => h.textContent))
-      .toEqual(['Category', 'Easy', 'Normal', 'Hard', 'Extreme', 'Total']);
+      .toEqual(['Category', 'Easy', 'Normal', 'Hard', 'Extreme', 'Total', 'Added']);
   });
 
   it('clears the ranking when the active tier is pressed again', () => {
@@ -146,6 +146,33 @@ describe('categoryMatrix', () => {
 
     expect(cells[0].className).toContain('from-green-900');
     expect(cells[1].className).toContain('from-blue-500');
+  });
+
+  it('shows growth as a signed figure, and a quiet week as a dash', () => {
+    // A column of "+0" reads as a broken feed rather than a week nobody added
+    // anything, and this column exists to answer "is this still being worked on".
+    render(
+      <CategoryMatrix
+        data={data({
+          category_matrix: {
+            items: [
+              { category: 'Growing', slug: 'g', total: 10, by_difficulty: [10, 0, 0, 0], added: 4 },
+              { category: 'Static', slug: 's', total: 10, by_difficulty: [10, 0, 0, 0], added: 0 },
+            ],
+            total: 2,
+            limit: 10,
+          },
+        })}
+        search=""
+        onSearchChange={vi.fn()}
+        difficulty={null}
+        onDifficultyChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('+4')).toBeInTheDocument();
+    expect(screen.queryByText('+0')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Static: 0 added in this window')).toBeInTheDocument();
   });
 
   it('leaves air between the cells', () => {

--- a/components/analytics/__tests__/CategoryMatrix.test.tsx
+++ b/components/analytics/__tests__/CategoryMatrix.test.tsx
@@ -1,5 +1,5 @@
 import type { QuestionBankResponse } from '@/types/reports';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { CategoryMatrix } from '@/components/analytics/panels/CategoryMatrix';
 
@@ -23,13 +23,13 @@ describe('categoryMatrix', () => {
   it('says the rows do not sum to the bank, rather than leaving it to be found', () => {
     // The one figure on the page that deliberately double-counts: most
     // questions carry more than one category.
-    render(<CategoryMatrix data={data()} search="" onSearchChange={vi.fn()} />);
+    render(<CategoryMatrix data={data()} search="" onSearchChange={vi.fn()} difficulty={null} onDifficultyChange={vi.fn()} />);
 
     expect(screen.getByText(/sum to more than the bank holds/)).toBeInTheDocument();
   });
 
   it('lays the difficulties out as columns in order', () => {
-    render(<CategoryMatrix data={data()} search="" onSearchChange={vi.fn()} />);
+    render(<CategoryMatrix data={data()} search="" onSearchChange={vi.fn()} difficulty={null} onDifficultyChange={vi.fn()} />);
 
     const headers = screen.getAllByRole('columnheader').map(h => h.textContent);
 
@@ -37,7 +37,7 @@ describe('categoryMatrix', () => {
   });
 
   it('shows each cell and the row total', () => {
-    render(<CategoryMatrix data={data()} search="" onSearchChange={vi.fn()} />);
+    render(<CategoryMatrix data={data()} search="" onSearchChange={vi.fn()} difficulty={null} onDifficultyChange={vi.fn()} />);
 
     expect(screen.getByText('277')).toBeInTheDocument();
     expect(screen.getByText('113')).toBeInTheDocument();
@@ -45,7 +45,7 @@ describe('categoryMatrix', () => {
   });
 
   it('reports the real category count, not the rows rendered', () => {
-    render(<CategoryMatrix data={data()} search="" onSearchChange={vi.fn()} />);
+    render(<CategoryMatrix data={data()} search="" onSearchChange={vi.fn()} difficulty={null} onDifficultyChange={vi.fn()} />);
 
     expect(screen.getByText('Showing 2 of 2,017')).toBeInTheDocument();
   });
@@ -53,7 +53,7 @@ describe('categoryMatrix', () => {
   it('puts the filter on the card it filters', () => {
     // In the page filter bar it sat beside the date range with nothing to say
     // which panel it applied to. It applies to this table alone.
-    render(<CategoryMatrix data={data()} search="" onSearchChange={vi.fn()} />);
+    render(<CategoryMatrix data={data()} search="" onSearchChange={vi.fn()} difficulty={null} onDifficultyChange={vi.fn()} />);
 
     expect(screen.getByLabelText('Filter categories in this table')).toBeInTheDocument();
   });
@@ -61,7 +61,7 @@ describe('categoryMatrix', () => {
   it('gives each difficulty its own column identity', () => {
     // Difficulty is ordinal, so the columns read cool-to-hot rather than as
     // four unrelated hues — a row is a shape before it is four numbers.
-    render(<CategoryMatrix data={data()} search="" onSearchChange={vi.fn()} />);
+    render(<CategoryMatrix data={data()} search="" onSearchChange={vi.fn()} difficulty={null} onDifficultyChange={vi.fn()} />);
 
     const headers = screen.getAllByRole('columnheader').map(h => h.textContent);
 
@@ -69,7 +69,7 @@ describe('categoryMatrix', () => {
   });
 
   it('gives every cell a visible solid fill, not an opacity tint', () => {
-    const { container } = render(<CategoryMatrix data={data()} search="" onSearchChange={vi.fn()} />);
+    const { container } = render(<CategoryMatrix data={data()} search="" onSearchChange={vi.fn()} difficulty={null} onDifficultyChange={vi.fn()} />);
 
     const cells = container.querySelectorAll('[data-difficulty]:not([data-empty])');
 
@@ -86,11 +86,73 @@ describe('categoryMatrix', () => {
     }
   });
 
+  it('ranks by a tier when one is chosen, and says so', () => {
+    const onDifficultyChange = vi.fn();
+    render(
+      <CategoryMatrix
+        data={data({ difficulty: 'EXTREME' })}
+        search=""
+        onSearchChange={vi.fn()}
+        difficulty="EXTREME"
+        onDifficultyChange={onDifficultyChange}
+      />,
+    );
+
+    expect(screen.getByText(/Ranked by Extreme questions/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Extreme' })).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('keeps every tier visible while ranking by one', () => {
+    // Hiding the other three would answer a different question: "thin at the
+    // top end" only means something against the tiers beside it.
+    render(
+      <CategoryMatrix
+        data={data({ difficulty: 'EXTREME' })}
+        search=""
+        onSearchChange={vi.fn()}
+        difficulty="EXTREME"
+        onDifficultyChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getAllByRole('columnheader').map(h => h.textContent))
+      .toEqual(['Category', 'Easy', 'Normal', 'Hard', 'Extreme', 'Total']);
+  });
+
+  it('clears the ranking when the active tier is pressed again', () => {
+    const onDifficultyChange = vi.fn();
+    render(
+      <CategoryMatrix
+        data={data({ difficulty: 'HARD' })}
+        search=""
+        onSearchChange={vi.fn()}
+        difficulty="HARD"
+        onDifficultyChange={onDifficultyChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hard' }));
+
+    expect(onDifficultyChange).toHaveBeenCalledWith(null);
+  });
+
+  it('alternates the gradient direction along a row', () => {
+    // Neighbours meet light against dark rather than repeating one direction,
+    // which is what makes the seam legible without a border between tiles.
+    const { container } = render(
+      <CategoryMatrix data={data()} search="" onSearchChange={vi.fn()} difficulty={null} onDifficultyChange={vi.fn()} />,
+    );
+    const cells = [...container.querySelectorAll('[data-difficulty]:not([data-empty])')];
+
+    expect(cells[0].className).toContain('from-green-900');
+    expect(cells[1].className).toContain('from-blue-500');
+  });
+
   it('leaves air between the cells', () => {
     // Welded edge to edge they read as one solid block and the eye has to hunt
     // for the boundaries; this is enough to make each a box without breaking
     // the row into four separate things.
-    const { container } = render(<CategoryMatrix data={data()} search="" onSearchChange={vi.fn()} />);
+    const { container } = render(<CategoryMatrix data={data()} search="" onSearchChange={vi.fn()} difficulty={null} onDifficultyChange={vi.fn()} />);
     const table = container.querySelector('table') as HTMLElement;
 
     expect(table.className).toContain('border-spacing-x-1');
@@ -98,7 +160,7 @@ describe('categoryMatrix', () => {
   });
 
   it('animates the cells in rather than blinking them', () => {
-    const { container } = render(<CategoryMatrix data={data()} search="" onSearchChange={vi.fn()} />);
+    const { container } = render(<CategoryMatrix data={data()} search="" onSearchChange={vi.fn()} difficulty={null} onDifficultyChange={vi.fn()} />);
 
     expect(container.querySelectorAll('.animate-data-rise').length).toBeGreaterThan(0);
   });
@@ -109,6 +171,8 @@ describe('categoryMatrix', () => {
         data={data({ search: 'zzz', category_matrix: { items: [], total: 0, limit: 10 } })}
         search="zzz"
         onSearchChange={vi.fn()}
+        difficulty={null}
+        onDifficultyChange={vi.fn()}
       />,
     );
 
@@ -129,6 +193,8 @@ describe('categoryMatrix', () => {
         })}
         search=""
         onSearchChange={vi.fn()}
+        difficulty={null}
+        onDifficultyChange={vi.fn()}
       />,
     );
 

--- a/components/analytics/__tests__/EraAndPools.test.tsx
+++ b/components/analytics/__tests__/EraAndPools.test.tsx
@@ -1,0 +1,66 @@
+import type { CoverageResponse } from '@/types/reports';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { EraAndPools } from '@/components/analytics/panels/EraAndPools';
+
+function data(over: Partial<CoverageResponse> = {}): CoverageResponse {
+  return {
+    eras: [
+      { era: 'Before 1950', by_difficulty: [16, 40, 79, 149], total: 284 },
+      { era: '2000s', by_difficulty: [138, 230, 258, 213], total: 839 },
+    ],
+    game_pools: [
+      { key: 'grid', label: 'Grid', by_difficulty: [955, 1584, 2457, 1728], total: 6724 },
+    ],
+    catalogue: 6729,
+    ...over,
+  } as unknown as CoverageResponse;
+}
+
+describe('eraAndPools', () => {
+  it('renders nothing before the backend ships the fields', () => {
+    const { container } = render(<EraAndPools data={{} as CoverageResponse} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('keeps the oldest bucket named rather than dated', () => {
+    render(<EraAndPools data={data()} />);
+
+    expect(screen.getByText('Before 1950')).toBeInTheDocument();
+    expect(screen.getByText('284')).toBeInTheDocument();
+  });
+
+  it('reads each era as its difficulty split, for anyone who cannot see it', () => {
+    render(<EraAndPools data={data()} />);
+
+    expect(
+      screen.getByRole('img', { name: 'Before 1950: 16 easy, 40 normal, 79 hard, 149 extreme' }),
+    ).toBeInTheDocument();
+  });
+
+  it('says what a pool is a share of', () => {
+    // "6,724" means nothing without the catalogue it is drawn from.
+    render(<EraAndPools data={data()} />);
+
+    expect(screen.getByText(/Of 6,729 approved footballers/)).toBeInTheDocument();
+  });
+
+  it('scales the bars against the biggest row, not each row', () => {
+    // Each row scaled to itself would make every bar full width and say nothing
+    // about size — the 284 era would look like the 839 one.
+    const { container } = render(<EraAndPools data={data()} />);
+    const segments = [...container.querySelectorAll('[role="img"] > span')];
+    const firstEra = segments.slice(0, 4).map(s => Number.parseFloat((s as HTMLElement).style.width));
+
+    // 16 of the largest total (839), not 16 of 284.
+    expect(firstEra[0]).toBeCloseTo((16 / 839) * 100, 1);
+  });
+
+  it('shows one panel when only one has arrived', () => {
+    render(<EraAndPools data={data({ game_pools: undefined })} />);
+
+    expect(screen.getByText('When they were born')).toBeInTheDocument();
+    expect(screen.queryByText('What each game can draw on')).not.toBeInTheDocument();
+  });
+});

--- a/components/analytics/__tests__/FootballerMatrix.test.tsx
+++ b/components/analytics/__tests__/FootballerMatrix.test.tsx
@@ -1,0 +1,76 @@
+import type { DifficultyMatrixResponse } from '@/types/reports';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { FootballerMatrix } from '@/components/analytics/panels/FootballerMatrix';
+
+function data(over: Partial<DifficultyMatrixResponse> = {}): DifficultyMatrixResponse {
+  return {
+    dimension: 'nation',
+    dimension_label: 'Nation',
+    rows_double_count: false,
+    difficulty_order: ['EASY', 'NORMAL', 'HARD', 'EXTREME'],
+    search: null,
+    difficulty: null,
+    matrix: {
+      items: [{ key: '1', name: 'England', total: 467, by_difficulty: [100, 127, 164, 76] }],
+      total: 132,
+      limit: 10,
+    },
+    ...over,
+  } as DifficultyMatrixResponse;
+}
+
+const props = {
+  dimension: 'nation',
+  onDimensionChange: vi.fn(),
+  search: '',
+  onSearchChange: vi.fn(),
+  difficulty: null,
+  onDifficultyChange: vi.fn(),
+};
+
+describe('footballerMatrix', () => {
+  it('says the nation rows add up', () => {
+    render(<FootballerMatrix data={data()} {...props} />);
+
+    expect(screen.getByText(/A footballer has one nation, so these rows add up/)).toBeInTheDocument();
+  });
+
+  it('warns that team rows do NOT add up, and why a squad looks smaller here', () => {
+    // Two things a reader would otherwise take as bugs: the same footballer in
+    // several rows, and a squad count below the one on the teams page.
+    render(
+      <FootballerMatrix
+        data={data({ dimension: 'team', dimension_label: 'Team', rows_double_count: true })}
+        {...props}
+        dimension="team"
+      />,
+    );
+
+    expect(screen.getByText(/belongs to every club they played for/)).toBeInTheDocument();
+    expect(screen.getByText(/Approved footballers only, which is why a squad here is smaller/)).toBeInTheDocument();
+  });
+
+  it('names the row column after the dimension', () => {
+    render(<FootballerMatrix data={data()} {...props} />);
+
+    expect(screen.getAllByRole('columnheader')[0]).toHaveTextContent('Nation');
+  });
+
+  it('switching dimension is a refetch, not a re-slice', () => {
+    const onDimensionChange = vi.fn();
+    render(<FootballerMatrix data={data()} {...props} onDimensionChange={onDimensionChange} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'By team' }));
+
+    expect(onDimensionChange).toHaveBeenCalledWith('team');
+  });
+
+  it('offers a ranking toggle per tier', () => {
+    render(<FootballerMatrix data={data()} {...props} />);
+
+    for (const label of ['Easy', 'Normal', 'Hard', 'Extreme']) {
+      expect(screen.getByRole('button', { name: label })).toBeInTheDocument();
+    }
+  });
+});

--- a/components/analytics/panels/CategoryMatrix.tsx
+++ b/components/analytics/panels/CategoryMatrix.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import type { QuestionBankResponse } from '@/types/reports';
+import { TileMatrix } from '@/components/analytics/panels/TileMatrix';
 import { SearchBox } from '@/components/reports/filters/SearchBox';
-import { CappedList } from '@/components/reports/primitives/CappedList';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { difficultyTier as tier } from '@/lib/data-colours';
 import { cn } from '@/lib/utils';
@@ -92,124 +92,25 @@ export function CategoryMatrix({ data, onExpand, expanded, search, onSearchChang
         </div>
       </CardHeader>
       <CardContent>
-        <CappedList
+        <TileMatrix
+          rows={matrix.items.map(row => ({
+            key: row.slug,
+            name: row.category,
+            total: row.total,
+            by_difficulty: row.by_difficulty,
+            extra: row.added ?? null,
+          }))}
+          order={order}
+          rowHeading="Category"
           total={matrix.total}
           shown={matrix.items.length}
           onExpand={onExpand}
           expanded={expanded}
           emptyLabel={search ? `No category matches "${search}".` : 'No categories carry an approved question.'}
-        >
-          {/* Its own scroller: the matrix is wider than a phone and the page
-              body must never scroll sideways. */}
-          <div className="-mx-2 overflow-x-auto px-2">
-            {/* A hair of space between cells — 4px. Welded edge to edge they
-                read as one solid block and the eye has to hunt for the
-                boundaries; fully separated they float. This is enough to make
-                each a box without breaking the row into four. */}
-            <table className="w-full min-w-[42rem] table-fixed border-separate border-spacing-x-1 border-spacing-y-1.5 text-sm">
-              <thead>
-                <tr>
-                  <th className="sticky left-0 z-10 w-52 bg-card py-1 pr-3 text-left text-xs font-medium text-muted-foreground">
-                    Category
-                  </th>
-                  {order.map(difficulty => (
-                    <th key={difficulty} className="pb-1.5 text-center">
-                      <span className={cn('inline-flex items-center gap-1.5 text-xs font-semibold', tier(difficulty).head)}>
-                        {/* The dot carries the colour into the header, so a
-                            column and its cells are visibly the same thing. */}
-                        <span aria-hidden className={cn('size-1.5 rounded-full', tier(difficulty).dot)} />
-                        {tier(difficulty).label}
-                      </span>
-                    </th>
-                  ))}
-                  <th className="pb-1.5 pl-2 text-center text-xs font-medium text-muted-foreground">Total</th>
-                </tr>
-              </thead>
-              <tbody>
-                {matrix.items.map(row => (
-                  <tr key={row.slug} className="group">
-                    <th
-                      scope="row"
-                      className="sticky left-0 z-10 max-w-48 truncate bg-card py-1 pr-3 text-left font-medium text-foreground transition-colors group-hover:bg-muted/40"
-                      title={row.category}
-                    >
-                      {row.category}
-                    </th>
-                    {row.by_difficulty.map((count, index) => (
-                      <Cell
-                        key={order[index]}
-                        difficulty={order[index]}
-                        count={count}
-                        index={index}
-                      />
-                    ))}
-                    <td className="p-0 pl-2">
-                      {/* The row total gets the same weight as a cell so the
-                          band reads as "these four, and what they come to"
-                          rather than trailing off into plain text. */}
-                      {/* The total is the one figure here that is not a
-                          difficulty, so it stays neutral — and reads as the sum
-                          rather than as a fifth tier. */}
-                      {/* Same height and shape as a difficulty cell so the row
-                          reads as one set of tiles, and centred like them —
-                          right-aligned it drifted away from the band. */}
-                      <span className="flex h-14 items-center justify-center rounded-lg bg-muted/70 text-sm font-bold tabular-nums text-foreground ring-1 ring-inset ring-border">
-                        {row.total.toLocaleString()}
-                      </span>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </CappedList>
+          extraHeading="Added"
+          extraLabel={row => `${row.name}: ${row.extra ?? 0} added in this window`}
+        />
       </CardContent>
     </Card>
-  );
-}
-
-function Cell({ difficulty, count, index }: {
-  difficulty: string;
-  count: number;
-  index: number;
-}) {
-  const style = tier(difficulty);
-
-  // A dash, not a zero. An empty cell is the thing you are looking for, and the
-  // gaps are the reason to read this table — so it keeps the tile's shape while
-  // clearly holding nothing.
-  if (count === 0) {
-    return (
-      <td className="p-0">
-        <span
-          data-difficulty={difficulty}
-          data-empty="true"
-          className="flex h-14 items-center justify-center rounded-lg border border-dashed border-border/70 text-sm text-muted-foreground/40"
-        >
-          —
-        </span>
-      </td>
-    );
-  }
-
-  return (
-    <td className="p-0">
-      <span
-        data-difficulty={difficulty}
-        className={cn(
-          // h-14 against a ~4.5rem column: near enough to square that the row
-          // reads as tiles rather than as a bar chart lying on its side.
-          'flex h-14 items-center justify-center rounded-lg bg-gradient-to-br text-sm font-bold tabular-nums shadow-sm',
-          'animate-data-rise transition-transform duration-150 hover:scale-[1.04]',
-          // Alternating direction: dark-to-colour, then colour-to-dark. Two
-          // neighbours meet light against dark instead of repeating, so the
-          // seam is legible without a border between them.
-          index % 2 === 0 ? style.chip : style.chipAlt,
-        )}
-        style={{ animationDelay: `${Math.min(index, 5) * 45}ms` }}
-      >
-        {count.toLocaleString()}
-      </span>
-    </td>
   );
 }

--- a/components/analytics/panels/CategoryMatrix.tsx
+++ b/components/analytics/panels/CategoryMatrix.tsx
@@ -25,12 +25,15 @@ import { cn } from '@/lib/utils';
  * most need to see the shape of.
  */
 
-export function CategoryMatrix({ data, onExpand, expanded, search, onSearchChange }: {
+export function CategoryMatrix({ data, onExpand, expanded, search, onSearchChange, difficulty, onDifficultyChange }: {
   data: QuestionBankResponse;
   onExpand?: () => void;
   expanded?: boolean;
   search: string;
   onSearchChange: (next: string) => void;
+  /** Rank by one tier, or null for overall size. */
+  difficulty: string | null;
+  onDifficultyChange: (next: string | null) => void;
 }) {
   const { category_matrix: matrix, difficulty_order: order } = data;
 
@@ -45,18 +48,48 @@ export function CategoryMatrix({ data, onExpand, expanded, search, onSearchChang
             A question can carry several categories, so these rows deliberately sum to more
             than the bank holds. Each cell is "questions carrying this category", never a
             share of the total.
+            {difficulty
+              ? ` Ranked by ${tier(difficulty).label} questions — every tier is still shown beside it.`
+              : ' Ranked by total questions.'}
           </CardDescription>
         </div>
         {/* ON the card it filters, not in the page filter bar. Up there it sat
             beside the date range with nothing to say which panel it applied to
             — and it applies to this table alone. */}
-        <SearchBox
-          value={search}
-          onChange={onSearchChange}
-          label="Filter categories in this table"
-          placeholder="Filter these categories…"
-          className="w-full shrink-0 sm:w-56"
-        />
+        <div className="flex shrink-0 flex-col gap-2 sm:items-end">
+          <SearchBox
+            value={search}
+            onChange={onSearchChange}
+            label="Filter categories in this table"
+            placeholder="Filter these categories…"
+            className="w-full sm:w-56"
+          />
+          {/* Ranking, not column-hiding. "Which categories are thin at the top
+              end" is answered by re-ordering the list, not by removing three
+              columns — the other tiers are the context that makes the answer
+              mean anything. */}
+          <div className="flex flex-wrap gap-1" role="group" aria-label="Rank categories by difficulty">
+            {order.map((tierKey) => {
+              const active = difficulty === tierKey;
+              return (
+                <button
+                  key={tierKey}
+                  type="button"
+                  aria-pressed={active}
+                  onClick={() => onDifficultyChange(active ? null : tierKey)}
+                  className={cn(
+                    'rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset transition-colors',
+                    active
+                      ? cn('bg-gradient-to-br text-white ring-transparent', tier(tierKey).chip)
+                      : 'text-muted-foreground ring-border hover:bg-muted',
+                  )}
+                >
+                  {tier(tierKey).label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
       </CardHeader>
       <CardContent>
         <CappedList
@@ -73,10 +106,10 @@ export function CategoryMatrix({ data, onExpand, expanded, search, onSearchChang
                 read as one solid block and the eye has to hunt for the
                 boundaries; fully separated they float. This is enough to make
                 each a box without breaking the row into four. */}
-            <table className="w-full min-w-[38rem] border-separate border-spacing-x-1 border-spacing-y-1.5 text-sm">
+            <table className="w-full min-w-[42rem] table-fixed border-separate border-spacing-x-1 border-spacing-y-1.5 text-sm">
               <thead>
                 <tr>
-                  <th className="sticky left-0 z-10 bg-card py-1 pr-3 text-left text-xs font-medium text-muted-foreground">
+                  <th className="sticky left-0 z-10 w-52 bg-card py-1 pr-3 text-left text-xs font-medium text-muted-foreground">
                     Category
                   </th>
                   {order.map(difficulty => (
@@ -89,7 +122,7 @@ export function CategoryMatrix({ data, onExpand, expanded, search, onSearchChang
                       </span>
                     </th>
                   ))}
-                  <th className="py-1 pl-4 text-right text-xs font-medium text-muted-foreground">Total</th>
+                  <th className="pb-1.5 pl-2 text-center text-xs font-medium text-muted-foreground">Total</th>
                 </tr>
               </thead>
               <tbody>
@@ -110,14 +143,17 @@ export function CategoryMatrix({ data, onExpand, expanded, search, onSearchChang
                         index={index}
                       />
                     ))}
-                    <td className="py-1 pl-4">
+                    <td className="p-0 pl-2">
                       {/* The row total gets the same weight as a cell so the
                           band reads as "these four, and what they come to"
                           rather than trailing off into plain text. */}
                       {/* The total is the one figure here that is not a
                           difficulty, so it stays neutral — and reads as the sum
                           rather than as a fifth tier. */}
-                      <span className="block rounded-lg bg-muted/70 px-3 py-2 text-center text-sm font-bold tabular-nums text-foreground ring-1 ring-inset ring-border">
+                      {/* Same height and shape as a difficulty cell so the row
+                          reads as one set of tiles, and centred like them —
+                          right-aligned it drifted away from the band. */}
+                      <span className="flex h-14 items-center justify-center rounded-lg bg-muted/70 text-sm font-bold tabular-nums text-foreground ring-1 ring-inset ring-border">
                         {row.total.toLocaleString()}
                       </span>
                     </td>
@@ -140,15 +176,15 @@ function Cell({ difficulty, count, index }: {
   const style = tier(difficulty);
 
   // A dash, not a zero. An empty cell is the thing you are looking for, and the
-  // gaps are the reason to read this table — so it keeps its shape in the row
-  // while clearly holding nothing.
+  // gaps are the reason to read this table — so it keeps the tile's shape while
+  // clearly holding nothing.
   if (count === 0) {
     return (
       <td className="p-0">
         <span
           data-difficulty={difficulty}
           data-empty="true"
-          className="block rounded-lg border border-dashed border-border/70 px-3 py-2 text-center text-sm text-muted-foreground/40"
+          className="flex h-14 items-center justify-center rounded-lg border border-dashed border-border/70 text-sm text-muted-foreground/40"
         >
           —
         </span>
@@ -161,12 +197,15 @@ function Cell({ difficulty, count, index }: {
       <span
         data-difficulty={difficulty}
         className={cn(
-          'block rounded-lg px-3 py-2 text-center text-sm font-semibold tabular-nums',
+          // h-14 against a ~4.5rem column: near enough to square that the row
+          // reads as tiles rather than as a bar chart lying on its side.
+          'flex h-14 items-center justify-center rounded-lg bg-gradient-to-br text-sm font-bold tabular-nums shadow-sm',
           'animate-data-rise transition-transform duration-150 hover:scale-[1.04]',
-          style.chip,
+          // Alternating direction: dark-to-colour, then colour-to-dark. Two
+          // neighbours meet light against dark instead of repeating, so the
+          // seam is legible without a border between them.
+          index % 2 === 0 ? style.chip : style.chipAlt,
         )}
-        // Staggered across the row so a refetched table fills left to right
-        // rather than flashing all at once.
         style={{ animationDelay: `${Math.min(index, 5) * 45}ms` }}
       >
         {count.toLocaleString()}

--- a/components/analytics/panels/EraAndPools.tsx
+++ b/components/analytics/panels/EraAndPools.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import type { CoverageResponse } from '@/types/reports';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { difficultyTier } from '@/lib/data-colours';
+import { cn } from '@/lib/utils';
+
+/**
+ * When the catalogue's footballers were born, and what each game may use.
+ *
+ * Two panels that share a shape — a row per bucket, split by difficulty — and
+ * answer questions the tier counts alone cannot.
+ *
+ * The era chart is the more interesting of the two: it shows whether "hard" has
+ * quietly become a synonym for "old". Locally it partly has, and that is a
+ * content decision nobody made on purpose.
+ */
+export function EraAndPools({ data }: { data: CoverageResponse }) {
+  const { eras, game_pools: pools, catalogue } = data;
+
+  // The BE may not carry these yet — the repositories deploy independently.
+  if (!eras && !pools) {
+    return null;
+  }
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-2">
+      {eras && eras.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>When they were born</CardTitle>
+            <CardDescription>
+              Whether the catalogue skews modern — and whether "hard" is really standing in
+              for "old". Everything before 1950 is one bucket; those decades hold a handful each.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <StackedRows
+              rows={eras.map(era => ({ label: era.era, parts: era.by_difficulty, total: era.total }))}
+            />
+          </CardContent>
+        </Card>
+      )}
+
+      {pools && pools.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>What each game can draw on</CardTitle>
+            <CardDescription>
+              {catalogue
+                ? `Of ${catalogue.toLocaleString()} approved footballers, how many each game is allowed to use — a full catalogue with an empty Extreme tier still cannot serve a hard round.`
+                : 'How many approved footballers each game is allowed to use.'}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <StackedRows
+              rows={pools.map(pool => ({ label: pool.label, parts: pool.by_difficulty, total: pool.total }))}
+            />
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+/**
+ * One row per bucket: the label, the total, and the difficulty split as a
+ * single segmented bar.
+ *
+ * Segmented rather than four bars per row because the question is composition —
+ * how this decade divides — and four separate bars make the reader add up to
+ * see the whole. Each segment is scaled against the LARGEST row so rows stay
+ * comparable; scaling each to its own width would make every row full and say
+ * nothing about size.
+ */
+function StackedRows({ rows }: { rows: { label: string; parts: number[]; total: number }[] }) {
+  const order = ['EASY', 'NORMAL', 'HARD', 'EXTREME'];
+  const largest = Math.max(...rows.map(row => row.total), 1);
+
+  return (
+    <dl className="space-y-2.5">
+      {rows.map(row => (
+        <div key={row.label} className="space-y-1">
+          <div className="flex items-baseline justify-between gap-2">
+            <dt className="text-sm text-muted-foreground">{row.label}</dt>
+            <dd className="text-sm font-medium tabular-nums text-foreground">{row.total.toLocaleString()}</dd>
+          </div>
+          <div
+            className="flex h-3 w-full gap-px overflow-hidden rounded-full"
+            role="img"
+            aria-label={`${row.label}: ${order.map((tier, index) => `${row.parts[index]} ${difficultyTier(tier).label.toLowerCase()}`).join(', ')}`}
+          >
+            {row.parts.map((count, index) => (
+              <span
+                key={order[index]}
+                className={cn('h-full first:rounded-l-full last:rounded-r-full', difficultyTier(order[index]).bar)}
+                // Widths are shares of the LARGEST row, so a short row stays
+                // short. The row's own total would make every bar full-width.
+                style={{ width: `${(count / largest) * 100}%` }}
+              />
+            ))}
+            {/* The remainder, so the track shows how far short of the biggest
+                row this one falls. */}
+            <span className="h-full flex-1 bg-foreground/[0.06]" />
+          </div>
+        </div>
+      ))}
+    </dl>
+  );
+}

--- a/components/analytics/panels/FootballerBreakdown.tsx
+++ b/components/analytics/panels/FootballerBreakdown.tsx
@@ -2,29 +2,23 @@
 
 import type { CoverageResponse } from '@/types/reports';
 import { CareerSplit } from '@/components/analytics/charts/CareerSplit';
-import { CappedList } from '@/components/reports/primitives/CappedList';
 import { DataBar } from '@/components/reports/primitives/DataBar';
-import { ReportTable } from '@/components/reports/primitives/ReportTable';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { CAREER_STATE } from '@/lib/data-colours';
 
 /**
- * Who is adding footballers, and how many of them have stopped playing.
+ * How much of the catalogue has stopped playing, overall and per tier.
  *
- * Contributors is footballers ONLY. `Footballer` is the single model of the
- * three that records who added it — `Team` and `Nation` carry no author — so
- * presenting this as catalogue-wide authorship would credit one person with
- * work the schema cannot attribute.
+ * The contributor list that used to sit beside this was dropped: only
+ * `Footballer` records who added it, so it could never describe the catalogue,
+ * and "one account added 86% of these" is a fact you act on once rather than
+ * watch. Era and per-game pools took the space.
  */
-export function FootballerBreakdown({ data, onExpand, expanded }: {
-  data: CoverageResponse;
-  onExpand?: () => void;
-  expanded?: boolean;
-}) {
-  const { contributors, career_state: careerState } = data;
+export function FootballerBreakdown({ data }: { data: CoverageResponse }) {
+  const { career_state: careerState } = data;
 
-  // The BE may not carry these yet — the repositories deploy independently.
-  if (!contributors && !careerState) {
+  // The BE may not carry this yet — the repositories deploy independently.
+  if (!careerState) {
     return null;
   }
 
@@ -32,41 +26,7 @@ export function FootballerBreakdown({ data, onExpand, expanded }: {
   const retiredPct = total ? Math.round((careerState!.retired / total) * 1000) / 10 : null;
 
   return (
-    <div className="grid gap-4 lg:grid-cols-2">
-      {contributors && (
-        <Card>
-          <CardHeader>
-            <CardTitle>Who added them</CardTitle>
-            <CardDescription>
-              Footballers only — teams and nations do not record who added them, so this is
-              not the whole catalogue.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <CappedList
-              total={contributors.total}
-              shown={contributors.items.length}
-              onExpand={onExpand}
-              expanded={expanded}
-              emptyLabel="No footballer records who added it."
-            >
-              <ReportTable>
-                <tbody>
-                  {contributors.items.map(row => (
-                    <tr key={row.username} className="border-b last:border-0">
-                      <td className="py-1.5 pr-4 text-sm text-foreground">{row.username}</td>
-                      <td className="py-1.5 text-right text-sm font-medium tabular-nums text-foreground">
-                        {row.footballers.toLocaleString()}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </ReportTable>
-            </CappedList>
-          </CardContent>
-        </Card>
-      )}
-
+    <div className="grid gap-4">
       {careerState && (
         <Card>
           <CardHeader>

--- a/components/analytics/panels/FootballerMatrix.tsx
+++ b/components/analytics/panels/FootballerMatrix.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import type { DifficultyMatrixResponse } from '@/types/reports';
+import { TileMatrix } from '@/components/analytics/panels/TileMatrix';
+import { SearchBox } from '@/components/reports/filters/SearchBox';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { difficultyTier as tier } from '@/lib/data-colours';
+import { cn } from '@/lib/utils';
+
+/**
+ * Approved footballers by nation or team, split by difficulty.
+ *
+ * The same table as the question matrix, asking the same question of a
+ * different row: is this one thin at the top end. Switching dimension refetches
+ * rather than re-slicing, because the two are different queries — a nation row
+ * counts each footballer once, a team row counts them per club.
+ */
+const DIMENSIONS = [
+  { key: 'nation', label: 'By nation' },
+  { key: 'team', label: 'By team' },
+];
+
+export function FootballerMatrix({ data, dimension, onDimensionChange, search, onSearchChange, difficulty, onDifficultyChange, onExpand, expanded }: {
+  data: DifficultyMatrixResponse;
+  dimension: string;
+  onDimensionChange: (next: string) => void;
+  search: string;
+  onSearchChange: (next: string) => void;
+  difficulty: string | null;
+  onDifficultyChange: (next: string | null) => void;
+  onExpand?: () => void;
+  expanded?: boolean;
+}) {
+  const { matrix, difficulty_order: order } = data;
+
+  return (
+    <Card>
+      <CardHeader className="gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-1.5">
+          <CardTitle>{`Footballers by ${data.dimension} and difficulty`}</CardTitle>
+          <CardDescription>
+            {data.rows_double_count
+              // Said outright, because the same footballer legitimately appears
+              // in several rows here and the column will not add up.
+              ? 'A footballer belongs to every club they played for, so these rows deliberately sum to more than the catalogue holds. Approved footballers only, which is why a squad here is smaller than on the teams page.'
+              : 'A footballer has one nation, so these rows add up. Approved footballers only.'}
+            {difficulty
+              ? ` Ranked by ${tier(difficulty).label} — every tier is still shown beside it.`
+              : ' Ranked by total.'}
+          </CardDescription>
+        </div>
+        <div className="flex shrink-0 flex-col gap-2 sm:items-end">
+          <div className="flex gap-1" role="group" aria-label="Group footballers by">
+            {DIMENSIONS.map(option => (
+              <button
+                key={option.key}
+                type="button"
+                aria-pressed={dimension === option.key}
+                onClick={() => onDimensionChange(option.key)}
+                className={cn(
+                  'rounded-md px-2.5 py-1 text-xs font-medium ring-1 ring-inset transition-colors',
+                  dimension === option.key
+                    ? 'bg-primary text-primary-foreground ring-transparent'
+                    : 'text-muted-foreground ring-border hover:bg-muted',
+                )}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+          <SearchBox
+            value={search}
+            onChange={onSearchChange}
+            label={`Filter ${data.dimension}s in this table`}
+            placeholder={`Filter these ${data.dimension}s…`}
+            className="w-full sm:w-56"
+          />
+          <div className="flex flex-wrap gap-1" role="group" aria-label="Rank by difficulty">
+            {order.map((tierKey) => {
+              const active = difficulty === tierKey;
+              return (
+                <button
+                  key={tierKey}
+                  type="button"
+                  aria-pressed={active}
+                  onClick={() => onDifficultyChange(active ? null : tierKey)}
+                  className={cn(
+                    'rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset transition-colors',
+                    active
+                      ? cn('bg-gradient-to-br text-white ring-transparent', tier(tierKey).chip)
+                      : 'text-muted-foreground ring-border hover:bg-muted',
+                  )}
+                >
+                  {tier(tierKey).label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <TileMatrix
+          rows={matrix.items}
+          order={order}
+          rowHeading={data.dimension_label}
+          total={matrix.total}
+          shown={matrix.items.length}
+          onExpand={onExpand}
+          expanded={expanded}
+          emptyLabel={search ? `No ${data.dimension} matches "${search}".` : `No ${data.dimension} has an approved footballer.`}
+        />
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/analytics/panels/TileMatrix.tsx
+++ b/components/analytics/panels/TileMatrix.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { CappedList } from '@/components/reports/primitives/CappedList';
+import { difficultyTier as tier } from '@/lib/data-colours';
+import { cn } from '@/lib/utils';
+
+/**
+ * A row-label column, four difficulty tiles, and a total.
+ *
+ * Extracted when the third caller appeared. Questions by category, footballers
+ * by nation and footballers by team are the same table asking the same question
+ * of three different rows — "is this one thin at the top end" — and a
+ * comparison ACROSS a row is what a matrix is for. Three copies would have
+ * drifted the way the difficulty colours already did once.
+ *
+ * The caller owns the card, the copy and the controls; this owns the grid.
+ */
+export type TileRow = {
+  key: string;
+  name: string;
+  total: number;
+  /** Counts positionally matching `order`. */
+  by_difficulty: number[];
+  /** An extra figure after the total — growth, say. */
+  extra?: number | null;
+};
+
+export function TileMatrix({ rows, order, rowHeading, total, shown, onExpand, expanded, emptyLabel, extraHeading, extraLabel }: {
+  rows: TileRow[];
+  order: string[];
+  /**
+   * What the row labels ARE — "Category", "Nation", "Team". A generic "Name"
+   *  makes the reader work out what they are looking at.
+   */
+  rowHeading: string;
+  total: number;
+  shown: number;
+  onExpand?: () => void;
+  expanded?: boolean;
+  emptyLabel: string;
+  /** Column heading for `extra`. Omit and the column is not rendered. */
+  extraHeading?: string;
+  /** How to read one `extra` value, for assistive tech. */
+  extraLabel?: (row: TileRow) => string;
+}): ReactNode {
+  return (
+    <CappedList
+      total={total}
+      shown={shown}
+      onExpand={onExpand}
+      expanded={expanded}
+      emptyLabel={emptyLabel}
+    >
+      {/* Its own scroller: the matrix is wider than a phone and the page body
+          must never scroll sideways. */}
+      <div className="-mx-2 overflow-x-auto px-2">
+        <table className="w-full min-w-[42rem] table-fixed border-separate border-spacing-x-1 border-spacing-y-1.5 text-sm">
+          <thead>
+            <tr>
+              <th className="sticky left-0 z-10 w-52 bg-card py-1 pr-3 text-left text-xs font-medium text-muted-foreground">
+                {rowHeading}
+              </th>
+              {order.map(difficulty => (
+                <th key={difficulty} className="pb-1.5 text-center">
+                  <span className={cn('inline-flex items-center gap-1.5 text-xs font-semibold', tier(difficulty).head)}>
+                    {/* The dot carries the colour into the header, so a column
+                        and its tiles are visibly the same thing. */}
+                    <span aria-hidden className={cn('size-1.5 rounded-full', tier(difficulty).dot)} />
+                    {tier(difficulty).label}
+                  </span>
+                </th>
+              ))}
+              <th className="pb-1.5 pl-2 text-center text-xs font-medium text-muted-foreground">Total</th>
+              {extraHeading && (
+                <th className="pb-1.5 pl-2 text-center text-xs font-medium text-muted-foreground">{extraHeading}</th>
+              )}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map(row => (
+              <tr key={row.key} className="group">
+                <th
+                  scope="row"
+                  className="sticky left-0 z-10 max-w-52 truncate bg-card py-1 pr-3 text-left font-medium text-foreground transition-colors group-hover:bg-muted/40"
+                  title={row.name}
+                >
+                  {row.name}
+                </th>
+                {row.by_difficulty.map((count, index) => (
+                  <Tile key={order[index]} difficulty={order[index]} count={count} index={index} />
+                ))}
+                <td className="p-0 pl-2">
+                  {/* Same height and shape as a tile so the row reads as one
+                      set, and centred with them. */}
+                  <span className="flex h-14 items-center justify-center rounded-lg bg-muted/70 text-sm font-bold tabular-nums text-foreground ring-1 ring-inset ring-border">
+                    {row.total.toLocaleString()}
+                  </span>
+                </td>
+                {extraHeading && (
+                  <td className="p-0 pl-2">
+                    <span
+                      className={cn(
+                        'flex h-14 items-center justify-center rounded-lg text-sm font-semibold tabular-nums ring-1 ring-inset',
+                        row.extra
+                          ? 'bg-emerald-500/10 text-emerald-600 ring-emerald-500/30 dark:text-emerald-400'
+                          : 'text-muted-foreground/40 ring-border',
+                      )}
+                      aria-label={extraLabel?.(row)}
+                    >
+                      {/* Nothing added is a dash, not a zero: a column of zeros
+                          reads as a broken feed rather than a quiet week. */}
+                      {row.extra ? `+${row.extra.toLocaleString()}` : '—'}
+                    </span>
+                  </td>
+                )}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </CappedList>
+  );
+}
+
+function Tile({ difficulty, count, index }: { difficulty: string; count: number; index: number }) {
+  const style = tier(difficulty);
+
+  // A dash, not a zero. An empty tier is the thing you are looking for, and the
+  // gaps are the reason to read this table — so it keeps the tile's shape while
+  // clearly holding nothing.
+  if (count === 0) {
+    return (
+      <td className="p-0">
+        <span
+          data-difficulty={difficulty}
+          data-empty="true"
+          className="flex h-14 items-center justify-center rounded-lg border border-dashed border-border/70 text-sm text-muted-foreground/40"
+        >
+          —
+        </span>
+      </td>
+    );
+  }
+
+  return (
+    <td className="p-0">
+      <span
+        data-difficulty={difficulty}
+        className={cn(
+          'flex h-14 items-center justify-center rounded-lg bg-gradient-to-br text-sm font-bold tabular-nums shadow-sm',
+          'animate-data-rise transition-transform duration-150 hover:scale-[1.04]',
+          // Alternating direction: dark-to-colour, then colour-to-dark. Two
+          // neighbours meet light against dark instead of repeating, so the
+          // seam is legible without a border between them.
+          index % 2 === 0 ? style.chip : style.chipAlt,
+        )}
+        style={{ animationDelay: `${Math.min(index, 5) * 45}ms` }}
+      >
+        {count.toLocaleString()}
+      </span>
+    </td>
+  );
+}

--- a/lib/data-colours.ts
+++ b/lib/data-colours.ts
@@ -30,8 +30,13 @@ export type DataTier = {
   /** The bar's own rail, in its own hue. A neutral grey rail reads as chrome. */
   track: string;
   /**
-   * A matrix cell: a soft tint of the hue, with the number in a strong shade of
-   * the SAME hue and a hairline ring around it.
+   * A matrix cell: dark at one end of the gradient, the hue at the other.
+   *
+   * `chip` runs dark to colour, `chipAlt` runs colour to dark, and the matrix
+   * alternates them across a row. Neighbouring cells meet light-against-dark
+   * rather than repeating one direction, which gives the band a rhythm instead
+   * of four identical tiles — and the seam between two cells stops needing a
+   * border to be legible.
    *
    * The saturated version read as shouting — four blocks of full-strength
    * colour side by side, competing with the numbers they were meant to carry.
@@ -52,6 +57,8 @@ export type DataTier = {
    * for more colour, or drop the ring to 100 for less.
    */
   chip: string;
+  /** The same fill with the gradient reversed. Alternated along a row. */
+  chipAlt: string;
   /** Text colour for a column header. */
   head: string;
   /** Solid dot carrying the colour into a legend or header. */
@@ -75,7 +82,8 @@ export const DIFFICULTY_TIERS: Record<string, DataTier> = {
     label: 'Easy',
     bar: 'bg-gradient-to-r from-green-400 to-green-500',
     track: 'bg-green-400/20',
-    chip: 'bg-gradient-to-br from-green-50 to-green-100 text-green-700 ring-1 ring-inset ring-green-200 dark:from-green-900/60 dark:to-green-800/60 dark:text-green-200 dark:ring-green-700/60',
+    chip: 'from-green-900 to-green-500 text-green-50 ring-1 ring-inset ring-green-400/30',
+    chipAlt: 'from-green-500 to-green-900 text-green-50 ring-1 ring-inset ring-green-400/30',
     head: 'text-green-600 dark:text-green-400',
     dot: 'bg-green-400',
     hex: '#22c55e',
@@ -84,7 +92,8 @@ export const DIFFICULTY_TIERS: Record<string, DataTier> = {
     label: 'Normal',
     bar: 'bg-gradient-to-r from-blue-400 to-blue-500',
     track: 'bg-blue-400/20',
-    chip: 'bg-gradient-to-br from-blue-50 to-blue-100 text-blue-700 ring-1 ring-inset ring-blue-200 dark:from-blue-900/60 dark:to-blue-800/60 dark:text-blue-200 dark:ring-blue-700/60',
+    chip: 'from-blue-900 to-blue-500 text-blue-50 ring-1 ring-inset ring-blue-400/30',
+    chipAlt: 'from-blue-500 to-blue-900 text-blue-50 ring-1 ring-inset ring-blue-400/30',
     head: 'text-blue-600 dark:text-blue-400',
     dot: 'bg-blue-400',
     hex: '#3b82f6',
@@ -93,7 +102,8 @@ export const DIFFICULTY_TIERS: Record<string, DataTier> = {
     label: 'Hard',
     bar: 'bg-gradient-to-r from-orange-400 to-orange-500',
     track: 'bg-orange-400/20',
-    chip: 'bg-gradient-to-br from-orange-50 to-orange-100 text-orange-700 ring-1 ring-inset ring-orange-200 dark:from-orange-900/60 dark:to-orange-800/60 dark:text-orange-200 dark:ring-orange-700/60',
+    chip: 'from-orange-900 to-orange-500 text-orange-50 ring-1 ring-inset ring-orange-400/30',
+    chipAlt: 'from-orange-500 to-orange-900 text-orange-50 ring-1 ring-inset ring-orange-400/30',
     head: 'text-orange-600 dark:text-orange-400',
     dot: 'bg-orange-400',
     hex: '#f97316',
@@ -102,7 +112,8 @@ export const DIFFICULTY_TIERS: Record<string, DataTier> = {
     label: 'Extreme',
     bar: 'bg-gradient-to-r from-red-400 to-red-500',
     track: 'bg-red-400/20',
-    chip: 'bg-gradient-to-br from-red-50 to-red-100 text-red-700 ring-1 ring-inset ring-red-200 dark:from-red-900/60 dark:to-red-800/60 dark:text-red-200 dark:ring-red-700/60',
+    chip: 'from-red-900 to-red-500 text-red-50 ring-1 ring-inset ring-red-400/30',
+    chipAlt: 'from-red-500 to-red-900 text-red-50 ring-1 ring-inset ring-red-400/30',
     head: 'text-red-600 dark:text-red-400',
     dot: 'bg-red-400',
     hex: '#ef4444',
@@ -114,6 +125,7 @@ const UNKNOWN_TIER: DataTier = {
   label: '',
   bar: 'bg-muted-foreground/40',
   track: 'bg-muted-foreground/10',
+  chipAlt: 'bg-muted text-foreground',
   chip: 'bg-muted text-foreground',
   head: 'text-muted-foreground',
   dot: 'bg-muted-foreground',

--- a/lib/reports-api.ts
+++ b/lib/reports-api.ts
@@ -5,6 +5,7 @@ import type {
   CareerPathAnalyticsResponse,
   ContentResponse,
   CoverageResponse,
+  DifficultyMatrixResponse,
   DifficultyResponse,
   DurationResponse,
   FallbacksResponse,
@@ -35,7 +36,15 @@ import { apiFetcher } from '@/lib/api-fetcher';
  * `include_bots` is passed through even when false: the BE echoes the resolved
  * filters back, and being explicit keeps request and response readable together.
  */
-function buildQuery(params?: ReportParams): string {
+/**
+ * Query string from a flat param bag.
+ *
+ * Typed as a plain record rather than `ReportParams` because not every endpoint
+ * is range-filtered — the catalogue matrices take a dimension and a limit and
+ * have no window at all. Widening `ReportParams` to fit them would have made
+ * them look range-filtered to `reports.guard.ts`, which is the opposite of true.
+ */
+function buildQuery(params?: Record<string, string | number | boolean | null | undefined>): string {
   if (!params) {
     return '';
   }
@@ -163,6 +172,21 @@ export class ReportsAPI {
   /** GET /core/analytics/football-data/teams/ — empty teams and the review queue. */
   static async getTeamGaps(limit?: number, search?: string): Promise<TeamGapsResponse> {
     return apiFetcher<TeamGapsResponse>(`core/analytics/football-data/teams/${buildQuery({ limit, search })}`);
+  }
+
+  /**
+   * GET /core/analytics/football-data/matrix/ — footballers by nation or team,
+   * split by difficulty. No range: this is the catalogue as it stands.
+   */
+  static async getDifficultyMatrix(
+    dimension: string,
+    limit?: number,
+    search?: string,
+    difficulty?: string,
+  ): Promise<DifficultyMatrixResponse> {
+    return apiFetcher<DifficultyMatrixResponse>(
+      `core/analytics/football-data/matrix/${buildQuery({ dimension, limit, search, difficulty })}`,
+    );
   }
 
   /** GET /core/analytics/football-data/questions/ — the question bank as data. */

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -213,6 +213,8 @@ export type ReportParams = {
   granularity?: Granularity;
   /** Username fragment, case-insensitive. Narrows who is counted, not who survives. */
   search?: string;
+  /** Rank the question matrix by one tier. Rejected server-side if unknown. */
+  difficulty?: string;
 };
 
 /**
@@ -1219,6 +1221,8 @@ export type QuestionBankResponse = {
   }>;
   difficulty_order: string[];
   search: string | null;
+  /** Echoed, so a rejected filter cannot look as if it applied. */
+  difficulty: string | null;
 } & ResolvedRange;
 
 export type CatalogueTotals = {

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -1146,11 +1146,6 @@ export type CoverageResponse = {
   totals?: CatalogueTotals;
   added_series?: CatalogueAddedPoint[];
   difficulty_tiers?: DifficultyTier[];
-  /**
-   * Who added the footballers. Only `Footballer` records this — Team and
-   *  Nation carry no author — so it is not catalogue-wide authorship.
-   */
-  contributors?: CappedRows<{ username: string; footballers: number }>;
   career_state?: {
     retired: number;
     active: number;
@@ -1162,6 +1157,12 @@ export type CoverageResponse = {
     by_difficulty?: { difficulty: string; retired: number; active: number }[];
   };
   review_queue?: ReviewQueue;
+  /** Footballers by decade of birth. Optional until the BE ships. */
+  eras?: EraRow[];
+  /** What each game may actually draw on, by tier. */
+  game_pools?: GamePool[];
+  /** Approved footballers overall, for reading the pools against. */
+  catalogue?: number;
 } & ResolvedRange;
 
 /**
@@ -1218,12 +1219,46 @@ export type QuestionBankResponse = {
     total: number;
     /** Counts in `difficulty_order`, positionally. */
     by_difficulty: number[];
+    /**
+     * Questions added to this category in the window, approved or not.
+     *  Optional: a backend predating it shows no column rather than zeros.
+     */
+    added?: number;
   }>;
   difficulty_order: string[];
   search: string | null;
   /** Echoed, so a rejected filter cannot look as if it applied. */
   difficulty: string | null;
 } & ResolvedRange;
+
+export type DifficultyMatrixResponse = {
+  dimension: string;
+  dimension_label: string;
+  matrix: CappedRows<{
+    key: string;
+    name: string;
+    total: number;
+    by_difficulty: number[];
+  }>;
+  difficulty_order: string[];
+  search: string | null;
+  difficulty: string | null;
+  /**
+   * True when a row can contain the same footballer more than once — a team
+   * row does, because a footballer belongs to every club they played for. A
+   * nation row does not.
+   */
+  rows_double_count: boolean;
+};
+
+export type EraRow = { era: string; by_difficulty: number[]; total: number };
+
+export type GamePool = {
+  key: string;
+  label: string;
+  by_difficulty: number[];
+  total: number;
+};
 
 export type CatalogueTotals = {
   /**


### PR DESCRIPTION

ONE TILE TABLE, THREE CALLERS

`TileMatrix` came out when the third caller appeared. Questions by category,
footballers by nation and footballers by team are the same table asking the same
question of different rows, and three copies would have drifted exactly the way
the difficulty colours already did once. The caller owns the card, the copy and
the controls; the component owns the grid.

Its row heading is caller-supplied rather than a generic "Name" — a reader
should not have to work out what they are looking at.

CATEGORY GROWTH

An "Added" column on the question matrix. Until now the date picker moved the
totals above the table and left the table untouched, which reads as a filter
that is broken rather than one that does not apply.

Nothing added shows a dash, not "+0". A column of zeros reads as a broken feed
rather than a quiet week, and this column exists to answer "is this still being
worked on".

ERA AND POOLS, REPLACING "WHO ADDED THEM"

Footballers by decade of birth, split by difficulty — it says whether "hard" has
quietly become a synonym for "old", which locally it partly has. And what each
game may actually draw on, which the availability flags never reported in
aggregate.

Both are segmented bars scaled against the LARGEST row, not each row: scaling
each to itself makes every bar full width and says nothing about size.

The contributor list is gone from the payload as well as the page. Only
`Footballer` records who added it, so it could never describe the catalogue, and
`response-fields-used` correctly failed when it was left being sent and no
longer rendered — an endpoint shipping a figure nobody displays is a query per
request for nothing.

NATION AND TEAM MATRIX

Above coverage, below the career split, switchable between nation and team and
rankable by tier. Switching dimension refetches rather than re-slicing, and
clears the row filters — a search for an Italian club means nothing once the
rows are nations.

The copy states the thing a reader would otherwise take as two bugs: team rows
double-count, because a footballer belongs to every club they played for, and a
squad here is smaller than on the teams page because this counts approved
footballers only.

`buildQuery` now takes a plain param record rather than `ReportParams`. Widening
`ReportParams` would have made these no-window endpoints look range-filtered to
`reports.guard.ts`, which is the opposite of true.

Five mutations checked: scaling era rows to themselves, dropping the era bar's
description, rendering "+0" instead of a dash, and hiding the team
double-count warning.

Refs https://github.com/FootballExtraTime/App/issues/1474

Also carries the dark alternating tiles and the difficulty ranking control: #143 was merged at an earlier commit, so those two commits were left on the old branch and are rebased onto production here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)