### PR TITLE
Page and filter the hardest categories, collapse the answer split

### DIFF
--- a/components/analytics/__tests__/CategoryQuality.test.tsx
+++ b/components/analytics/__tests__/CategoryQuality.test.tsx
@@ -1,0 +1,90 @@
+import type { QuestionsAnalyticsResponse } from '@/types/reports';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { CategoryQuality } from '@/components/analytics/panels/CategoryQuality';
+
+function rows(count: number) {
+  return Array.from({ length: count }, (_, index) => ({
+    category_id: index,
+    name: `Cat${index}`,
+    questions: 10,
+    questions_answered: 10,
+    answers: 100,
+    // Ascending rate: the BE sends hardest first and this preserves that.
+    correct_pct: 20 + index,
+  }));
+}
+
+function data(count: number): QuestionsAnalyticsResponse {
+  return {
+    categories: { rows: rows(count), min_answers: 30, categories_measured: count },
+  } as unknown as QuestionsAnalyticsResponse;
+}
+
+describe('categoryQuality', () => {
+  it('shows ten rows and offers the rest', () => {
+    render(<CategoryQuality data={data(40)} />);
+
+    expect(screen.getAllByRole('row')).toHaveLength(11); // header + 10
+    expect(screen.getByText('Showing 10 of 40')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Show 30 more' })).toBeInTheDocument();
+  });
+
+  it('expands to the whole list', () => {
+    render(<CategoryQuality data={data(40)} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show 30 more' }));
+
+    expect(screen.getAllByRole('row')).toHaveLength(41);
+    expect(screen.queryByText(/Showing/)).not.toBeInTheDocument();
+  });
+
+  it('offers nothing to expand when the list already fits', () => {
+    // "10 of 10" is noise.
+    render(<CategoryQuality data={data(6)} />);
+
+    expect(screen.queryByText(/Showing/)).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Show/ })).not.toBeInTheDocument();
+  });
+
+  it('keeps the hardest first, which is the point of the panel', () => {
+    render(<CategoryQuality data={data(40)} />);
+
+    const first = screen.getAllByRole('row')[1];
+
+    expect(first).toHaveTextContent('Cat0');
+    expect(first).toHaveTextContent('20%');
+  });
+
+  /** The filter is debounced, so a change only lands after the pause. */
+  function type(value: string) {
+    vi.useFakeTimers();
+    try {
+      fireEvent.change(screen.getByLabelText('Filter categories in this table'), {
+        target: { value },
+      });
+      act(() => void vi.advanceTimersByTime(400));
+    } finally {
+      vi.useRealTimers();
+    }
+  }
+
+  it('counts the FILTERED list, not the whole one', () => {
+    // Offering "of 40" while a search is active would promise rows that are not
+    // there.
+    render(<CategoryQuality data={data(40)} />);
+
+    type('Cat1');
+
+    // Cat1 and Cat10..Cat19 — eleven matches, so ten shown and one more.
+    expect(screen.getByText('Showing 10 of 11')).toBeInTheDocument();
+  });
+
+  it('says which search found nothing', () => {
+    render(<CategoryQuality data={data(40)} />);
+
+    type('zzz');
+
+    expect(screen.getByText('No category matches "zzz".')).toBeInTheDocument();
+  });
+});

--- a/components/analytics/__tests__/QuestionsAnalytics.test.tsx
+++ b/components/analytics/__tests__/QuestionsAnalytics.test.tsx
@@ -1,5 +1,5 @@
 import type { QuestionRow, QuestionsAnalyticsResponse } from '@/types/reports';
-import { render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { CategoryQuality } from '@/components/analytics/panels/CategoryQuality';
 import { GlobalQuizUsage } from '@/components/analytics/panels/GlobalQuizUsage';
@@ -73,10 +73,43 @@ function response(rows: QuestionRow[], over: Partial<QuestionsAnalyticsResponse[
 }
 
 describe('questionQuality', () => {
+  /**
+   * The answer split is collapsed by default — it is the heaviest DOM on the
+   * page and sits under a summary that already says whether it is worth opening.
+   * Tests that assert on the list have to open it, which is the point.
+   */
+  function openSplit() {
+    fireEvent.click(screen.getByRole('button', { name: /answer split/ }));
+  }
+
+  it('keeps the split collapsed until asked', () => {
+    render(<QuestionQuality data={response([question({ question_id: 1, text: 'How many goals?' })])} />);
+
+    expect(screen.queryByText('How many goals?')).not.toBeInTheDocument();
+    // The summary stays visible: it is the reason to open the panel at all.
+    expect(screen.getByText('Need a look')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Show the answer split for 1 question/ }))
+      .toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('renders the list only once opened, and hides it again', () => {
+    render(<QuestionQuality data={response([question({ question_id: 1, text: 'How many goals?' })])} />);
+
+    openSplit();
+
+    expect(screen.getByText('How many goals?')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Hide the answer split/ }));
+
+    expect(screen.queryByText('How many goals?')).not.toBeInTheDocument();
+  });
+
   it('marks a question a wrong option won', () => {
     // The finding. Without it the row is just a low correct rate, which a hard
     // question produces too.
     render(<QuestionQuality data={response([question({ question_id: 1, text: 'How many goals?' })])} />);
+
+    openSplit();
 
     expect(screen.getByText('A wrong option won')).toBeInTheDocument();
     expect(screen.getByText('How many goals?')).toBeInTheDocument();
@@ -88,6 +121,8 @@ describe('questionQuality', () => {
     // without reading the answer.
     render(<QuestionQuality data={response([question({ question_id: 1, text: 'How many goals?' })])} />);
 
+    openSplit();
+
     expect(screen.getByText('One goal')).toBeInTheDocument();
     expect(screen.getByText('A hat-trick')).toBeInTheDocument();
   });
@@ -96,6 +131,8 @@ describe('questionQuality', () => {
     // The split IS the evidence: 75/25 across two options is a different
     // question from 25/25/25/25, and both have the same correct rate.
     render(<QuestionQuality data={response([question({ question_id: 1, text: 'Q' })])} />);
+
+    openSplit();
 
     expect(screen.getByText('75%')).toBeInTheDocument();
     expect(screen.getByText('25%')).toBeInTheDocument();
@@ -127,6 +164,8 @@ describe('questionQuality', () => {
       />,
     );
 
+    openSplit();
+
     expect(screen.getByText('33.3% ran out of time')).toBeInTheDocument();
   });
 
@@ -149,6 +188,8 @@ describe('questionQuality', () => {
       />,
     );
 
+    openSplit();
+
     expect(screen.getByText('31 ran out of time')).toBeInTheDocument();
     expect(screen.queryByText(/null%/)).not.toBeInTheDocument();
   });
@@ -156,11 +197,15 @@ describe('questionQuality', () => {
   it('leads with how many need a look', () => {
     render(<QuestionQuality data={response([question({ question_id: 1, text: 'Q' })])} />);
 
+    openSplit();
+
     expect(screen.getByText('Need a look')).toBeInTheDocument();
   });
 
   it('says nothing was rated rather than showing an empty list', () => {
     render(<QuestionQuality data={response([])} />);
+
+    openSplit();
 
     expect(screen.getByText('No question was answered enough times to rate.')).toBeInTheDocument();
   });

--- a/components/analytics/panels/CategoryQuality.tsx
+++ b/components/analytics/panels/CategoryQuality.tsx
@@ -1,9 +1,12 @@
 'use client';
 
 import type { QuestionsAnalyticsResponse } from '@/types/reports';
+import { useMemo, useState } from 'react';
+import { SearchBox } from '@/components/reports/filters/SearchBox';
 import { EmptyState } from '@/components/reports/primitives/EmptyState';
 import { MetricInfo } from '@/components/reports/primitives/MetricInfo';
 import { ReportHead, ReportRow, ReportTable, Td, Th } from '@/components/reports/primitives/ReportTable';
+import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
 
@@ -18,19 +21,46 @@ import { cn } from '@/lib/utils';
 /** Below this, a category is harder than the bank's own EXTREME tier. */
 const HARD_PCT = 50;
 
+/** Rows shown before asking for the rest. The BE caps the payload at 40. */
+const PAGE = 10;
+
 export function CategoryQuality({ data }: { data: QuestionsAnalyticsResponse }) {
   const { rows, min_answers: minAnswers, categories_measured: measured } = data.categories;
+  const [search, setSearch] = useState('');
+  const [expanded, setExpanded] = useState(false);
+
+  // Filtered and sliced HERE rather than server-side: the payload is already
+  // capped at 40 rows, so a round trip per keystroke would buy nothing and cost
+  // a spinner. The rows arrive sorted hardest-first, which is this panel's whole
+  // job — re-sorting client-side would only let the two disagree.
+  const matching = useMemo(() => {
+    const needle = search.trim().toLowerCase();
+    return needle ? rows.filter(row => row.name.toLowerCase().includes(needle)) : rows;
+  }, [rows, search]);
+  const visible = expanded ? matching : matching.slice(0, PAGE);
 
   return (
     <Card>
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2">
-          Which categories are hardest
-          <MetricInfo metric="category_correct_rate" />
-        </CardTitle>
-        <CardDescription>
-          {`${measured.toLocaleString()} categories were answered at least ${minAnswers} times. The rest of the bank's 2,017 are a handful of questions about one footballer, which is why the list stops here rather than listing them all.`}
-        </CardDescription>
+      <CardHeader className="gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-1.5">
+          <CardTitle className="flex items-center gap-2">
+            Which categories are hardest
+            <MetricInfo metric="category_correct_rate" />
+          </CardTitle>
+          <CardDescription>
+            {`${measured.toLocaleString()} categories were answered at least ${minAnswers} times. The rest of the bank's 2,017 are a handful of questions about one footballer, which is why the list stops here rather than listing them all.`}
+            {' Lowest correct rate first — that is the order, not a column you pick.'}
+          </CardDescription>
+        </div>
+        {/* On the card it filters. Narrows the list only; the count above still
+            describes the whole measured set. */}
+        <SearchBox
+          value={search}
+          onChange={setSearch}
+          label="Filter categories in this table"
+          placeholder="Filter these categories…"
+          className="w-full shrink-0 sm:w-56"
+        />
       </CardHeader>
       <CardContent className="overflow-x-auto">
         {rows.length === 0
@@ -39,48 +69,69 @@ export function CategoryQuality({ data }: { data: QuestionsAnalyticsResponse }) 
                 No category was answered enough times to rate.
               </EmptyState>
             )
-          : (
-              <ReportTable>
-                <ReportHead>
-                  <Th>Category</Th>
-                  <Th align="right" title="Questions in this category that were answered in the window">Questions</Th>
-                  <Th align="right">Answers</Th>
-                  <Th align="right">Correct</Th>
-                </ReportHead>
-                <tbody>
-                  {rows.map(row => (
-                    <ReportRow key={row.category_id}>
-                      <Td strong>{row.name}</Td>
-                      {/* Both counts, because they answer different questions.
+          : matching.length === 0
+            ? <p className="text-sm text-muted-foreground">{`No category matches "${search}".`}</p>
+            : (
+                <ReportTable>
+                  <ReportHead>
+                    <Th>Category</Th>
+                    <Th align="right" title="Questions in this category that were answered in the window">Questions</Th>
+                    <Th align="right">Answers</Th>
+                    <Th align="right">Correct</Th>
+                  </ReportHead>
+                  <tbody>
+                    {visible.map(row => (
+                      <ReportRow key={row.category_id}>
+                        <Td strong>{row.name}</Td>
+                        {/* Both counts, because they answer different questions.
                           `questions` is what a fix would cost — four is an
                           afternoon, forty is a project — and `questions_answered`
                           is how much of the category the rate is actually about.
                           A question nobody was served is invisible to the rate
                           and still has to be rewritten. */}
-                      <Td align="right" className="text-muted-foreground">
-                        {row.questions.toLocaleString()}
-                        {row.questions_answered < row.questions && (
-                          <span className="mt-0.5 block text-xs">
-                            {`${row.questions_answered.toLocaleString()} served`}
-                          </span>
-                        )}
-                      </Td>
-                      <Td align="right">{row.answers.toLocaleString()}</Td>
-                      <Td
-                        align="right"
-                        strong
-                        className={cn(
-                          row.correct_pct !== null && row.correct_pct < HARD_PCT
-                          && 'text-amber-600 dark:text-amber-500',
-                        )}
-                      >
-                        {row.correct_pct === null ? '—' : `${row.correct_pct}%`}
-                      </Td>
-                    </ReportRow>
-                  ))}
-                </tbody>
-              </ReportTable>
-            )}
+                        <Td align="right" className="text-muted-foreground">
+                          {row.questions.toLocaleString()}
+                          {row.questions_answered < row.questions && (
+                            <span className="mt-0.5 block text-xs">
+                              {`${row.questions_answered.toLocaleString()} served`}
+                            </span>
+                          )}
+                        </Td>
+                        <Td align="right">{row.answers.toLocaleString()}</Td>
+                        <Td
+                          align="right"
+                          strong
+                          className={cn(
+                            row.correct_pct !== null && row.correct_pct < HARD_PCT
+                            && 'text-amber-600 dark:text-amber-500',
+                          )}
+                        >
+                          {row.correct_pct === null ? '—' : `${row.correct_pct}%`}
+                        </Td>
+                      </ReportRow>
+                    ))}
+                  </tbody>
+                </ReportTable>
+              )}
+
+        {/* Only when there is more. "10 of 10" is noise, and the count describes
+            the FILTERED list — saying "of 40" while a search is active would
+            offer rows that are not there. */}
+        {matching.length > visible.length && (
+          <div className="flex items-center gap-3 pt-2">
+            <p className="text-xs text-muted-foreground">
+              {`Showing ${visible.length} of ${matching.length.toLocaleString()}`}
+            </p>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-auto px-2 py-0.5 text-xs"
+              onClick={() => setExpanded(true)}
+            >
+              {`Show ${(matching.length - visible.length).toLocaleString()} more`}
+            </Button>
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/components/analytics/panels/QuestionQuality.tsx
+++ b/components/analytics/panels/QuestionQuality.tsx
@@ -1,9 +1,12 @@
 'use client';
 
 import type { QuestionRow, QuestionsAnalyticsResponse } from '@/types/reports';
+import { ChevronDown } from 'lucide-react';
+import { useState } from 'react';
 import { EmptyState } from '@/components/reports/primitives/EmptyState';
 import { MetricInfo } from '@/components/reports/primitives/MetricInfo';
 import { MetricRow } from '@/components/reports/primitives/MetricRow';
+import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
 
@@ -75,6 +78,7 @@ function OptionBar({ option, suspect }: { option: QuestionRow['options'][number]
 export function QuestionQuality({ data }: { data: QuestionsAnalyticsResponse }) {
   const { rows, min_answers: minAnswers, questions_measured: measured } = data.quality;
   const suspect = data.quality.beaten_by_a_wrong_answer;
+  const [open, setOpen] = useState(false);
 
   return (
     <Card>
@@ -90,6 +94,9 @@ export function QuestionQuality({ data }: { data: QuestionsAnalyticsResponse }) 
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
+        {/* The summary stays out of the collapse: "how many need a look" is the
+            reason to open this at all, and hiding it would make the reader expand
+            the panel to find out whether it was worth expanding. */}
         <MetricRow
           columns={3}
           metrics={[
@@ -103,61 +110,83 @@ export function QuestionQuality({ data }: { data: QuestionsAnalyticsResponse }) 
           ]}
         />
 
-        {rows.length === 0
-          ? (
-              <EmptyState hint="Try a wider date range.">
-                No question was answered enough times to rate.
-              </EmptyState>
-            )
-          : (
-              <ul className="space-y-4">
-                {rows.map(row => (
-                  <li key={row.question_id} className="space-y-2 rounded-md border p-3">
-                    <div className="flex flex-wrap items-start justify-between gap-2">
-                      <p className="min-w-0 flex-1 text-sm font-medium">{row.text}</p>
-                      {row.beaten_by_a_wrong_answer && (
-                        <span
-                          className="shrink-0 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900/40 dark:text-amber-300"
-                          title="More players chose one wrong option than the keyed answer, by more than chance"
-                        >
-                          A wrong option won
-                        </span>
-                      )}
-                    </div>
+        {/* Collapsed by default, and the list is not RENDERED until it opens.
+            It is one bordered block plus four labelled bars per question, which
+            is the heaviest DOM on the page — and it sits under a summary that
+            already says whether anything needs attention.
 
-                    <div className="space-y-1">
-                      {row.options.map(option => (
-                        <OptionBar
-                          key={option.option}
-                          option={option}
-                          suspect={option.option === row.top_wrong_option && row.beaten_by_a_wrong_answer}
-                        />
-                      ))}
-                    </div>
+            A render deferral rather than a fetch one: this data arrives with the
+            page payload, so there is no request left to postpone. Splitting it
+            onto its own endpoint would make the payload smaller too, and is the
+            obvious next step if the page ever feels slow to arrive. */}
+        <Button
+          variant="outline"
+          size="sm"
+          className="w-full justify-between"
+          aria-expanded={open}
+          onClick={() => setOpen(value => !value)}
+        >
+          <span>{open ? 'Hide the answer split' : `Show the answer split for ${rows.length.toLocaleString()} questions`}</span>
+          <ChevronDown className={cn('size-4 transition-transform', open && 'rotate-180')} />
+        </Button>
 
-                    <p className="flex flex-wrap gap-x-3 text-xs text-muted-foreground">
-                      <span>{`${row.answered.toLocaleString()} answered`}</span>
-                      {row.difficulty && <span>{`graded ${row.difficulty.toLowerCase()}`}</span>}
-                      {/* Timeouts sit here rather than in the bars: they carry
+        {!open
+          ? null
+          : rows.length === 0
+            ? (
+                <EmptyState hint="Try a wider date range.">
+                  No question was answered enough times to rate.
+                </EmptyState>
+              )
+            : (
+                <ul className="space-y-4">
+                  {rows.map(row => (
+                    <li key={row.question_id} className="space-y-2 rounded-md border p-3">
+                      <div className="flex flex-wrap items-start justify-between gap-2">
+                        <p className="min-w-0 flex-1 text-sm font-medium">{row.text}</p>
+                        {row.beaten_by_a_wrong_answer && (
+                          <span
+                            className="shrink-0 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900/40 dark:text-amber-300"
+                            title="More players chose one wrong option than the keyed answer, by more than chance"
+                          >
+                            A wrong option won
+                          </span>
+                        )}
+                      </div>
+
+                      <div className="space-y-1">
+                        {row.options.map(option => (
+                          <OptionBar
+                            key={option.option}
+                            option={option}
+                            suspect={option.option === row.top_wrong_option && row.beaten_by_a_wrong_answer}
+                          />
+                        ))}
+                      </div>
+
+                      <p className="flex flex-wrap gap-x-3 text-xs text-muted-foreground">
+                        <span>{`${row.answered.toLocaleString()} answered`}</span>
+                        {row.difficulty && <span>{`graded ${row.difficulty.toLowerCase()}`}</span>}
+                        {/* Timeouts sit here rather than in the bars: they carry
                           whatever option was highlighted when the clock ran out,
                           so they are not a choice — but a question that times
                           out often may simply be too long to read. */}
-                      {row.timeouts > 0 && (
-                        <span title="Answers submitted when the clock ran out — not counted as choices above">
-                          {/* The count when the share is missing: a question
+                        {row.timeouts > 0 && (
+                          <span title="Answers submitted when the clock ran out — not counted as choices above">
+                            {/* The count when the share is missing: a question
                               where EVERY answer timed out has no deliberate
                               denominator, and `null%` is worse than a raw
                               number (Copilot on #128). */}
-                          {row.timeout_pct === null
-                            ? `${row.timeouts.toLocaleString()} ran out of time`
-                            : `${row.timeout_pct}% ran out of time`}
-                        </span>
-                      )}
-                    </p>
-                  </li>
-                ))}
-              </ul>
-            )}
+                            {row.timeout_pct === null
+                              ? `${row.timeouts.toLocaleString()} ran out of time`
+                              : `${row.timeout_pct}% ran out of time`}
+                          </span>
+                        )}
+                      </p>
+                    </li>
+                  ))}
+                </ul>
+              )}
       </CardContent>
     </Card>
   );


### PR DESCRIPTION

WHICH CATEGORIES ARE HARDEST

Ten rows with a name filter and a "show N more", where it previously printed all
forty at once.

No backend change was needed, and finding that out changed the design: the
endpoint ALREADY sorts by correct rate ascending — hardest first — and caps the
payload at forty while reporting the true measured count. So the sort I was going
to add existed, and the filtering belongs client-side: a round trip per keystroke
over forty rows already in memory buys nothing and costs a spinner.

The description now says the order outright ("lowest correct rate first — that is
the order, not a column you pick"), because a ranked list whose ranking is
unstated reads as arbitrary.

The count describes the FILTERED list. Saying "10 of 40" with a search active
would offer rows that are not there.

WHAT PLAYERS ACTUALLY CHOSE

Collapsed, and the list is not RENDERED until it opens — one bordered block plus
four labelled bars per question is the heaviest DOM on the page.

The summary row stays OUTSIDE the collapse. "How many need a look" is the reason
to open the panel at all, and hiding it would make someone expand the thing to
find out whether it was worth expanding.

A render deferral, not a fetch one, and worth being precise about: this data
arrives with the page payload, so there is no request left to postpone. Splitting
the answer distribution onto its own endpoint would shrink the payload too, and is
the obvious next step if the page ever feels slow to arrive — say the word.

Four mutations checked: removing the paging, counting the unfiltered list,
rendering the split unconditionally, and hiding the summary inside the collapse.

Refs https://github.com/FootballExtraTime/App/issues/1474

🤖 Generated with [Claude Code](https://claude.com/claude-code)