### PR TITLE
Squad depth becomes a table you can walk into

### DIFF
--- a/app/analytics/football-data/teams/page.tsx
+++ b/app/analytics/football-data/teams/page.tsx
@@ -7,27 +7,37 @@ import { TeamGaps } from '@/components/analytics/panels/TeamGaps';
 import { AnalyticsShell } from '@/components/analytics/shell/AnalyticsShell';
 import { ReportPanel } from '@/components/reports/primitives/ReportPanel';
 import { useReport } from '@/hooks/use-report';
+import { useTeamTable } from '@/hooks/use-team-table';
 import { useAuth } from '@/lib/auth';
 import { ReportsAPI } from '@/lib/reports-api';
 
-const PAGE = 10;
+/** What the gap worklist expands to. The ranking pages instead. */
 const EXPANDED = 100;
 
 /** Team coverage. No date filter — see the nations page for why. */
 export default function TeamsAnalyticsPage() {
   const { isAuthenticated, user } = useAuth();
   const enabled = isAuthenticated && !!(user?.is_staff || user?.is_superuser);
-  const [limit, setLimit] = useState(PAGE);
-  const [search, setSearch] = useState('');
+  const table = useTeamTable();
+  // The endpoint takes ONE limit for both lists, so the ranking's page size is
+  // also the gap list's cap. Expanding the worklist therefore sets the page
+  // size — coupled at the API, and worth splitting there rather than papering
+  // over it here.
+  const [expanded, setExpanded] = useState(false);
 
   const state = useReport(
-    () => ReportsAPI.getTeamGaps(limit, search || undefined),
+    () => ReportsAPI.getTeamGaps(
+      table.limit,
+      table.search || undefined,
+      table.page,
+      table.ordering,
+    ),
     {},
     enabled,
     'The team gaps endpoint',
-    // Both are part of the fetch identity: without them, typing or asking for
-    // more would not refetch.
-    `${limit}:${search}`,
+    // Every value the request is built from. Drop one and the control that
+    // changes it stops refetching — see `use-team-table`.
+    table.requestKey,
   );
 
   return (
@@ -40,10 +50,16 @@ export default function TeamsAnalyticsPage() {
         {data => (
           <SquadDepth
             data={data}
-            search={search}
-            onSearchChange={setSearch}
-            expanded={limit > PAGE}
-            onExpand={() => setLimit(EXPANDED)}
+            search={table.search}
+            onSearchChange={table.setSearch}
+            ordering={table.ordering}
+            onSort={table.sortBy}
+            onPageChange={table.setPage}
+            onLimitChange={(next) => {
+              setExpanded(next >= EXPANDED);
+              table.setLimit(next);
+            }}
+            busy={state.isLoading}
           />
         )}
       </ReportPanel>
@@ -51,7 +67,14 @@ export default function TeamsAnalyticsPage() {
       <ReportPanel state={state} skeletonClassName="h-80 w-full">
         {data => (
           <div className="space-y-4">
-            <TeamGaps data={data} expanded={limit > PAGE} onExpand={() => setLimit(EXPANDED)} />
+            <TeamGaps
+              data={data}
+              expanded={expanded}
+              onExpand={() => {
+                setExpanded(true);
+                table.setLimit(EXPANDED);
+              }}
+            />
             <ReviewQueue counts={data.review_queue} subject="teams" />
           </div>
         )}

--- a/app/team-players/page.tsx
+++ b/app/team-players/page.tsx
@@ -8,8 +8,8 @@ import type {
   TransferFilter,
 } from '@/types/team';
 import { LayoutGrid, List, Users2 } from 'lucide-react';
-import { useRouter } from 'next/navigation';
-import { useEffect, useMemo, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Suspense, useEffect, useMemo, useRef, useState } from 'react';
 import { LoadingSpinner } from '@/components/loading-spinner';
 import { LoginForm } from '@/components/login-form';
 import { Navigation } from '@/components/navigation';
@@ -32,12 +32,18 @@ import { useDebouncedValue } from '@/hooks/use-debounced-value';
 import { useAuth } from '@/lib/auth';
 import config from '@/lib/config';
 import { TeamAPI } from '@/lib/team-api';
+import { parseTeamId } from '@/lib/team-id-param';
 
 const PAGE_SIZE = 50;
 
-export default function TeamPlayersPage() {
+function TeamPlayers() {
   const { isLoading, isAuthenticated } = useAuth();
   const router = useRouter();
+  const searchParams = useSearchParams();
+  // Consumed once. The URL is a starting point, not a binding — picking a
+  // different team from the search box must not be undone by a re-render
+  // reading the original id back out of the query string.
+  const consumedTeamIdParam = useRef(false);
 
   // ---- selected team + payload ------------------------------------------
   const [teamId, setTeamId] = useState<number | null>(null);
@@ -56,6 +62,22 @@ export default function TeamPlayersPage() {
   const [view, setView] = useState<'cards' | 'table'>('table');
 
   // ---- effects -----------------------------------------------------------
+  // Deep-link entry point for `/team-players?teamId=<id>`. The teams analytics
+  // page links every row and every empty-team chip here, which is the point of
+  // that page: a club with a thin or missing squad is one click from the screen
+  // where you fix it.
+  useEffect(() => {
+    if (consumedTeamIdParam.current || !isAuthenticated) {
+      return;
+    }
+    const fromUrl = parseTeamId(searchParams?.get('teamId'));
+    if (fromUrl === null) {
+      return;
+    }
+    consumedTeamIdParam.current = true;
+    setTeamId(fromUrl);
+  }, [isAuthenticated, searchParams]);
+
   useEffect(() => {
     if (teamId === null) {
       return;
@@ -128,6 +150,13 @@ export default function TeamPlayersPage() {
   function handleTeamSelect(id: number) {
     setTeamId(id);
     setError(null);
+    // Keep the address bar honest. Arriving by deep link and then picking a
+    // different team would otherwise leave the URL naming the previous club,
+    // so a refresh or a shared link would land somewhere else than the screen.
+    // Marked consumed first, so the resulting `searchParams` change cannot
+    // re-enter the deep-link effect.
+    consumedTeamIdParam.current = true;
+    router.replace(`/team-players?teamId=${id}`);
   }
 
   function handleEditFootballer(footballerId: number) {
@@ -301,5 +330,19 @@ export default function TeamPlayersPage() {
         )}
       </div>
     </div>
+  );
+}
+
+/**
+ * `useSearchParams` suspends, and a client page that reads it without a
+ * boundary makes the whole route bail out of prerendering — a build error in
+ * Next 16, not a runtime one. The fallback is what the page already shows while
+ * it works out who you are.
+ */
+export default function TeamPlayersPage() {
+  return (
+    <Suspense fallback={<LoadingSpinner message="Loading" subtitle="Preparing team lookup..." />}>
+      <TeamPlayers />
+    </Suspense>
   );
 }

--- a/components/analytics/NationFlag.tsx
+++ b/components/analytics/NationFlag.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { mediaUrl } from '@/lib/media-url';
+import { cn } from '@/lib/utils';
+
+/**
+ * A nation's flag, beside the nation's name.
+ *
+ * The reliable half of a team's identity: 230 of 233 active nations carry a
+ * flag against 8.5% of clubs carrying a crest, so this is what actually makes
+ * a row recognisable at a glance.
+ *
+ * Nothing is rendered when there is no flag — no placeholder, no held-open box.
+ * At three nations out of 233 a gap marker would draw more attention than the
+ * gap deserves, and the name is right next to it either way.
+ *
+ * Plain `<img>` rather than `next/image`, as in `TeamCrest`: a staff-only
+ * dashboard has nothing to gain from optimisation that would cost a
+ * remote-pattern entry in `next.config.mjs` and per-image Vercel billing.
+ */
+export function NationFlag({ flag, className }: {
+  flag: string | null | undefined;
+  className?: string;
+}) {
+  const src = mediaUrl(flag);
+  if (!src) {
+    return null;
+  }
+
+  return (
+    // eslint-disable-next-line next/no-img-element -- deliberate, see above
+    <img
+      src={src}
+      // Decorative: the nation's name is rendered next to it by every caller.
+      alt=""
+      loading="lazy"
+      className={cn('h-3 w-[1.125rem] shrink-0 rounded-[2px] object-cover ring-1 ring-inset ring-border/60', className)}
+    />
+  );
+}

--- a/components/analytics/TeamCrest.tsx
+++ b/components/analytics/TeamCrest.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useState } from 'react';
+import { mediaUrl } from '@/lib/media-url';
+import { cn } from '@/lib/utils';
+
+/** The first letter of the first two words — "Manchester United" → "MU". */
+function initials(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map(word => word[0]?.toUpperCase() ?? '')
+    .join('');
+}
+
+/**
+ * A club's crest, or the tile that stands in for it.
+ *
+ * Built fallback-first on purpose. 377 of 4,455 approved teams carry a badge —
+ * 8.5% — so the initials tile is what most of this table renders, and treating
+ * it as the error path would leave nine rows in ten looking broken. The image
+ * is the bonus layered on top, and it steps aside again if it fails to load:
+ * a column of broken-image glyphs is worse than a column of tidy monograms.
+ *
+ * Plain `<img>` rather than `next/image`. This is a staff-only dashboard, so
+ * there is nothing to gain from optimisation that would justify a remote-pattern
+ * entry in `next.config.mjs` and per-image Vercel billing.
+ */
+export function TeamCrest({ name, badge, className }: {
+  name: string;
+  /** Path or URL from the API. Null for most teams. */
+  badge: string | null;
+  className?: string;
+}) {
+  const [failed, setFailed] = useState(false);
+  const src = failed ? null : mediaUrl(badge);
+
+  return (
+    <span
+      className={cn(
+        'flex size-8 shrink-0 items-center justify-center overflow-hidden rounded-md',
+        'bg-muted text-[0.65rem] font-semibold text-muted-foreground ring-1 ring-inset ring-border',
+        className,
+      )}
+    >
+      {src
+        ? (
+            // eslint-disable-next-line next/no-img-element -- deliberate, see above
+            <img
+              src={src}
+              // Decorative: the club name sits next to it in every caller, and
+              // an alt here would have a screen reader say it twice.
+              alt=""
+              loading="lazy"
+              className="size-full object-contain"
+              onError={() => setFailed(true)}
+            />
+          )
+        : (
+            <span aria-hidden>{initials(name)}</span>
+          )}
+    </span>
+  );
+}

--- a/components/analytics/__tests__/NationFlag.test.tsx
+++ b/components/analytics/__tests__/NationFlag.test.tsx
@@ -1,0 +1,29 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { NationFlag } from '@/components/analytics/NationFlag';
+
+describe('nationFlag', () => {
+  it('renders the flag against the API origin, lazily', () => {
+    const { container } = render(<NationFlag flag="/media/nation_flags/italy-flag.png" />);
+
+    const img = container.querySelector('img');
+
+    expect(img).toHaveAttribute('loading', 'lazy');
+    expect(img?.getAttribute('src')).not.toBe('/media/nation_flags/italy-flag.png');
+    expect(img?.getAttribute('src')).toContain('/media/nation_flags/italy-flag.png');
+  });
+
+  it('renders nothing at all when the nation has no flag', () => {
+    // 230 of 233 nations have one, so this is rare — and an empty box held open
+    // for the three that do not would be more visible than the gap it marks.
+    const { container } = render(<NationFlag flag={null} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('is decorative — the nation name sits beside it', () => {
+    const { container } = render(<NationFlag flag="/media/nation_flags/italy-flag.png" />);
+
+    expect(container.querySelector('img')).toHaveAttribute('alt', '');
+  });
+});

--- a/components/analytics/__tests__/SquadDepth.test.tsx
+++ b/components/analytics/__tests__/SquadDepth.test.tsx
@@ -1,5 +1,5 @@
 import type { TeamGapsResponse } from '@/types/reports';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { SquadDepth } from '@/components/analytics/panels/SquadDepth';
 import { TeamGaps } from '@/components/analytics/panels/TeamGaps';
@@ -8,23 +8,40 @@ function data(over: Partial<TeamGapsResponse> = {}): TeamGapsResponse {
   return {
     teams_by_players: {
       items: [
-        { name: 'Inter', nation: 'Italy', players: 352 },
-        { name: 'Milan', nation: 'Italy', players: 338 },
+        {
+          id: 11,
+          name: 'Inter',
+          nation: 'Italy',
+          flag: '/media/nation_flags/italy-flag.png',
+          badge: '/media/team_badges/inter.svg',
+          players: 352,
+        },
+        { id: 12, name: 'Milan', nation: 'Italy', flag: null, badge: null, players: 338 },
       ],
       total: 4402,
       limit: 10,
+      page: 1,
+      pages: 441,
     },
     teams_without_footballers: {
-      items: [{ name: 'Empty FC', nation: null }],
+      items: [{ id: 90, name: 'Empty FC', nation: null, flag: null, badge: null }],
       total: 53,
       limit: 10,
     },
     review_queue: {},
+    ordering: 'players',
     ...over,
-  } as unknown as TeamGapsResponse;
+  } as TeamGapsResponse;
 }
 
-const props = { search: '', onSearchChange: vi.fn() };
+const props = {
+  search: '',
+  onSearchChange: vi.fn(),
+  ordering: 'players' as const,
+  onSort: vi.fn(),
+  onPageChange: vi.fn(),
+  onLimitChange: vi.fn(),
+};
 
 describe('squadDepth', () => {
   it('carries its own filter, on the card it narrows', () => {
@@ -35,29 +52,91 @@ describe('squadDepth', () => {
     expect(screen.getByLabelText('Filter teams in this table')).toBeInTheDocument();
   });
 
-  it('numbers the rows, so a position means something', () => {
-    render(<SquadDepth data={data()} {...props} />);
+  it('numbers rows by their place in the whole table, not in the page', () => {
+    // Row one of page five is row 41. Numbering from one on every page would
+    // say the opposite of what a ranked table is for.
+    render(
+      <SquadDepth
+        data={data({
+          teams_by_players: { ...data().teams_by_players!, page: 5, limit: 10 },
+        })}
+        {...props}
+      />,
+    );
 
-    const items = screen.getAllByRole('listitem');
+    const rows = screen.getAllByRole('row').slice(1); // drop the header row
 
-    expect(items[0]).toHaveTextContent('1');
-    expect(items[0]).toHaveTextContent('Inter');
-    expect(items[1]).toHaveTextContent('2');
+    expect(within(rows[0]).getByText('41')).toBeInTheDocument();
+    expect(within(rows[1]).getByText('42')).toBeInTheDocument();
   });
 
-  it('names the nation, and says so when there is none', () => {
+  it('shows the squad size as the figure, with no bar', () => {
+    // The bar compared ten rows against the biggest of the ten. Across 441
+    // pages there is no "the biggest on screen" worth comparing against, and
+    // the count is the answer anyway.
     render(<SquadDepth data={data()} {...props} />);
 
-    // Both rows are Italian, so there are two.
-    expect(screen.getAllByText('Italy')).toHaveLength(2);
+    expect(screen.getByText('352')).toBeInTheDocument();
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+  });
+
+  it('sends every row to the squad behind it', () => {
+    render(<SquadDepth data={data()} {...props} />);
+
+    expect(screen.getByRole('link', { name: /Inter/ })).toHaveAttribute(
+      'href',
+      '/team-players?teamId=11',
+    );
+  });
+
+  it('marks the sorted column and sorts through the server', () => {
+    // Sorting the fetched page in the browser would order ten rows out of
+    // 4,402 and read as broken the moment there is a page two.
+    const onSort = vi.fn();
+    render(<SquadDepth data={data()} {...props} onSort={onSort} />);
+
+    const header = screen.getByRole('columnheader', { name: /Players/ });
+
+    expect(header).toHaveAttribute('aria-sort', 'descending');
+
+    fireEvent.click(within(header).getByRole('button'));
+
+    expect(onSort).toHaveBeenCalledWith('players');
+  });
+
+  it('marks the name column when that is what the server sorted by', () => {
+    render(<SquadDepth data={data()} {...props} ordering="name" />);
+
+    expect(screen.getByRole('columnheader', { name: /Team/ })).toHaveAttribute(
+      'aria-sort',
+      'ascending',
+    );
+    expect(screen.getByRole('columnheader', { name: /Players/ })).not.toHaveAttribute('aria-sort');
+  });
+
+  it('offers the page sizes the endpoint will actually serve', () => {
+    // 100 is MAX_LIST_LIMIT server-side; anything larger comes back clamped,
+    // so a bigger option would be a control that lies about what it did.
+    render(<SquadDepth data={data()} {...props} />);
+
+    expect(screen.getByLabelText('Rows per page')).toBeInTheDocument();
+  });
+
+  it('pages through the whole table rather than expanding once', () => {
+    render(<SquadDepth data={data()} {...props} />);
+
+    expect(screen.getByText('Showing 2 of 4402 results')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Show 90 more/ })).not.toBeInTheDocument();
   });
 
   it('says which search found nothing', () => {
     render(
       <SquadDepth
-        data={data({ teams_by_players: { items: [], total: 0, limit: 10 } })}
+        data={data({
+          teams_by_players: { items: [], total: 0, limit: 10, page: 1, pages: 1 },
+        })}
+        {...props}
         search="zzz"
-        onSearchChange={vi.fn()}
       />,
     );
 
@@ -79,6 +158,34 @@ describe('teamGaps', () => {
 
     expect(screen.getByText('Empty FC')).toBeInTheDocument();
     expect(screen.getByText('No nation')).toBeInTheDocument();
+  });
+
+  it('makes an empty team one click from the screen that fills it', () => {
+    render(<TeamGaps data={data()} />);
+
+    expect(screen.getByRole('link', { name: /Empty FC/ })).toHaveAttribute(
+      'href',
+      '/team-players?teamId=90',
+    );
+  });
+
+  it('still lists a team the API has not given an id yet', () => {
+    // The ids arrive in a later backend deploy than this page. A chip with no
+    // id is a chip you cannot click, not a chip that disappears.
+    render(
+      <TeamGaps
+        data={data({
+          teams_without_footballers: {
+            items: [{ name: 'Idless FC', nation: 'Spain' }],
+            total: 1,
+            limit: 10,
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByText('Idless FC')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
 
   it('reports the real gap, not the chips shown', () => {

--- a/components/analytics/__tests__/TeamCrest.test.tsx
+++ b/components/analytics/__tests__/TeamCrest.test.tsx
@@ -1,0 +1,69 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { TeamCrest } from '@/components/analytics/TeamCrest';
+
+// Queried directly rather than through `getByRole('img')`: the badge is
+// decorative and carries `alt=""`, which puts it under the `presentation` role.
+// A `queryByRole('img')` assertion here would pass whether or not the image was
+// rendered, which is worse than no assertion.
+const badgeIn = (container: HTMLElement) => container.querySelector('img');
+
+describe('teamCrest', () => {
+  it('shows initials when there is no badge — the ordinary case', () => {
+    // 377 of 4,455 teams carry a badge. The fallback is not an edge case, it is
+    // what 91.5% of rows render, so it has to be a designed thing rather than a
+    // gap where an image should be.
+    const { container } = render(<TeamCrest name="Manchester United" badge={null} />);
+
+    expect(screen.getByText('MU')).toBeInTheDocument();
+    expect(badgeIn(container)).toBeNull();
+  });
+
+  it('takes initials from the first two words only', () => {
+    render(<TeamCrest name="Borussia Vfl Mönchengladbach 1900" badge={null} />);
+
+    expect(screen.getByText('BV')).toBeInTheDocument();
+  });
+
+  it('falls back to a single letter for a one-word name', () => {
+    render(<TeamCrest name="Barcelona" badge={null} />);
+
+    expect(screen.getByText('B')).toBeInTheDocument();
+  });
+
+  it('renders the badge when there is one, lazily and against the API origin', () => {
+    const { container } = render(
+      <TeamCrest name="Manchester United" badge="/media/team_badges/united.svg" />,
+    );
+
+    const img = badgeIn(container);
+
+    expect(img).toHaveAttribute('loading', 'lazy');
+    expect(img?.getAttribute('src')).toContain('/media/team_badges/united.svg');
+    // Resolved against the API origin, not left as a path on this app.
+    expect(img?.getAttribute('src')).not.toBe('/media/team_badges/united.svg');
+  });
+
+  it('stays out of the accessibility tree — the name is already in the row', () => {
+    // Decorative. Announcing "Manchester United crest" immediately before the
+    // text "Manchester United" reads the club name twice to a screen reader.
+    const { container } = render(
+      <TeamCrest name="Manchester United" badge="/media/team_badges/united.svg" />,
+    );
+
+    expect(badgeIn(container)).toHaveAttribute('alt', '');
+  });
+
+  it('drops back to initials when the badge fails to load', () => {
+    // A broken-image glyph repeated down a 4,400-row table is worse than no
+    // image at all, and some of these files are old enough to point at nothing.
+    const { container } = render(
+      <TeamCrest name="Manchester United" badge="/media/team_badges/gone.svg" />,
+    );
+
+    fireEvent.error(badgeIn(container)!);
+
+    expect(screen.getByText('MU')).toBeInTheDocument();
+    expect(badgeIn(container)).toBeNull();
+  });
+});

--- a/components/analytics/panels/SquadDepth.tsx
+++ b/components/analytics/panels/SquadDepth.tsx
@@ -1,28 +1,92 @@
 'use client';
 
-import type { TeamGapsResponse } from '@/types/reports';
+import type { TeamSortColumn } from '@/hooks/use-team-table';
+import type { TeamGapsResponse, TeamOrdering } from '@/types/reports';
+import Link from 'next/link';
+import { NationFlag } from '@/components/analytics/NationFlag';
+import { TeamCrest } from '@/components/analytics/TeamCrest';
 import { SearchBox } from '@/components/reports/filters/SearchBox';
-import { CappedList } from '@/components/reports/primitives/CappedList';
-import { DataBar } from '@/components/reports/primitives/DataBar';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { MAGNITUDE_BAR, MAGNITUDE_TRACK } from '@/lib/data-colours';
+import { DataPagination } from '@/components/ui/data-pagination';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { TEAM_PAGE_SIZES } from '@/hooks/use-team-table';
+import { cn } from '@/lib/utils';
+
+/** What `aria-sort` should say about a column, given what the server sorted by. */
+function sortState(ordering: TeamOrdering, column: TeamSortColumn) {
+  if (column === 'name') {
+    return ordering === 'name' ? ('ascending' as const) : undefined;
+  }
+  if (ordering === 'players') {
+    return 'descending' as const;
+  }
+  return ordering === 'players_asc' ? ('ascending' as const) : undefined;
+}
+
+/** A column heading you can press, marked when it is the one in force. */
+function SortableHeader({ label, column, ordering, onSort, className }: {
+  label: string;
+  column: TeamSortColumn;
+  ordering: TeamOrdering;
+  onSort: (column: TeamSortColumn) => void;
+  className?: string;
+}) {
+  const state = sortState(ordering, column);
+  const arrow = state === 'ascending' ? '↑' : '↓';
+
+  return (
+    <th scope="col" aria-sort={state} className={cn('px-2 pb-2 text-xs font-medium', className)}>
+      <button
+        type="button"
+        onClick={() => onSort(column)}
+        className={cn(
+          'inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 transition-colors',
+          state ? 'bg-primary/10 text-foreground ring-1 ring-inset ring-primary/40' : 'text-muted-foreground hover:bg-muted',
+        )}
+      >
+        {label}
+        {state && <span aria-hidden className="text-primary">{arrow}</span>}
+        <span className="sr-only">
+          {state ? '(sorted by this column — press to change)' : '(press to sort by this column)'}
+        </span>
+      </button>
+    </th>
+  );
+}
 
 /**
- * Teams with the deepest squads.
+ * Teams by squad size — the whole table, a page at a time.
  *
- * The other end of the same table as the empty-team list below it, and the pair
- * is the point: one says what the catalogue leans on, the other what it forgot.
+ * It used to be a top ten with a bar scaled against the biggest row on screen,
+ * and an "expand to 100" for anyone who wanted more. Across 4,402 teams that
+ * bar compares ten rows to the largest of the same ten, which says nothing, and
+ * "expand to 100" cannot answer what is on page 40 of 441. So: a real table,
+ * ordered and paged by the server, with the count as the figure.
  *
- * The bar is scaled against the largest team on screen rather than an absolute
- * ceiling, because the question is relative — which of these is deep — and an
- * absolute scale would flatten every row once one team ran away with it.
+ * Sorting goes back to the API rather than reordering what arrived. Sorting the
+ * fetched page would order ten rows out of 4,402 and look broken the moment
+ * there is a page two.
+ *
+ * Every row is a link into `/team-players`, which shows the squad with the
+ * years each footballer was there. A ranked list of clubs whose squads you
+ * cannot open is a list you can only read.
  */
-export function SquadDepth({ data, onExpand, expanded, search, onSearchChange }: {
+export function SquadDepth({ data, search, onSearchChange, ordering, onSort, onPageChange, onLimitChange, busy }: {
   data: TeamGapsResponse;
-  onExpand?: () => void;
-  expanded?: boolean;
   search: string;
   onSearchChange: (next: string) => void;
+  ordering: TeamOrdering;
+  onSort: (column: TeamSortColumn) => void;
+  onPageChange: (page: number) => void;
+  onLimitChange: (limit: number) => void;
+  /** A request is in flight — the controls stay visible but inert. */
+  busy?: boolean;
 }) {
   const ranked = data.teams_by_players;
 
@@ -31,7 +95,8 @@ export function SquadDepth({ data, onExpand, expanded, search, onSearchChange }:
     return null;
   }
 
-  const largest = Math.max(...ranked.items.map(row => row.players), 1);
+  // The page's place in the whole table, so row one of page five reads as 41.
+  const offset = (ranked.page - 1) * ranked.limit;
 
   return (
     <Card>
@@ -40,7 +105,7 @@ export function SquadDepth({ data, onExpand, expanded, search, onSearchChange }:
           <CardTitle>Teams with the most players</CardTitle>
           <CardDescription>
             Squad size as the catalogue holds it — not a real squad, but everyone ever
-            recorded at the club.
+            recorded at the club. Every row opens that club's squad.
           </CardDescription>
         </div>
         {/* ON this card. In the page filter bar it sat with nothing to say which
@@ -53,49 +118,102 @@ export function SquadDepth({ data, onExpand, expanded, search, onSearchChange }:
           className="w-full shrink-0 sm:w-56"
         />
       </CardHeader>
-      <CardContent>
-        <CappedList
-          total={ranked.total}
-          shown={ranked.items.length}
-          onExpand={onExpand}
-          expanded={expanded}
-          emptyLabel={search ? `No team matches "${search}".` : 'No team has a squad yet.'}
-        >
-          <ol className="space-y-1.5">
-            {ranked.items.map((row, index) => (
-              <li
-                key={`${row.name}-${row.nation ?? ''}`}
-                className="group flex items-center gap-3 rounded-lg p-2 transition-colors hover:bg-muted/50"
-              >
-                {/* The rank, because a ranked list should say where you are in
-                    it — row four of a hundred reads differently from row four
-                    of four. */}
-                <span className="w-6 shrink-0 text-right text-xs font-medium tabular-nums text-muted-foreground">
-                  {index + 1}
-                </span>
-                <span className="min-w-0 flex-1">
-                  <span className="block truncate text-sm font-medium text-foreground">{row.name}</span>
-                  <span className="block truncate text-xs text-muted-foreground">
-                    {row.nation ?? 'No nation'}
-                  </span>
-                </span>
-                <span className="flex w-1/2 shrink-0 items-center gap-2">
-                  <DataBar
-                    value={row.players}
-                    max={largest}
-                    colour={MAGNITUDE_BAR}
-                    track={MAGNITUDE_TRACK}
-                    label={`${row.name}: ${row.players} players`}
-                    className="flex-1"
+      <CardContent className="space-y-4">
+        {ranked.total === 0
+          ? (
+              <p className="text-sm text-muted-foreground">
+                {search ? `No team matches "${search}".` : 'No team has a squad yet.'}
+              </p>
+            )
+          : (
+              <>
+                {/* Its own scroller: the page body must never scroll sideways. */}
+                <div className="-mx-2 overflow-x-auto px-2">
+                  <table className="w-full min-w-[26rem] text-sm">
+                    <thead>
+                      <tr className="border-b">
+                        <th scope="col" className="w-10 px-2 pb-2 text-right text-xs font-medium text-muted-foreground">
+                          #
+                        </th>
+                        <SortableHeader
+                          label="Team"
+                          column="name"
+                          ordering={ordering}
+                          onSort={onSort}
+                          className="text-left"
+                        />
+                        <SortableHeader
+                          label="Players"
+                          column="players"
+                          ordering={ordering}
+                          onSort={onSort}
+                          className="w-28 text-right [&>button]:justify-end"
+                        />
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {ranked.items.map((row, index) => (
+                        <tr key={row.id} className="group border-b border-border/50 last:border-0">
+                          {/* Where you are in the table, not in the page. */}
+                          <td className="px-2 py-1.5 text-right text-xs tabular-nums text-muted-foreground">
+                            {offset + index + 1}
+                          </td>
+                          <td className="px-2 py-1.5">
+                            <Link
+                              href={`/team-players?teamId=${row.id}`}
+                              className="flex items-center gap-2.5 rounded-md py-0.5 transition-colors group-hover:text-primary"
+                            >
+                              <TeamCrest name={row.name} badge={row.badge} />
+                              <span className="min-w-0">
+                                <span className="block truncate font-medium text-foreground group-hover:text-primary">
+                                  {row.name}
+                                </span>
+                                <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                                  <NationFlag flag={row.flag} />
+                                  <span className="truncate">{row.nation ?? 'No nation'}</span>
+                                </span>
+                              </span>
+                            </Link>
+                          </td>
+                          <td className="px-2 py-1.5 text-right text-sm font-semibold tabular-nums text-foreground">
+                            {row.players.toLocaleString()}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs text-muted-foreground">Rows</span>
+                    <Select
+                      value={String(ranked.limit)}
+                      onValueChange={value => onLimitChange(Number(value))}
+                      disabled={busy}
+                    >
+                      <SelectTrigger aria-label="Rows per page" className="h-8 w-[4.5rem]">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {TEAM_PAGE_SIZES.map(size => (
+                          <SelectItem key={size} value={String(size)}>{size}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+
+                  <DataPagination
+                    currentPage={ranked.page}
+                    totalPages={ranked.pages}
+                    totalCount={ranked.total}
+                    visibleCount={ranked.items.length}
+                    onPageChange={onPageChange}
+                    disabled={busy}
                   />
-                  <span className="w-12 shrink-0 text-right text-sm font-semibold tabular-nums text-foreground">
-                    {row.players.toLocaleString()}
-                  </span>
-                </span>
-              </li>
-            ))}
-          </ol>
-        </CappedList>
+                </div>
+              </>
+            )}
       </CardContent>
     </Card>
   );

--- a/components/analytics/panels/TeamGaps.tsx
+++ b/components/analytics/panels/TeamGaps.tsx
@@ -1,8 +1,28 @@
 'use client';
 
-import type { TeamGapsResponse } from '@/types/reports';
+import type { TeamGapRow, TeamGapsResponse } from '@/types/reports';
+import Link from 'next/link';
+import { NationFlag } from '@/components/analytics/NationFlag';
+import { TeamCrest } from '@/components/analytics/TeamCrest';
 import { CappedList } from '@/components/reports/primitives/CappedList';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+const CHIP = 'inline-flex items-center gap-2 rounded-md bg-muted/60 px-2 py-1 text-sm ring-1 ring-inset ring-border transition-colors hover:bg-muted';
+
+/** The chip's contents, which are the same whether or not it can be clicked. */
+function Gap({ row }: { row: TeamGapRow }) {
+  return (
+    <>
+      <TeamCrest name={row.name} badge={row.badge ?? null} className="size-6 rounded" />
+      <span className="font-medium text-foreground">{row.name}</span>
+      <span className="flex items-center gap-1 text-xs text-muted-foreground">
+        <NationFlag flag={row.flag} />
+        {/* Not `null` — a team with no nation is its own small gap. */}
+        {row.nation ?? 'No nation'}
+      </span>
+    </>
+  );
+}
 
 /**
  * Teams nobody plays for.
@@ -10,6 +30,10 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
  * A team with no squad is a row that exists and cannot be used: it can never be
  * a Career Path step or a Grid criterion, and it will sit in search results
  * returning nothing. Cheap to fix and invisible until you look for it.
+ *
+ * Each chip links to the screen where it gets fixed. This is the one list on
+ * the page where every entry is a job, so being able to open it matters more
+ * here than in the ranking above.
  */
 export function TeamGaps({ data, onExpand, expanded }: {
   data: TeamGapsResponse;
@@ -34,13 +58,17 @@ export function TeamGaps({ data, onExpand, expanded }: {
               wrapped list of names is a worklist you can scan. */}
           <ul className="flex flex-wrap gap-1.5">
             {data.teams_without_footballers.items.map(row => (
-              <li
-                key={`${row.name}-${row.nation ?? ''}`}
-                className="inline-flex items-baseline gap-1.5 rounded-md bg-muted/60 px-2 py-1 text-sm ring-1 ring-inset ring-border transition-colors hover:bg-muted"
-              >
-                <span className="font-medium text-foreground">{row.name}</span>
-                {/* Not `null` — a team with no nation is its own small gap. */}
-                <span className="text-xs text-muted-foreground">{row.nation ?? 'No nation'}</span>
+              <li key={row.id ?? `${row.name}-${row.nation ?? ''}`}>
+                {/* The id arrives in a later backend deploy than this page. No
+                    id means a chip you cannot open yet — never a chip that
+                    vanishes, and never a link to `teamId=undefined`. */}
+                {row.id === undefined
+                  ? <span className={CHIP}><Gap row={row} /></span>
+                  : (
+                      <Link href={`/team-players?teamId=${row.id}`} className={CHIP}>
+                        <Gap row={row} />
+                      </Link>
+                    )}
               </li>
             ))}
           </ul>

--- a/hooks/__tests__/use-team-table.test.ts
+++ b/hooks/__tests__/use-team-table.test.ts
@@ -1,0 +1,99 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { nextOrdering, useTeamTable } from '@/hooks/use-team-table';
+
+describe('nextOrdering', () => {
+  it('toggles the players column between most and fewest', () => {
+    expect(nextOrdering('players', 'players')).toBe('players_asc');
+    expect(nextOrdering('players_asc', 'players')).toBe('players');
+  });
+
+  it('comes back to most-players first when arriving from the name column', () => {
+    // "Sort by players" from a standing start should mean the interesting end.
+    expect(nextOrdering('name', 'players')).toBe('players');
+  });
+
+  it('has only one direction for the name column', () => {
+    // The endpoint declares `name` and no reverse, so offering a Z–A toggle
+    // would be a control that silently does nothing every second press.
+    expect(nextOrdering('name', 'name')).toBe('name');
+    expect(nextOrdering('players', 'name')).toBe('name');
+  });
+});
+
+describe('useTeamTable', () => {
+  it('starts on the first page, biggest squads first', () => {
+    const { result } = renderHook(() => useTeamTable());
+
+    expect(result.current.page).toBe(1);
+    expect(result.current.ordering).toBe('players');
+    expect(result.current.search).toBe('');
+  });
+
+  it('goes back to page 1 when the page size changes', () => {
+    // Otherwise page 40 of 441 becomes page 40 of 45 — the backend clamps to
+    // the last page, so you land somewhere you did not ask for and the table
+    // looks like it jumped.
+    const { result } = renderHook(() => useTeamTable());
+
+    act(() => result.current.setPage(40));
+    act(() => result.current.setLimit(100));
+
+    expect(result.current.limit).toBe(100);
+    expect(result.current.page).toBe(1);
+  });
+
+  it('goes back to page 1 when the sort changes', () => {
+    // Page 12 of one ordering has nothing to do with page 12 of another.
+    const { result } = renderHook(() => useTeamTable());
+
+    act(() => result.current.setPage(12));
+    act(() => result.current.sortBy('name'));
+
+    expect(result.current.ordering).toBe('name');
+    expect(result.current.page).toBe(1);
+  });
+
+  it('goes back to page 1 when the search changes', () => {
+    // A filter that matches four teams has no page 12 at all.
+    const { result } = renderHook(() => useTeamTable());
+
+    act(() => result.current.setPage(12));
+    act(() => result.current.setSearch('inter'));
+
+    expect(result.current.search).toBe('inter');
+    expect(result.current.page).toBe(1);
+  });
+
+  it('still lets the paginator move between pages', () => {
+    const { result } = renderHook(() => useTeamTable());
+
+    act(() => result.current.setPage(3));
+
+    expect(result.current.page).toBe(3);
+  });
+
+  it('gives one identity string covering everything the request depends on', () => {
+    // `use-report` refetches on this value. Leave any of the four out and that
+    // control stops refetching — the sort button goes dead, or paging shows
+    // page one again.
+    const { result } = renderHook(() => useTeamTable());
+    const first = result.current.requestKey;
+
+    act(() => result.current.setPage(2));
+
+    expect(result.current.requestKey).not.toBe(first);
+
+    act(() => result.current.setLimit(25));
+    const afterLimit = result.current.requestKey;
+
+    act(() => result.current.sortBy('name'));
+
+    expect(result.current.requestKey).not.toBe(afterLimit);
+
+    const afterSort = result.current.requestKey;
+    act(() => result.current.setSearch('inter'));
+
+    expect(result.current.requestKey).not.toBe(afterSort);
+  });
+});

--- a/hooks/use-team-table.ts
+++ b/hooks/use-team-table.ts
@@ -1,0 +1,71 @@
+import type { TeamOrdering } from '@/types/reports';
+import { useCallback, useState } from 'react';
+
+/** Page sizes offered in the dropdown. 100 is the endpoint's own ceiling. */
+export const TEAM_PAGE_SIZES = [10, 25, 50, 100] as const;
+
+/** Which column header was pressed, as opposed to what to ask the API for. */
+export type TeamSortColumn = 'players' | 'name';
+
+/**
+ * The ordering a click on a column header should produce.
+ *
+ * Players toggles between its two directions. Name has only one — the endpoint
+ * declares `name` and no reverse, and a toggle where every second press does
+ * nothing is worse than a control that plainly sorts one way.
+ */
+export function nextOrdering(current: TeamOrdering, column: TeamSortColumn): TeamOrdering {
+  if (column === 'name') {
+    return 'name';
+  }
+  return current === 'players' ? 'players_asc' : 'players';
+}
+
+/**
+ * Everything the squad-depth request is made of, and the rule that keeps them
+ * consistent: anything that changes WHICH rows exist resets to page one.
+ *
+ * That rule is the whole reason this is a hook rather than four `useState`
+ * calls in the page. Page 40 of 441 is not page 40 of 45, and page 12 of a
+ * four-row search does not exist at all. The endpoint clamps out-of-range pages
+ * to the last one, so getting this wrong degrades quietly — you land on a page
+ * you did not ask for and the table looks like it jumped on its own.
+ */
+export function useTeamTable(initialLimit: number = TEAM_PAGE_SIZES[0]) {
+  const [page, setPage] = useState(1);
+  const [limit, setLimitState] = useState(initialLimit);
+  const [ordering, setOrdering] = useState<TeamOrdering>('players');
+  const [search, setSearchState] = useState('');
+
+  const setLimit = useCallback((next: number) => {
+    setLimitState(next);
+    setPage(1);
+  }, []);
+
+  const sortBy = useCallback((column: TeamSortColumn) => {
+    setOrdering(current => nextOrdering(current, column));
+    setPage(1);
+  }, []);
+
+  const setSearch = useCallback((next: string) => {
+    setSearchState(next);
+    setPage(1);
+  }, []);
+
+  return {
+    page,
+    limit,
+    ordering,
+    search,
+    setPage,
+    setLimit,
+    sortBy,
+    setSearch,
+    /**
+     * Fetch identity for `use-report`, which refetches when this changes and
+     * has no other way to know. Every value the request is built from has to
+     * appear here: omit one and the control that changes it goes dead.
+     */
+    requestKey: `${limit}:${search}:${page}:${ordering}`,
+  };
+}

--- a/lib/__tests__/media-url.test.ts
+++ b/lib/__tests__/media-url.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import config from '@/lib/config';
+import { mediaUrl } from '@/lib/media-url';
+
+describe('mediaUrl', () => {
+  it('resolves a relative media path against the API, not this app', () => {
+    // The whole reason this exists: the dashboard and the API are different
+    // origins, so `/media/...` rendered as-is asks THIS app for the image.
+    expect(mediaUrl('/media/team_badges/united.svg')).toBe(
+      `${config.API_BASE_URL}/media/team_badges/united.svg`,
+    );
+  });
+
+  it('leaves an already-absolute URL alone', () => {
+    // The backend sends absolute URLs now. Prefixing them again would produce
+    // `https://api.example.com/https://api.example.com/media/...`.
+    const absolute = 'https://api.extratime.world/media/nation_flags/england-flag.png';
+
+    expect(mediaUrl(absolute)).toBe(absolute);
+    expect(mediaUrl('http://localhost:8000/media/x.png')).toBe('http://localhost:8000/media/x.png');
+  });
+
+  it('leaves a protocol-relative or inline URL alone', () => {
+    // What a CDN move would produce, and what an inline SVG placeholder is.
+    expect(mediaUrl('//cdn.example.com/badge.svg')).toBe('//cdn.example.com/badge.svg');
+    expect(mediaUrl('data:image/svg+xml,<svg/>')).toBe('data:image/svg+xml,<svg/>');
+  });
+
+  it('treats absent as absent', () => {
+    // 91.5% of teams have no badge, so this is the ordinary path, and it has to
+    // stay null rather than becoming a URL that 404s.
+    expect(mediaUrl(null)).toBeNull();
+    expect(mediaUrl(undefined)).toBeNull();
+    expect(mediaUrl('')).toBeNull();
+  });
+});

--- a/lib/__tests__/team-id-param.test.ts
+++ b/lib/__tests__/team-id-param.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { parseTeamId } from '@/lib/team-id-param';
+
+describe('parseTeamId', () => {
+  it('reads a team id out of the query string', () => {
+    expect(parseTeamId('1042')).toBe(1042);
+  });
+
+  it('ignores a missing parameter', () => {
+    // The page is still reachable without one — the search box is the other
+    // way in, and an absent id must not be read as a request for team NaN.
+    expect(parseTeamId(null)).toBeNull();
+    expect(parseTeamId(undefined)).toBeNull();
+    expect(parseTeamId('')).toBeNull();
+  });
+
+  it('refuses anything that is not a whole positive number', () => {
+    // Straight into a `/data/team/<id>/players/` path, so a value that is not
+    // an id is a request that can only 404 — and the page renders that 404 as
+    // "the backend may not be deployed", which is a confusing lie about a typo.
+    for (const raw of ['abc', '12abc', '0', '-3', '1.5', 'Infinity', 'NaN']) {
+      expect(parseTeamId(raw), raw).toBeNull();
+    }
+  });
+
+  it('tolerates the whitespace a copied-and-pasted id arrives with', () => {
+    expect(parseTeamId(' 7 ')).toBe(7);
+  });
+});

--- a/lib/media-url.ts
+++ b/lib/media-url.ts
@@ -1,0 +1,27 @@
+import config from '@/lib/config';
+
+/** Already a location a browser can fetch, rather than a path on the API. */
+const ALREADY_ABSOLUTE = /^(?:https?:)?\/\/|^data:/i;
+
+/**
+ * A media path from the API, as a URL this app can actually load.
+ *
+ * The dashboard and the API are separate origins, so a bare `/media/badge.svg`
+ * in an `<img src>` asks the DASHBOARD for the image and gets a 404. Django's
+ * `FileField.url` is relative by default, and while the analytics endpoint now
+ * wraps these in `build_absolute_uri`, that is one serializer's decision — not
+ * a property of the field. Resolving here means the UI renders correctly under
+ * either, and survives a later move to a CDN.
+ *
+ * Absent stays absent. Only 8.5% of teams carry a badge, so a null is the
+ * ordinary answer and the caller has to render something else regardless.
+ */
+export function mediaUrl(path: string | null | undefined): string | null {
+  if (!path) {
+    return null;
+  }
+  if (ALREADY_ABSOLUTE.test(path)) {
+    return path;
+  }
+  return config.getApiUrl(path);
+}

--- a/lib/reports-api.ts
+++ b/lib/reports-api.ts
@@ -26,6 +26,7 @@ import type {
   RollupHealth,
   SummaryResponse,
   TeamGapsResponse,
+  TeamOrdering,
   TopPlayersResponse,
   UnfinishedResponse,
 } from '@/types/reports';
@@ -169,9 +170,24 @@ export class ReportsAPI {
     return apiFetcher<NationGapsResponse>(`core/analytics/football-data/nations/${buildQuery({ limit })}`);
   }
 
-  /** GET /core/analytics/football-data/teams/ — empty teams and the review queue. */
-  static async getTeamGaps(limit?: number, search?: string): Promise<TeamGapsResponse> {
-    return apiFetcher<TeamGapsResponse>(`core/analytics/football-data/teams/${buildQuery({ limit, search })}`);
+  /**
+   * GET /core/analytics/football-data/teams/ — empty teams, the review queue,
+   * and one page of the squad-depth table.
+   *
+   * `limit` is the page size of that table AND the cap on the empty-team
+   * worklist — the endpoint takes one for both. `page` is clamped server-side,
+   * so an out-of-range page shows the last one instead of an empty table, and
+   * an unknown `ordering` is a 400 rather than a silently different sort.
+   */
+  static async getTeamGaps(
+    limit?: number,
+    search?: string,
+    page?: number,
+    ordering?: TeamOrdering,
+  ): Promise<TeamGapsResponse> {
+    return apiFetcher<TeamGapsResponse>(
+      `core/analytics/football-data/teams/${buildQuery({ limit, search, page, ordering })}`,
+    );
   }
 
   /**

--- a/lib/team-id-param.ts
+++ b/lib/team-id-param.ts
@@ -1,0 +1,23 @@
+/**
+ * The team id carried in `/team-players?teamId=<id>`.
+ *
+ * The teams analytics page links every row here, so this value arrives from a
+ * URL rather than from the page's own search box — which means it can be
+ * anything. It goes straight into a `/data/team/<id>/players/` path, and that
+ * endpoint answers a nonsense id with a 404 which the page explains as "the
+ * backend may not have this deployed yet". True for a real missing endpoint,
+ * an actively misleading thing to say about a typo.
+ *
+ * So it is validated here rather than trusted: a whole positive number, or
+ * nothing at all.
+ */
+export function parseTeamId(raw: string | null | undefined): number | null {
+  if (!raw) {
+    return null;
+  }
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return null;
+  }
+  return parsed;
+}

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -1188,13 +1188,54 @@ export type NationGapsResponse = {
   nations_by_footballers: CappedRows<{ name: string; short: string; footballers: number }>;
 };
 
+/**
+ * A page of rows, plus where the page sits in the whole set.
+ *
+ * `CappedRows` says "here are the first ten of 4,402 and that is all you get".
+ * This says which ten, out of how many pages — the difference between a sample
+ * and a table you can walk.
+ */
+export type PagedRows<T> = {
+  items: T[];
+  total: number;
+  /** Rows per page, echoed. */
+  limit: number;
+  /** 1-based, and clamped server-side: asking for page 900 returns the last. */
+  page: number;
+  pages: number;
+};
+
+/** Who a team is, in either of the two lists on the teams page. */
+export type TeamRow = {
+  id: number;
+  name: string;
+  nation: string | null;
+  /** The nation's flag. 230 of 233 active nations have one. */
+  flag: string | null;
+  /** The club crest. Only 377 of 4,455 teams have one — expect null. */
+  badge: string | null;
+};
+
+/**
+ * The empty-team rows gained `id`, `flag` and `badge` in a later backend PR
+ * than the ranking did, so they are optional: this app can deploy first and
+ * the chips become clickable when the API catches up.
+ */
+export type TeamGapRow
+  = Omit<TeamRow, 'id' | 'flag' | 'badge'> & Partial<Pick<TeamRow, 'id' | 'flag' | 'badge'>>;
+
+/** How the squad-depth table may be ordered. Rejected server-side if unknown. */
+export type TeamOrdering = 'players' | 'players_asc' | 'name';
+
 export type TeamGapsResponse = {
-  teams_without_footballers: CappedRows<{ name: string; nation: string | null }>;
+  teams_without_footballers: CappedRows<TeamGapRow>;
   review_queue: ReviewQueue;
-  /** The other end of the same table: the deepest squads. */
-  teams_by_players?: CappedRows<{ name: string; nation: string | null; players: number }>;
+  /** The other end of the same table: the deepest squads, one page at a time. */
+  teams_by_players?: PagedRows<TeamRow & { players: number }>;
   /** Echoed so an empty ranking reads as "no matches" rather than "no data". */
   search?: string | null;
+  /** Echoed so the header can mark the column the server actually sorted by. */
+  ordering?: TeamOrdering | null;
 };
 
 export type QuestionBankResponse = {


### PR DESCRIPTION
The teams page showed a top ten with a bar and an "expand to 100". Behind it sit 4,402 teams, so the bar compared ten rows against the largest of the same ten — which says nothing — and "expand to 100" cannot answer what is on page 40 of 441. App#1518 made the endpoint pageable and ordered; this uses it.

## A row you can open

Every row links to `/team-players?teamId=<id>`, which already shows a club's squad with the years each footballer was there. A ranked list of clubs whose squads you cannot open is a list you can only read.

That page took its team from its own search box only, so the links needed it to read the URL as well. It now does, validated to whole positive numbers: the id goes straight into a `/data/team/<id>/players/` path, and that endpoint answers a nonsense id with a 404 which the page explains as "the backend may not have this deployed yet" — true of a real missing endpoint, an actively misleading thing to say about a typo. It also writes the URL back when a team is picked, so a deep link and a manual pick leave the address bar saying the same thing.

`useSearchParams` suspends, so the page is wrapped in a boundary. Without one the route stops prerendering, which is a build failure rather than a runtime one.

## Fallback-first crests

377 of 4,455 teams carry a badge — 8.5% — while 230 of 233 nations carry a flag. So the initials tile is not the error path, it is what nine rows in ten render, and `TeamCrest` is built around it with the image layered on top. It steps aside again on a load error: a column of broken-image glyphs is worse than a column of tidy monograms.

Plain `<img loading="lazy">` throughout. This is a staff-only dashboard, so there is nothing to gain from optimisation that would cost a remote-pattern entry in `next.config.mjs` and per-image Vercel billing.

`mediaUrl` resolves a relative path against the API and leaves an absolute one alone. App#1519 makes these absolute, but that is one serializer's decision rather than a property of the field, so the UI renders correctly under either and survives a move to a CDN.

## Sorted and paged by the server

Both column headers sort through the `ordering` param. Sorting the fetched page in the browser would order ten rows out of 4,402 and read as broken the moment there is a page two. Players toggles both directions; Team has one, because the endpoint declares `name` and no reverse and a toggle where every second press does nothing is worse than a control that plainly sorts one way.

`useTeamTable` holds page, size, sort and search together for one rule: anything that changes WHICH rows exist resets to page one. The endpoint clamps an out-of-range page to the last one, so getting that wrong degrades quietly — you land on a page you did not ask for and the table looks like it jumped.

It also owns the fetch identity `use-report` refetches on. Leave any of the four values out and the control that changes it goes dead.

## Depends on

The empty-team chips need `id`/`flag`/`badge` from https://github.com/FootballExtraTime/App/pull/1519. Until that deploys they render as unlinked chips rather than breaking — `TeamGapRow` types those three as optional for exactly that window.

## Known coupling

The endpoint takes one `limit` for both lists, so the page size is also the cap on the empty-team worklist: setting 100 rows expands that list to 100 chips, and its "show more" sets the page size. It degrades sensibly and is commented, but splitting the two params server-side is the real fix.

## Verification

- 795 tests pass, `tsc --noEmit` clean, `lint:reports` clean, `components/analytics` and `app/analytics` clean at `--max-warnings 0`, `next build` compiles with no errors or warnings.
- Five guards mutation-tested: the page-one reset, the fetch identity, the absolute-URL passthrough, the `teamId` validation, and the unlinked chip for a row with no id.
- `app/team-players` goes from 3 lint warnings to 4 — the new deep-link effect trips `no-direct-set-state-in-use-effect`, the same as the file's existing three and the same as the `?edit=` pattern it copies. Removing the effect would fire the fetch before auth resolves.

Refs https://github.com/FootballExtraTime/App/issues/1474

🤖 Generated with [Claude Code](https://claude.com/claude-code)