### PR TITLE
Nations get the same table, and the row count stops moving other lists

### DIFF
--- a/app/analytics/football-data/nations/page.tsx
+++ b/app/analytics/football-data/nations/page.tsx
@@ -1,15 +1,17 @@
 'use client';
 
 import { useState } from 'react';
+import { NationDepth } from '@/components/analytics/panels/NationDepth';
 import { NationGaps } from '@/components/analytics/panels/NationGaps';
 import { AnalyticsShell } from '@/components/analytics/shell/AnalyticsShell';
 import { ReportPanel } from '@/components/reports/primitives/ReportPanel';
+import { useNationTable } from '@/hooks/use-nation-table';
 import { useReport } from '@/hooks/use-report';
 import { useAuth } from '@/lib/auth';
 import { ReportsAPI } from '@/lib/reports-api';
 
 /** Rows a gap list shows before you ask for more, and after. */
-const PAGE = 10;
+const WORKLIST = 10;
 const EXPANDED = 100;
 
 /**
@@ -22,15 +24,18 @@ const EXPANDED = 100;
 export default function NationsAnalyticsPage() {
   const { isAuthenticated, user } = useAuth();
   const enabled = isAuthenticated && !!(user?.is_staff || user?.is_superuser);
-  const [limit, setLimit] = useState(PAGE);
+  const table = useNationTable();
+  // Separate from the table's page size. One number used to drive all three
+  // lists, so the row-count dropdown rewrote both worklists underneath it.
+  const [worklistLimit, setWorklistLimit] = useState(WORKLIST);
 
   const state = useReport(
-    () => ReportsAPI.getNationGaps(limit),
+    () => ReportsAPI.getNationGaps(worklistLimit, table.pageSize, table.page, table.ordering),
     {},
     enabled,
     'The nation gaps endpoint',
-    // Part of the fetch identity: without it, asking for more would not refetch.
-    String(limit),
+    // Every value the request is built from — without it, nothing refetches.
+    `${table.requestKey}:${worklistLimit}`,
   );
 
   return (
@@ -38,12 +43,25 @@ export default function NationsAnalyticsPage() {
       title="Nations"
       description="Which nations nothing points at, and where the catalogue is deepest."
     >
-      <ReportPanel state={state} skeletonClassName="h-96 w-full">
+      <ReportPanel state={state} skeletonClassName="h-80 w-full">
         {data => (
           <NationGaps
             data={data}
-            expanded={limit > PAGE}
-            onExpand={() => setLimit(EXPANDED)}
+            expanded={worklistLimit >= EXPANDED}
+            onExpand={() => setWorklistLimit(EXPANDED)}
+          />
+        )}
+      </ReportPanel>
+
+      <ReportPanel state={state} skeletonClassName="h-96 w-full">
+        {data => (
+          <NationDepth
+            data={data}
+            ordering={table.ordering}
+            onSort={table.sortBy}
+            onPageChange={table.setPage}
+            onPageSizeChange={table.setPageSize}
+            busy={state.isLoading}
           />
         )}
       </ReportPanel>

--- a/app/analytics/football-data/teams/page.tsx
+++ b/app/analytics/football-data/teams/page.tsx
@@ -11,7 +11,8 @@ import { useTeamTable } from '@/hooks/use-team-table';
 import { useAuth } from '@/lib/auth';
 import { ReportsAPI } from '@/lib/reports-api';
 
-/** What the gap worklist expands to. The ranking pages instead. */
+/** Rows the empty-team worklist shows before you ask for more, and after. */
+const WORKLIST = 10;
 const EXPANDED = 100;
 
 /** Team coverage. No date filter — see the nations page for why. */
@@ -19,25 +20,24 @@ export default function TeamsAnalyticsPage() {
   const { isAuthenticated, user } = useAuth();
   const enabled = isAuthenticated && !!(user?.is_staff || user?.is_superuser);
   const table = useTeamTable();
-  // The endpoint takes ONE limit for both lists, so the ranking's page size is
-  // also the gap list's cap. Expanding the worklist therefore sets the page
-  // size — coupled at the API, and worth splitting there rather than papering
-  // over it here.
-  const [expanded, setExpanded] = useState(false);
+  // Its own control now. The endpoint used to take one `limit` for the table
+  // and the worklist, so the row-count dropdown quietly rewrote this list too.
+  const [worklistLimit, setWorklistLimit] = useState(WORKLIST);
 
   const state = useReport(
     () => ReportsAPI.getTeamGaps(
-      table.limit,
+      worklistLimit,
       table.search || undefined,
       table.page,
       table.ordering,
+      table.pageSize,
     ),
     {},
     enabled,
     'The team gaps endpoint',
     // Every value the request is built from. Drop one and the control that
-    // changes it stops refetching — see `use-team-table`.
-    table.requestKey,
+    // changes it stops refetching — see `use-ranked-table`.
+    `${table.requestKey}:${worklistLimit}`,
   );
 
   return (
@@ -55,10 +55,7 @@ export default function TeamsAnalyticsPage() {
             ordering={table.ordering}
             onSort={table.sortBy}
             onPageChange={table.setPage}
-            onLimitChange={(next) => {
-              setExpanded(next >= EXPANDED);
-              table.setLimit(next);
-            }}
+            onPageSizeChange={table.setPageSize}
             busy={state.isLoading}
           />
         )}
@@ -69,11 +66,8 @@ export default function TeamsAnalyticsPage() {
           <div className="space-y-4">
             <TeamGaps
               data={data}
-              expanded={expanded}
-              onExpand={() => {
-                setExpanded(true);
-                table.setLimit(EXPANDED);
-              }}
+              expanded={worklistLimit >= EXPANDED}
+              onExpand={() => setWorklistLimit(EXPANDED)}
             />
             <ReviewQueue counts={data.review_queue} subject="teams" />
           </div>

--- a/app/footballer-management/page.tsx
+++ b/app/footballer-management/page.tsx
@@ -30,6 +30,7 @@ import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useAuth } from '@/lib/auth';
 import { FootballerAPI } from '@/lib/footballer-api';
+import { parseNationFilter } from '@/lib/nation-param';
 
 export default function FootballerManagementPage() {
   const { isLoading, isAuthenticated } = useAuth();
@@ -38,6 +39,8 @@ export default function FootballerManagementPage() {
   // Track whether we've already consumed the ``?edit=<id>`` deep-link
   // so a re-render (e.g. nations finishing loading) doesn't re-fire it.
   const consumedEditParam = useRef(false);
+  // Same idea for `?nation=<code>`, which arrives from the nations page.
+  const consumedNationParam = useRef(false);
   const [footballers, setFootballers] = useState<Footballer[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -51,6 +54,10 @@ export default function FootballerManagementPage() {
 
   // Filter and search states
   const [searchQuery, setSearchQuery] = useState('');
+  // Set from `?nation=<code>` by the nations analytics page, which links every
+  // row and every gap chip here. Not a control in the filter bar: it arrives
+  // with the link and is cleared with the others.
+  const [nationFilter, setNationFilter] = useState('');
   const [statusFilter, setStatusFilter] = useState('all');
   const [retiredFilter, setRetiredFilter] = useState('all');
   const [isPlayerFilter, setIsPlayerFilter] = useState('all');
@@ -144,7 +151,35 @@ export default function FootballerManagementPage() {
     handleLoadNations();
   }, []);
 
-  const handleGetFootballers = async (page: number = 1, resetPage: boolean = false) => {
+  // Deep-link entry point for `/footballer-management?nation=<code>`, used by
+  // the nations analytics page. It loads the list straight away rather than
+  // only setting the filter: arriving from a link that says "show me Italy's
+  // footballers" onto an empty screen with a primed filter is a page that did
+  // three quarters of what was asked.
+  //
+  // Consumed once, so re-renders cannot undo a filter cleared by hand.
+  useEffect(() => {
+    if (consumedNationParam.current || !isAuthenticated) {
+      return;
+    }
+    const fromUrl = parseNationFilter(searchParams?.get('nation'));
+    if (fromUrl === null) {
+      return;
+    }
+    consumedNationParam.current = true;
+    setNationFilter(fromUrl);
+    // eslint-disable-next-line ts/no-use-before-define -- pre-existing hoisting; handleGetFootballers is defined below.
+    handleGetFootballers(1, true, fromUrl);
+  }, [isAuthenticated, searchParams]);
+
+  const handleGetFootballers = async (
+    page: number = 1,
+    resetPage: boolean = false,
+    // The deep-link effect fetches in the same tick it sets the filter, so the
+    // state it just set is not readable yet. Passing the value avoids a fetch
+    // that silently ignores the nation it was opened for.
+    nationOverride?: string,
+  ) => {
     setLoading(true);
     setError(null);
     setSingleFootballer(null); // Clear single footballer result
@@ -162,6 +197,11 @@ export default function FootballerManagementPage() {
       }
 
       // Add filters
+      const nation = (nationOverride ?? nationFilter).trim();
+      if (nation) {
+        // Matched server-side against name, nationality or short code.
+        params.nation = nation;
+      }
       if (statusFilter && statusFilter !== 'all') {
         params.status = statusFilter;
       }
@@ -614,6 +654,7 @@ export default function FootballerManagementPage() {
 
   const handleClearFilters = () => {
     setSearchQuery('');
+    setNationFilter('');
     setStatusFilter('all');
     setRetiredFilter('all');
     setIsPlayerFilter('all');
@@ -632,6 +673,11 @@ export default function FootballerManagementPage() {
 
     if (searchQuery.trim()) {
       filters.push(`Search: "${searchQuery}"`);
+    }
+    // Listed like any other filter, because it is one — arriving by link should
+    // not leave a narrowing nobody can see and nobody can clear.
+    if (nationFilter.trim()) {
+      filters.push(`Nation: ${nationFilter.trim()}`);
     }
     if (statusFilter !== 'all') {
       const statusLabels = {

--- a/components/analytics/IdentityTile.tsx
+++ b/components/analytics/IdentityTile.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useState } from 'react';
+import { mediaUrl } from '@/lib/media-url';
+import { cn } from '@/lib/utils';
+
+/**
+ * A small square standing for a team or a nation: its image, or some text.
+ *
+ * Both callers need the same three things — resolve the path against the API,
+ * load it lazily, and step aside for text when it is absent or broken — and
+ * they disagree only about what the text is. What differs between them is which
+ * case is normal: 8.5% of clubs carry a crest against 99% of nations carrying a
+ * flag, so for teams the text is the usual outcome and for nations it is the
+ * exception. Neither is treated as an error path here.
+ *
+ * Plain `<img>` rather than `next/image`: a staff-only dashboard has nothing to
+ * gain from optimisation that would cost a remote-pattern entry in
+ * `next.config.mjs` and per-image Vercel billing.
+ */
+export function IdentityTile({ image, fallback, className }: {
+  /** Path or URL from the API, or null when there is none. */
+  image: string | null | undefined;
+  /** Shown when there is no image, or when it fails to load. */
+  fallback: string;
+  className?: string;
+}) {
+  const [failed, setFailed] = useState(false);
+  const src = failed ? null : mediaUrl(image);
+
+  return (
+    <span
+      className={cn(
+        'flex size-8 shrink-0 items-center justify-center overflow-hidden rounded-md',
+        'bg-muted text-[0.65rem] font-semibold text-muted-foreground ring-1 ring-inset ring-border',
+        className,
+      )}
+    >
+      {src
+        ? (
+            // eslint-disable-next-line next/no-img-element -- deliberate, see above
+            <img
+              src={src}
+              // Decorative: the name it stands for is beside it in every caller.
+              alt=""
+              loading="lazy"
+              className="size-full object-contain"
+              onError={() => setFailed(true)}
+            />
+          )
+        : (
+            <span aria-hidden>{fallback}</span>
+          )}
+    </span>
+  );
+}

--- a/components/analytics/NationCrest.tsx
+++ b/components/analytics/NationCrest.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { IdentityTile } from '@/components/analytics/IdentityTile';
+
+/**
+ * A nation's flag, falling back to its short code.
+ *
+ * The short code rather than initials, which is what `TeamCrest` uses: "ITA" is
+ * already what this nation is called in every other column, while initialising
+ * "Italy" would invent a second and worse name for it.
+ *
+ * The fallback is rare here — 230 of 233 active nations carry a flag — which is
+ * the mirror image of teams, where the tile does almost all the work.
+ */
+export function NationCrest({ short, flag, className }: {
+  short: string;
+  flag: string | null | undefined;
+  className?: string;
+}) {
+  return <IdentityTile image={flag} fallback={short} className={className} />;
+}

--- a/components/analytics/RankedTable.tsx
+++ b/components/analytics/RankedTable.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { DataPagination } from '@/components/ui/data-pagination';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { RANKED_PAGE_SIZES, sortState } from '@/hooks/use-ranked-table';
+import { cn } from '@/lib/utils';
+
+/** A column heading you can press, marked when it is the one in force. */
+export function SortableHeader({ label, column, ordering, onSort, className }: {
+  label: string;
+  column: string;
+  ordering: string;
+  onSort: (column: string) => void;
+  className?: string;
+}) {
+  const state = sortState(ordering, column);
+  const arrow = state === 'ascending' ? '↑' : '↓';
+
+  return (
+    <th scope="col" aria-sort={state} className={cn('px-2 pb-2 text-xs font-medium', className)}>
+      <button
+        type="button"
+        onClick={() => onSort(column)}
+        className={cn(
+          'inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 transition-colors',
+          state
+            ? 'bg-primary/10 text-foreground ring-1 ring-inset ring-primary/40'
+            : 'text-muted-foreground hover:bg-muted',
+        )}
+      >
+        {label}
+        {state && <span aria-hidden className="text-primary">{arrow}</span>}
+        <span className="sr-only">
+          {state ? '(sorted by this column — press to change)' : '(press to sort by this column)'}
+        </span>
+      </button>
+    </th>
+  );
+}
+
+/**
+ * Row count on the left, paginator on the right.
+ *
+ * The page size comes from the server's echo rather than local state, so the
+ * dropdown shows what was actually served — including when the endpoint clamps
+ * a value it will not honour.
+ */
+export function TableControls({ page, pages, total, pageSize, shown, onPageChange, onPageSizeChange, busy }: {
+  page: number;
+  pages: number;
+  total: number;
+  pageSize: number;
+  shown: number;
+  onPageChange: (page: number) => void;
+  onPageSizeChange: (size: number) => void;
+  busy?: boolean;
+}) {
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex items-center gap-2">
+        <span className="text-xs text-muted-foreground">Rows</span>
+        <Select
+          value={String(pageSize)}
+          onValueChange={value => onPageSizeChange(Number(value))}
+          disabled={busy}
+        >
+          <SelectTrigger aria-label="Rows per page" className="h-8 w-[4.5rem]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {RANKED_PAGE_SIZES.map(size => (
+              <SelectItem key={size} value={String(size)}>{size}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <DataPagination
+        currentPage={page}
+        totalPages={pages}
+        totalCount={total}
+        visibleCount={shown}
+        onPageChange={onPageChange}
+        disabled={busy}
+      />
+    </div>
+  );
+}

--- a/components/analytics/TeamCrest.tsx
+++ b/components/analytics/TeamCrest.tsx
@@ -1,8 +1,6 @@
 'use client';
 
-import { useState } from 'react';
-import { mediaUrl } from '@/lib/media-url';
-import { cn } from '@/lib/utils';
+import { IdentityTile } from '@/components/analytics/IdentityTile';
 
 /** The first letter of the first two words — "Manchester United" → "MU". */
 function initials(name: string): string {
@@ -15,17 +13,15 @@ function initials(name: string): string {
 }
 
 /**
- * A club's crest, or the tile that stands in for it.
+ * A club's crest, or the monogram that stands in for it.
  *
- * Built fallback-first on purpose. 377 of 4,455 approved teams carry a badge —
- * 8.5% — so the initials tile is what most of this table renders, and treating
- * it as the error path would leave nine rows in ten looking broken. The image
- * is the bonus layered on top, and it steps aside again if it fails to load:
- * a column of broken-image glyphs is worse than a column of tidy monograms.
+ * The monogram is the usual outcome: 377 of 4,455 approved teams carry a badge,
+ * so nine rows in ten render initials and treating that as the error path would
+ * leave most of the table looking broken. The crest is the bonus on top.
  *
- * Plain `<img>` rather than `next/image`. This is a staff-only dashboard, so
- * there is nothing to gain from optimisation that would justify a remote-pattern
- * entry in `next.config.mjs` and per-image Vercel billing.
+ * Initials rather than a short code, which is what `NationCrest` falls back to —
+ * teams have no short code, and their names are long enough that two letters is
+ * the only thing that fits.
  */
 export function TeamCrest({ name, badge, className }: {
   name: string;
@@ -33,33 +29,5 @@ export function TeamCrest({ name, badge, className }: {
   badge: string | null;
   className?: string;
 }) {
-  const [failed, setFailed] = useState(false);
-  const src = failed ? null : mediaUrl(badge);
-
-  return (
-    <span
-      className={cn(
-        'flex size-8 shrink-0 items-center justify-center overflow-hidden rounded-md',
-        'bg-muted text-[0.65rem] font-semibold text-muted-foreground ring-1 ring-inset ring-border',
-        className,
-      )}
-    >
-      {src
-        ? (
-            // eslint-disable-next-line next/no-img-element -- deliberate, see above
-            <img
-              src={src}
-              // Decorative: the club name sits next to it in every caller, and
-              // an alt here would have a screen reader say it twice.
-              alt=""
-              loading="lazy"
-              className="size-full object-contain"
-              onError={() => setFailed(true)}
-            />
-          )
-        : (
-            <span aria-hidden>{initials(name)}</span>
-          )}
-    </span>
-  );
+  return <IdentityTile image={badge} fallback={initials(name)} className={className} />;
 }

--- a/components/analytics/__tests__/IdentityTile.test.tsx
+++ b/components/analytics/__tests__/IdentityTile.test.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { IdentityTile } from '@/components/analytics/IdentityTile';
+
+// Queried directly rather than through `getByRole('img')`: these images are
+// decorative and carry `alt=""`, which puts them under the `presentation` role.
+const imageIn = (container: HTMLElement) => container.querySelector('img');
+
+describe('identityTile', () => {
+  it('shows the image when there is one, lazily and against the API origin', () => {
+    const { container } = render(
+      <IdentityTile image="/media/team_badges/united.svg" fallback="MU" />,
+    );
+
+    const img = imageIn(container);
+
+    expect(img).toHaveAttribute('loading', 'lazy');
+    expect(img?.getAttribute('src')).toContain('/media/team_badges/united.svg');
+    expect(img?.getAttribute('src')).not.toBe('/media/team_badges/united.svg');
+  });
+
+  it('shows the fallback text when there is no image', () => {
+    const { container } = render(<IdentityTile image={null} fallback="MU" />);
+
+    expect(screen.getByText('MU')).toBeInTheDocument();
+    expect(imageIn(container)).toBeNull();
+  });
+
+  it('falls back when the image fails to load', () => {
+    // A broken-image glyph repeated down a table is worse than no image at all,
+    // and some of these files are old enough to point at nothing.
+    const { container } = render(
+      <IdentityTile image="/media/team_badges/gone.svg" fallback="MU" />,
+    );
+
+    fireEvent.error(imageIn(container)!);
+
+    expect(screen.getByText('MU')).toBeInTheDocument();
+    expect(imageIn(container)).toBeNull();
+  });
+
+  it('stays out of the accessibility tree', () => {
+    // Decorative. The name it stands for is rendered beside it in every caller,
+    // so announcing it here reads the same thing twice.
+    const { container } = render(
+      <IdentityTile image="/media/team_badges/united.svg" fallback="MU" />,
+    );
+
+    expect(imageIn(container)).toHaveAttribute('alt', '');
+  });
+});

--- a/components/analytics/__tests__/NationCrest.test.tsx
+++ b/components/analytics/__tests__/NationCrest.test.tsx
@@ -1,0 +1,37 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { NationCrest } from '@/components/analytics/NationCrest';
+
+const imageIn = (container: HTMLElement) => container.querySelector('img');
+
+describe('nationCrest', () => {
+  it('shows the flag, which is the usual case here', () => {
+    // The mirror of TeamCrest: 230 of 233 nations carry a flag against 8.5% of
+    // clubs carrying a crest, so for nations the image is the normal path.
+    const { container } = render(
+      <NationCrest short="ITA" flag="/media/nation_flags/italy-flag.png" />,
+    );
+
+    expect(imageIn(container)?.getAttribute('src')).toContain('italy-flag.png');
+    expect(screen.queryByText('ITA')).not.toBeInTheDocument();
+  });
+
+  it('falls back to the short code, not to initials', () => {
+    // "ITA" is what a nation is already called in every other column, and
+    // initialising "Italy" to "I" would invent a second, worse name for it.
+    const { container } = render(<NationCrest short="ITA" flag={null} />);
+
+    expect(screen.getByText('ITA')).toBeInTheDocument();
+    expect(imageIn(container)).toBeNull();
+  });
+
+  it('drops back to the short code when the flag fails to load', () => {
+    const { container } = render(
+      <NationCrest short="ITA" flag="/media/nation_flags/gone.png" />,
+    );
+
+    fireEvent.error(imageIn(container)!);
+
+    expect(screen.getByText('ITA')).toBeInTheDocument();
+  });
+});

--- a/components/analytics/__tests__/NationGaps.test.tsx
+++ b/components/analytics/__tests__/NationGaps.test.tsx
@@ -1,69 +1,128 @@
 import type { NationGapsResponse } from '@/types/reports';
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { NationDepth } from '@/components/analytics/panels/NationDepth';
 import { NationGaps } from '@/components/analytics/panels/NationGaps';
-import { ReviewQueue } from '@/components/analytics/panels/ReviewQueue';
 
-function data(): NationGapsResponse {
+function data(over: Partial<NationGapsResponse> = {}): NationGapsResponse {
   return {
-    nations_without_footballers: {
-      items: [{ name: 'Afghanistan', short: 'AFG' }, { name: 'American Samoa', short: 'ASM' }],
-      total: 101,
-      limit: 10,
-    },
-    nations_without_teams: { items: [{ name: 'Aruba', short: 'ABW' }], total: 94, limit: 10 },
     nations_by_footballers: {
-      items: [{ name: 'England', short: 'ENG', footballers: 467 }],
-      total: 132,
+      items: [
+        { id: 1, name: 'Italy', short: 'ITA', flag: '/media/nation_flags/italy-flag.png', footballers: 812 },
+        { id: 2, name: 'Spain', short: 'ESP', flag: null, footballers: 640 },
+      ],
+      total: 178,
+      limit: 10,
+      page: 1,
+      pages: 18,
+    },
+    nations_without_footballers: {
+      items: [{ id: 40, name: 'Tuvalu', short: 'TUV', flag: '/media/nation_flags/tuvalu-flag.png' }],
+      total: 55,
       limit: 10,
     },
-  };
+    nations_without_teams: {
+      items: [{ id: 41, name: 'Nauru', short: 'NRU', flag: null }],
+      total: 61,
+      limit: 10,
+    },
+    ordering: 'footballers',
+    ...over,
+  } as NationGapsResponse;
 }
 
-describe('nationGaps', () => {
-  it('describes the gap by its real size, not by the sample', () => {
-    render(<NationGaps data={data()} />);
+const depthProps = {
+  ordering: 'footballers' as const,
+  onSort: vi.fn(),
+  onPageChange: vi.fn(),
+  onPageSizeChange: vi.fn(),
+};
 
-    expect(screen.getByText('Showing 2 of 101')).toBeInTheDocument();
-    expect(screen.getByText('Showing 1 of 94')).toBeInTheDocument();
+describe('nationDepth', () => {
+  it('numbers rows by their place in the whole table, not in the page', () => {
+    render(
+      <NationDepth
+        data={data({ nations_by_footballers: { ...data().nations_by_footballers, page: 3, limit: 10 } })}
+        {...depthProps}
+      />,
+    );
+
+    const rows = screen.getAllByRole('row').slice(1);
+
+    expect(within(rows[0]).getByText('21')).toBeInTheDocument();
   });
 
-  it('keeps "no footballers" and "no teams" as separate jobs', () => {
-    // They overlap heavily but are not the same fix: a nation can have players
-    // and no clubs, and club-based content needs the clubs.
+  it('sends every nation to its footballers', () => {
+    // The short code, not the id: `/data/footballers/` filters by name,
+    // nationality or short code, and the id is not one of them.
+    render(<NationDepth data={data()} {...depthProps} />);
+
+    expect(screen.getByRole('link', { name: /Italy/ })).toHaveAttribute(
+      'href',
+      '/footballer-management?nation=ITA',
+    );
+  });
+
+  it('marks the sorted column and sorts through the server', () => {
+    const onSort = vi.fn();
+    render(<NationDepth data={data()} {...depthProps} onSort={onSort} />);
+
+    const header = screen.getByRole('columnheader', { name: /Footballers/ });
+
+    expect(header).toHaveAttribute('aria-sort', 'descending');
+
+    fireEvent.click(within(header).getByRole('button'));
+
+    expect(onSort).toHaveBeenCalledWith('footballers');
+  });
+
+  it('pages rather than expanding once', () => {
+    render(<NationDepth data={data()} {...depthProps} />);
+
+    expect(screen.getByText('Showing 2 of 178 results')).toBeInTheDocument();
+    expect(screen.getByLabelText('Rows per page')).toBeInTheDocument();
+  });
+});
+
+describe('nationGaps', () => {
+  it('keeps the two gaps apart, because they are different jobs', () => {
+    // A nation with no footballers cannot appear in anything nation-scoped; a
+    // nation with no teams cannot appear in club-based content. They overlap
+    // heavily but fixing one does not fix the other.
     render(<NationGaps data={data()} />);
 
     expect(screen.getByText('Nations with no footballers')).toBeInTheDocument();
     expect(screen.getByText('Nations with no teams')).toBeInTheDocument();
+    expect(screen.getByText('Tuvalu')).toBeInTheDocument();
+    expect(screen.getByText('Nauru')).toBeInTheDocument();
   });
 
-  it('shows the depth ranking with its counts', () => {
+  it('sends a footballer-less nation to the screen that fills it', () => {
     render(<NationGaps data={data()} />);
 
-    expect(screen.getByText('England')).toBeInTheDocument();
-    expect(screen.getByText('467')).toBeInTheDocument();
-  });
-});
-
-describe('reviewQueue', () => {
-  it('renders nothing when nothing is pending', () => {
-    // Not every deployment uses the review states. A permanent row of zeros
-    // would be a workflow the page invented.
-    const { container } = render(<ReviewQueue counts={{}} subject="teams" />);
-
-    expect(container).toBeEmptyDOMElement();
+    expect(screen.getByRole('link', { name: /Tuvalu/ })).toHaveAttribute(
+      'href',
+      '/footballer-management?nation=TUV',
+    );
   });
 
-  it('renders nothing when the backend predates the field', () => {
-    const { container } = render(<ReviewQueue counts={undefined} subject="teams" />);
+  it('sends a team-less nation to the admin, since nothing in here adds a team', () => {
+    // The one external link on the page. There is no team-management screen in
+    // this app, so the alternative is a chip that names a job with nowhere to
+    // do it.
+    render(<NationGaps data={data()} />);
 
-    expect(container).toBeEmptyDOMElement();
+    const link = screen.getByRole('link', { name: /Nauru/ });
+
+    expect(link).toHaveAttribute('href', expect.stringContaining('FootballData/team/add/'));
+    expect(link).toHaveAttribute('href', expect.stringContaining('nation=41'));
+    expect(link).toHaveAttribute('target', '_blank');
   });
 
-  it('names the status in words when something is waiting', () => {
-    render(<ReviewQueue counts={{ AWAITING_REVISION: 12 }} subject="footballers" />);
+  it('reports the real gaps, not the chips shown', () => {
+    render(<NationGaps data={data()} />);
 
-    expect(screen.getByText('Awaiting revision')).toBeInTheDocument();
-    expect(screen.getByText('12')).toBeInTheDocument();
+    expect(screen.getByText('Showing 1 of 55')).toBeInTheDocument();
+    expect(screen.getByText('Showing 1 of 61')).toBeInTheDocument();
   });
 });

--- a/components/analytics/__tests__/SquadDepth.test.tsx
+++ b/components/analytics/__tests__/SquadDepth.test.tsx
@@ -40,7 +40,7 @@ const props = {
   ordering: 'players' as const,
   onSort: vi.fn(),
   onPageChange: vi.fn(),
-  onLimitChange: vi.fn(),
+  onPageSizeChange: vi.fn(),
 };
 
 describe('squadDepth', () => {

--- a/components/analytics/panels/NationDepth.tsx
+++ b/components/analytics/panels/NationDepth.tsx
@@ -1,76 +1,57 @@
 'use client';
 
-import type { TeamGapsResponse, TeamOrdering } from '@/types/reports';
+import type { NationGapsResponse, NationOrdering } from '@/types/reports';
 import Link from 'next/link';
-import { NationFlag } from '@/components/analytics/NationFlag';
+import { NationCrest } from '@/components/analytics/NationCrest';
 import { SortableHeader, TableControls } from '@/components/analytics/RankedTable';
-import { TeamCrest } from '@/components/analytics/TeamCrest';
-import { SearchBox } from '@/components/reports/filters/SearchBox';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { nationFootballersHref } from '@/lib/nation-param';
 
 /**
- * Teams by squad size — the whole table, a page at a time.
+ * Where the catalogue is deepest.
  *
- * It used to be a top ten with a bar scaled against the biggest row on screen,
- * and an "expand to 100" for anyone who wanted more. Across 4,402 teams that
- * bar compares ten rows to the largest of the same ten, which says nothing, and
- * "expand to 100" cannot answer what is on page 40 of 441. So: a real table,
- * ordered and paged by the server, with the count as the figure.
+ * Context for the two gap lists beside it: those say what cannot be used at
+ * all, this says what the games will actually feel like to play. A nation with
+ * four footballers is not a gap, but it is not depth either, and only a ranked
+ * table shows you where the falloff starts.
  *
- * Sorting goes back to the API rather than reordering what arrived. Sorting the
- * fetched page would order ten rows out of 4,402 and look broken the moment
- * there is a page two.
- *
- * Every row is a link into `/team-players`, which shows the squad with the
- * years each footballer was there. A ranked list of clubs whose squads you
- * cannot open is a list you can only read.
+ * Paged and sorted by the server, like the teams table. There are far fewer
+ * nations than teams — around 233 against 4,402 — so this is a shorter table,
+ * but the sort is the point: reading it by name and reading it by depth are two
+ * different questions.
  */
-export function SquadDepth({ data, search, onSearchChange, ordering, onSort, onPageChange, onPageSizeChange, busy }: {
-  data: TeamGapsResponse;
-  search: string;
-  onSearchChange: (next: string) => void;
-  ordering: TeamOrdering;
+export function NationDepth({ data, ordering, onSort, onPageChange, onPageSizeChange, busy }: {
+  data: NationGapsResponse;
+  ordering: NationOrdering;
   onSort: (column: string) => void;
   onPageChange: (page: number) => void;
   onPageSizeChange: (size: number) => void;
-  /** A request is in flight — the controls stay visible but inert. */
   busy?: boolean;
 }) {
-  const ranked = data.teams_by_players;
+  const ranked = data.nations_by_footballers;
 
-  // The BE may not carry this yet — the repositories deploy independently.
+  // The BE may not carry the paged shape yet — the repositories deploy
+  // independently, and before that this was a capped list with no `page`.
   if (!ranked) {
     return null;
   }
 
-  // The page's place in the whole table, so row one of page five reads as 41.
   const offset = (ranked.page - 1) * ranked.limit;
 
   return (
     <Card>
-      <CardHeader className="gap-3 sm:flex-row sm:items-start sm:justify-between">
-        <div className="space-y-1.5">
-          <CardTitle>Teams with the most players</CardTitle>
-          <CardDescription>
-            Squad size as the catalogue holds it — not a real squad, but everyone ever
-            recorded at the club. Every row opens that club's squad.
-          </CardDescription>
-        </div>
-        {/* ON this card. In the page filter bar it sat with nothing to say which
-            of the two tables it narrowed — and it narrows only this one. */}
-        <SearchBox
-          value={search}
-          onChange={onSearchChange}
-          label="Filter teams in this table"
-          placeholder="Filter these teams…"
-          className="w-full shrink-0 sm:w-56"
-        />
+      <CardHeader>
+        <CardTitle>Where the catalogue is deepest</CardTitle>
+        <CardDescription>
+          Context for the gaps above: this is what the games will actually feel like to play.
+          Every row opens that nation's footballers.
+        </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
         {ranked.total === 0
           ? (
               <p className="text-sm text-muted-foreground">
-                {search ? `No team matches "${search}".` : 'No team has a squad yet.'}
+                No footballers are assigned to a nation yet.
               </p>
             )
           : (
@@ -84,18 +65,18 @@ export function SquadDepth({ data, search, onSearchChange, ordering, onSort, onP
                           #
                         </th>
                         <SortableHeader
-                          label="Team"
+                          label="Nation"
                           column="name"
                           ordering={ordering}
                           onSort={onSort}
                           className="text-left"
                         />
                         <SortableHeader
-                          label="Players"
-                          column="players"
+                          label="Footballers"
+                          column="footballers"
                           ordering={ordering}
                           onSort={onSort}
-                          className="w-28 text-right [&>button]:justify-end"
+                          className="w-32 text-right [&>button]:justify-end"
                         />
                       </tr>
                     </thead>
@@ -108,23 +89,22 @@ export function SquadDepth({ data, search, onSearchChange, ordering, onSort, onP
                           </td>
                           <td className="px-2 py-1.5">
                             <Link
-                              href={`/team-players?teamId=${row.id}`}
-                              className="flex items-center gap-2.5 rounded-md py-0.5 transition-colors group-hover:text-primary"
+                              href={nationFootballersHref(row.short)}
+                              className="flex items-center gap-2.5 rounded-md py-0.5"
                             >
-                              <TeamCrest name={row.name} badge={row.badge} />
+                              <NationCrest short={row.short} flag={row.flag} />
                               <span className="min-w-0">
                                 <span className="block truncate font-medium text-foreground group-hover:text-primary">
                                   {row.name}
                                 </span>
-                                <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                                  <NationFlag flag={row.flag} />
-                                  <span className="truncate">{row.nation ?? 'No nation'}</span>
+                                <span className="block truncate text-xs text-muted-foreground">
+                                  {row.short}
                                 </span>
                               </span>
                             </Link>
                           </td>
                           <td className="px-2 py-1.5 text-right text-sm font-semibold tabular-nums text-foreground">
-                            {row.players.toLocaleString()}
+                            {row.footballers.toLocaleString()}
                           </td>
                         </tr>
                       ))}

--- a/components/analytics/panels/NationGaps.tsx
+++ b/components/analytics/panels/NationGaps.tsx
@@ -1,17 +1,44 @@
 'use client';
 
-import type { NationGapsResponse } from '@/types/reports';
+import type { NationGapsResponse, NationRow } from '@/types/reports';
+import Link from 'next/link';
+import { NationCrest } from '@/components/analytics/NationCrest';
 import { CappedList } from '@/components/reports/primitives/CappedList';
-import { ReportTable } from '@/components/reports/primitives/ReportTable';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import config from '@/lib/config';
+import { nationFootballersHref } from '@/lib/nation-param';
+
+const CHIP = 'inline-flex items-center gap-2 rounded-md bg-muted/60 px-2 py-1 text-sm ring-1 ring-inset ring-border transition-colors hover:bg-muted';
 
 /**
- * Nations nothing points at, and the ones the catalogue leans on.
+ * Where a team for this nation can be created.
  *
- * Two gaps and one skew, in that order, because the first two are worklists and
- * the third is context for them. A nation with no footballers cannot appear in
- * anything nation-scoped; a nation with no teams cannot appear in club-based
- * content. They overlap heavily but are not the same job.
+ * The Django admin, and the only external link on the page. There is no
+ * team-management screen in this app, so the alternative is a chip that names
+ * a job with nowhere to do it.
+ */
+function addTeamHref(nationId: number) {
+  return config.getAdminUrl(`FootballData/team/add/?nation=${nationId}`);
+}
+
+/** Flag, name, short code — the same identity in both lists. */
+function NationChip({ row }: { row: NationRow }) {
+  return (
+    <>
+      <NationCrest short={row.short} flag={row.flag} className="size-6 rounded" />
+      <span className="font-medium text-foreground">{row.name}</span>
+      <span className="text-xs text-muted-foreground">{row.short}</span>
+    </>
+  );
+}
+
+/**
+ * Nations nothing points at.
+ *
+ * Two gaps, kept apart because they are different jobs. A nation with no
+ * footballers cannot appear in anything nation-scoped — no national-team clue,
+ * no nation criterion. A nation with no teams cannot appear in club-based
+ * content. They overlap heavily, and fixing one does not fix the other.
  *
  * Active nations only. A defunct country with no footballers is not a gap to
  * fill — mixing the two turns a worklist into a list nobody will action.
@@ -38,7 +65,17 @@ export function NationGaps({ data, onExpand, expanded }: {
             expanded={expanded}
             emptyLabel="Every active nation has at least one footballer."
           >
-            <NameList rows={data.nations_without_footballers.items} />
+            <ul className="flex flex-wrap gap-1.5">
+              {data.nations_without_footballers.items.map(row => (
+                <li key={row.short}>
+                  {/* Lands on an empty filtered list, which is the honest view
+                      of the gap — and the Add form is on the same screen. */}
+                  <Link href={nationFootballersHref(row.short)} className={CHIP}>
+                    <NationChip row={row} />
+                  </Link>
+                </li>
+              ))}
+            </ul>
           </CappedList>
         </CardContent>
       </Card>
@@ -58,56 +95,23 @@ export function NationGaps({ data, onExpand, expanded }: {
             expanded={expanded}
             emptyLabel="Every active nation has at least one team."
           >
-            <NameList rows={data.nations_without_teams.items} />
-          </CappedList>
-        </CardContent>
-      </Card>
-
-      <Card className="lg:col-span-2">
-        <CardHeader>
-          <CardTitle>Where the catalogue is deepest</CardTitle>
-          <CardDescription>
-            Context for the gaps above: this is what the games will actually feel like to play.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <CappedList
-            total={data.nations_by_footballers.total}
-            shown={data.nations_by_footballers.items.length}
-            onExpand={onExpand}
-            expanded={expanded}
-            emptyLabel="No footballers are assigned to a nation yet."
-          >
-            <ReportTable>
-              <tbody>
-                {data.nations_by_footballers.items.map(row => (
-                  <tr key={row.short} className="border-b last:border-0">
-                    <td className="py-1.5 pr-4 text-sm text-foreground">{row.name}</td>
-                    <td className="py-1.5 pr-4 text-xs text-muted-foreground">{row.short}</td>
-                    <td className="py-1.5 text-right text-sm font-medium tabular-nums text-foreground">
-                      {row.footballers.toLocaleString()}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </ReportTable>
+            <ul className="flex flex-wrap gap-1.5">
+              {data.nations_without_teams.items.map(row => (
+                <li key={row.short}>
+                  <a
+                    href={addTeamHref(row.id)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={CHIP}
+                  >
+                    <NationChip row={row} />
+                  </a>
+                </li>
+              ))}
+            </ul>
           </CappedList>
         </CardContent>
       </Card>
     </div>
-  );
-}
-
-/** A plain list of names — no counts, because every row here is a zero. */
-function NameList({ rows }: { rows: { name: string; short: string }[] }) {
-  return (
-    <ul className="flex flex-wrap gap-x-3 gap-y-1.5 text-sm">
-      {rows.map(row => (
-        <li key={row.short} className="text-foreground">
-          {row.name}
-          <span className="ml-1 text-xs text-muted-foreground">{row.short}</span>
-        </li>
-      ))}
-    </ul>
   );
 }

--- a/hooks/__tests__/sort-state.test.ts
+++ b/hooks/__tests__/sort-state.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { sortState } from '@/hooks/use-ranked-table';
+
+describe('sortState', () => {
+  it('reads the interesting direction as descending', () => {
+    expect(sortState('players', 'players')).toBe('descending');
+    expect(sortState('footballers', 'footballers')).toBe('descending');
+  });
+
+  it('reads the _asc variant as ascending', () => {
+    expect(sortState('players_asc', 'players')).toBe('ascending');
+    expect(sortState('footballers_asc', 'footballers')).toBe('ascending');
+  });
+
+  it('reads name as ascending, since A–Z is its only direction', () => {
+    // The one column that breaks the "bare ordering means descending" rule.
+    // Calling it descending would draw an arrow pointing the wrong way.
+    expect(sortState('name', 'name')).toBe('ascending');
+  });
+
+  it('says nothing about a column that is not the one in force', () => {
+    // `aria-sort` on more than one column would claim the table is sorted by
+    // both, which is how a screen reader gets told the opposite of the truth.
+    expect(sortState('players', 'name')).toBeUndefined();
+    expect(sortState('name', 'players')).toBeUndefined();
+    expect(sortState('players_asc', 'name')).toBeUndefined();
+  });
+});

--- a/hooks/__tests__/use-nation-table.test.ts
+++ b/hooks/__tests__/use-nation-table.test.ts
@@ -1,0 +1,38 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { nextNationOrdering, useNationTable } from '@/hooks/use-nation-table';
+
+describe('nextNationOrdering', () => {
+  it('toggles the footballers column between most and fewest', () => {
+    expect(nextNationOrdering('footballers', 'footballers')).toBe('footballers_asc');
+    expect(nextNationOrdering('footballers_asc', 'footballers')).toBe('footballers');
+  });
+
+  it('comes back to most-footballers first when arriving from the name column', () => {
+    expect(nextNationOrdering('name', 'footballers')).toBe('footballers');
+  });
+
+  it('has only one direction for the name column', () => {
+    // The endpoint declares `name` and no reverse, so a Z–A toggle would be a
+    // control that silently does nothing every second press.
+    expect(nextNationOrdering('footballers', 'name')).toBe('name');
+    expect(nextNationOrdering('name', 'name')).toBe('name');
+  });
+});
+
+describe('useNationTable', () => {
+  it('starts with the deepest nations first', () => {
+    const { result } = renderHook(() => useNationTable());
+
+    expect(result.current.ordering).toBe('footballers');
+    expect(result.current.page).toBe(1);
+  });
+
+  it('sorts through the nation toggle', () => {
+    const { result } = renderHook(() => useNationTable());
+
+    act(() => result.current.sortBy('footballers'));
+
+    expect(result.current.ordering).toBe('footballers_asc');
+  });
+});

--- a/hooks/__tests__/use-ranked-table.test.ts
+++ b/hooks/__tests__/use-ranked-table.test.ts
@@ -1,0 +1,105 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useRankedTable } from '@/hooks/use-ranked-table';
+
+type Ordering = 'big' | 'small' | 'name';
+
+/** A toggle standing in for a real one, so the generic rules are what is tested. */
+const toggle = (current: Ordering, column: string): Ordering => {
+  if (column === 'name') {
+    return 'name';
+  }
+  return current === 'big' ? 'small' : 'big';
+};
+
+const setup = () => renderHook(() => useRankedTable<Ordering>({ defaultOrdering: 'big', toggle }));
+
+describe('useRankedTable', () => {
+  it('starts on the first page with the given default ordering', () => {
+    const { result } = setup();
+
+    expect(result.current.page).toBe(1);
+    expect(result.current.ordering).toBe('big');
+    expect(result.current.search).toBe('');
+  });
+
+  it('goes back to page 1 when the page size changes', () => {
+    // Otherwise page 40 of 441 becomes page 40 of 45 — the backend clamps to
+    // the last page, so you land somewhere you did not ask for and the table
+    // looks like it jumped.
+    const { result } = setup();
+
+    act(() => result.current.setPage(40));
+    act(() => result.current.setPageSize(100));
+
+    expect(result.current.pageSize).toBe(100);
+    expect(result.current.page).toBe(1);
+  });
+
+  it('goes back to page 1 when the sort changes', () => {
+    // Page 12 of one ordering has nothing to do with page 12 of another.
+    const { result } = setup();
+
+    act(() => result.current.setPage(12));
+    act(() => result.current.sortBy('name'));
+
+    expect(result.current.ordering).toBe('name');
+    expect(result.current.page).toBe(1);
+  });
+
+  it('goes back to page 1 when the search changes', () => {
+    // A filter that matches four rows has no page 12 at all.
+    const { result } = setup();
+
+    act(() => result.current.setPage(12));
+    act(() => result.current.setSearch('inter'));
+
+    expect(result.current.search).toBe('inter');
+    expect(result.current.page).toBe(1);
+  });
+
+  it('still lets the paginator move between pages', () => {
+    const { result } = setup();
+
+    act(() => result.current.setPage(3));
+
+    expect(result.current.page).toBe(3);
+  });
+
+  it('routes sorting through the caller-supplied toggle', () => {
+    // The two tables disagree about what a second press on a column means, and
+    // that is the only thing they disagree about.
+    const { result } = setup();
+
+    act(() => result.current.sortBy('size'));
+
+    expect(result.current.ordering).toBe('small');
+  });
+
+  it('gives one identity string covering everything the request depends on', () => {
+    // `use-report` refetches on this value. Leave any of the four out and that
+    // control stops refetching — the sort button goes dead, or paging shows
+    // page one again.
+    const { result } = setup();
+    const start = result.current.requestKey;
+
+    act(() => result.current.setPage(2));
+
+    expect(result.current.requestKey).not.toBe(start);
+
+    const afterPage = result.current.requestKey;
+    act(() => result.current.setPageSize(25));
+
+    expect(result.current.requestKey).not.toBe(afterPage);
+
+    const afterSize = result.current.requestKey;
+    act(() => result.current.sortBy('name'));
+
+    expect(result.current.requestKey).not.toBe(afterSize);
+
+    const afterSort = result.current.requestKey;
+    act(() => result.current.setSearch('inter'));
+
+    expect(result.current.requestKey).not.toBe(afterSort);
+  });
+});

--- a/hooks/__tests__/use-team-table.test.ts
+++ b/hooks/__tests__/use-team-table.test.ts
@@ -2,6 +2,10 @@ import { act, renderHook } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { nextOrdering, useTeamTable } from '@/hooks/use-team-table';
 
+// The page/size/sort/search rules these two tables share live in
+// `use-ranked-table` and are tested there. What is left here is the one thing
+// the teams table decides for itself: what a second press on a column means.
+
 describe('nextOrdering', () => {
   it('toggles the players column between most and fewest', () => {
     expect(nextOrdering('players', 'players')).toBe('players_asc');
@@ -30,70 +34,11 @@ describe('useTeamTable', () => {
     expect(result.current.search).toBe('');
   });
 
-  it('goes back to page 1 when the page size changes', () => {
-    // Otherwise page 40 of 441 becomes page 40 of 45 — the backend clamps to
-    // the last page, so you land somewhere you did not ask for and the table
-    // looks like it jumped.
+  it('sorts through the team toggle', () => {
     const { result } = renderHook(() => useTeamTable());
 
-    act(() => result.current.setPage(40));
-    act(() => result.current.setLimit(100));
+    act(() => result.current.sortBy('players'));
 
-    expect(result.current.limit).toBe(100);
-    expect(result.current.page).toBe(1);
-  });
-
-  it('goes back to page 1 when the sort changes', () => {
-    // Page 12 of one ordering has nothing to do with page 12 of another.
-    const { result } = renderHook(() => useTeamTable());
-
-    act(() => result.current.setPage(12));
-    act(() => result.current.sortBy('name'));
-
-    expect(result.current.ordering).toBe('name');
-    expect(result.current.page).toBe(1);
-  });
-
-  it('goes back to page 1 when the search changes', () => {
-    // A filter that matches four teams has no page 12 at all.
-    const { result } = renderHook(() => useTeamTable());
-
-    act(() => result.current.setPage(12));
-    act(() => result.current.setSearch('inter'));
-
-    expect(result.current.search).toBe('inter');
-    expect(result.current.page).toBe(1);
-  });
-
-  it('still lets the paginator move between pages', () => {
-    const { result } = renderHook(() => useTeamTable());
-
-    act(() => result.current.setPage(3));
-
-    expect(result.current.page).toBe(3);
-  });
-
-  it('gives one identity string covering everything the request depends on', () => {
-    // `use-report` refetches on this value. Leave any of the four out and that
-    // control stops refetching — the sort button goes dead, or paging shows
-    // page one again.
-    const { result } = renderHook(() => useTeamTable());
-    const first = result.current.requestKey;
-
-    act(() => result.current.setPage(2));
-
-    expect(result.current.requestKey).not.toBe(first);
-
-    act(() => result.current.setLimit(25));
-    const afterLimit = result.current.requestKey;
-
-    act(() => result.current.sortBy('name'));
-
-    expect(result.current.requestKey).not.toBe(afterLimit);
-
-    const afterSort = result.current.requestKey;
-    act(() => result.current.setSearch('inter'));
-
-    expect(result.current.requestKey).not.toBe(afterSort);
+    expect(result.current.ordering).toBe('players_asc');
   });
 });

--- a/hooks/use-nation-table.ts
+++ b/hooks/use-nation-table.ts
@@ -1,0 +1,27 @@
+import type { NationOrdering } from '@/types/reports';
+import { useRankedTable } from '@/hooks/use-ranked-table';
+
+/** Which column header was pressed, as opposed to what to ask the API for. */
+export type NationSortColumn = 'footballers' | 'name';
+
+/**
+ * The ordering a click on a nations column header should produce.
+ *
+ * Footballers toggles between its two directions. Name has only one — the
+ * endpoint declares `name` and no reverse, and a toggle where every second
+ * press does nothing is worse than a control that plainly sorts one way.
+ */
+export function nextNationOrdering(current: NationOrdering, column: string): NationOrdering {
+  if (column === 'name') {
+    return 'name';
+  }
+  return current === 'footballers' ? 'footballers_asc' : 'footballers';
+}
+
+/** Page, size, sort and search for the deepest-nations table. */
+export function useNationTable() {
+  return useRankedTable<NationOrdering>({
+    defaultOrdering: 'footballers',
+    toggle: nextNationOrdering,
+  });
+}

--- a/hooks/use-ranked-table.ts
+++ b/hooks/use-ranked-table.ts
@@ -1,0 +1,82 @@
+import { useCallback, useState } from 'react';
+
+/** Page sizes offered in the dropdown. 100 is the endpoint's own ceiling. */
+export const RANKED_PAGE_SIZES = [10, 25, 50, 100] as const;
+
+/**
+ * What `aria-sort` should say about a column, given what the server sorted by.
+ *
+ * Lives beside the hook because it is the other half of the same convention:
+ * both tables name their orderings `<column>` for the interesting direction and
+ * `<column>_asc` for the other, so one rule covers teams and nations. The
+ * exception is `name`, whose single direction is A–Z — reporting it as
+ * descending would draw an arrow pointing the wrong way.
+ */
+export function sortState(ordering: string, column: string) {
+  if (ordering === column) {
+    return column === 'name' ? ('ascending' as const) : ('descending' as const);
+  }
+  if (ordering === `${column}_asc`) {
+    return 'ascending' as const;
+  }
+  return undefined;
+}
+
+/**
+ * Everything a server-ordered table's request is made of, and the rule that
+ * keeps them consistent: anything that changes WHICH rows exist resets to
+ * page one.
+ *
+ * That rule is why this is a hook rather than four `useState` calls in a page.
+ * Page 40 of 441 is not page 40 of 45, and page 12 of a four-row search does
+ * not exist at all. The endpoint clamps an out-of-range page to the last one,
+ * so getting it wrong degrades quietly — you land on a page you did not ask for
+ * and the table looks like it jumped on its own.
+ *
+ * The two tables using this disagree about one thing only: what a second press
+ * on a column header means. That comes in as `toggle`.
+ */
+export function useRankedTable<T extends string>({ defaultOrdering, toggle, initialPageSize = RANKED_PAGE_SIZES[0] }: {
+  defaultOrdering: T;
+  toggle: (current: T, column: string) => T;
+  initialPageSize?: number;
+}) {
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSizeState] = useState<number>(initialPageSize);
+  const [ordering, setOrdering] = useState<T>(defaultOrdering);
+  const [search, setSearchState] = useState('');
+
+  const setPageSize = useCallback((next: number) => {
+    setPageSizeState(next);
+    setPage(1);
+  }, []);
+
+  const sortBy = useCallback((column: string) => {
+    setOrdering(current => toggle(current, column));
+    setPage(1);
+    // `toggle` is a module-level function at every call site, so this is stable
+    // in practice; depending on it keeps that honest rather than assumed.
+  }, [toggle]);
+
+  const setSearch = useCallback((next: string) => {
+    setSearchState(next);
+    setPage(1);
+  }, []);
+
+  return {
+    page,
+    pageSize,
+    ordering,
+    search,
+    setPage,
+    setPageSize,
+    sortBy,
+    setSearch,
+    /**
+     * Fetch identity for `use-report`, which refetches when this changes and
+     * has no other way to know. Every value the request is built from has to
+     * appear here: omit one and the control that changes it goes dead.
+     */
+    requestKey: `${pageSize}:${search}:${page}:${ordering}`,
+  };
+}

--- a/hooks/use-team-table.ts
+++ b/hooks/use-team-table.ts
@@ -1,71 +1,27 @@
 import type { TeamOrdering } from '@/types/reports';
-import { useCallback, useState } from 'react';
-
-/** Page sizes offered in the dropdown. 100 is the endpoint's own ceiling. */
-export const TEAM_PAGE_SIZES = [10, 25, 50, 100] as const;
+import { useRankedTable } from '@/hooks/use-ranked-table';
 
 /** Which column header was pressed, as opposed to what to ask the API for. */
 export type TeamSortColumn = 'players' | 'name';
 
 /**
- * The ordering a click on a column header should produce.
+ * The ordering a click on a teams column header should produce.
  *
  * Players toggles between its two directions. Name has only one — the endpoint
  * declares `name` and no reverse, and a toggle where every second press does
  * nothing is worse than a control that plainly sorts one way.
  */
-export function nextOrdering(current: TeamOrdering, column: TeamSortColumn): TeamOrdering {
+export function nextOrdering(current: TeamOrdering, column: string): TeamOrdering {
   if (column === 'name') {
     return 'name';
   }
   return current === 'players' ? 'players_asc' : 'players';
 }
 
-/**
- * Everything the squad-depth request is made of, and the rule that keeps them
- * consistent: anything that changes WHICH rows exist resets to page one.
- *
- * That rule is the whole reason this is a hook rather than four `useState`
- * calls in the page. Page 40 of 441 is not page 40 of 45, and page 12 of a
- * four-row search does not exist at all. The endpoint clamps out-of-range pages
- * to the last one, so getting this wrong degrades quietly — you land on a page
- * you did not ask for and the table looks like it jumped on its own.
- */
-export function useTeamTable(initialLimit: number = TEAM_PAGE_SIZES[0]) {
-  const [page, setPage] = useState(1);
-  const [limit, setLimitState] = useState(initialLimit);
-  const [ordering, setOrdering] = useState<TeamOrdering>('players');
-  const [search, setSearchState] = useState('');
-
-  const setLimit = useCallback((next: number) => {
-    setLimitState(next);
-    setPage(1);
-  }, []);
-
-  const sortBy = useCallback((column: TeamSortColumn) => {
-    setOrdering(current => nextOrdering(current, column));
-    setPage(1);
-  }, []);
-
-  const setSearch = useCallback((next: string) => {
-    setSearchState(next);
-    setPage(1);
-  }, []);
-
-  return {
-    page,
-    limit,
-    ordering,
-    search,
-    setPage,
-    setLimit,
-    sortBy,
-    setSearch,
-    /**
-     * Fetch identity for `use-report`, which refetches when this changes and
-     * has no other way to know. Every value the request is built from has to
-     * appear here: omit one and the control that changes it goes dead.
-     */
-    requestKey: `${limit}:${search}:${page}:${ordering}`,
-  };
+/** Page, size, sort and search for the squad-depth table. */
+export function useTeamTable() {
+  return useRankedTable<TeamOrdering>({
+    defaultOrdering: 'players',
+    toggle: nextOrdering,
+  });
 }

--- a/lib/__tests__/nation-param.test.ts
+++ b/lib/__tests__/nation-param.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { parseNationFilter } from '@/lib/nation-param';
+
+describe('parseNationFilter', () => {
+  it('reads a nation code out of the query string', () => {
+    expect(parseNationFilter('ITA')).toBe('ITA');
+  });
+
+  it('ignores a missing or blank parameter', () => {
+    // Blank is not a filter: sending `nation=` would look like a filter that is
+    // on while narrowing nothing.
+    expect(parseNationFilter(null)).toBeNull();
+    expect(parseNationFilter(undefined)).toBeNull();
+    expect(parseNationFilter('   ')).toBeNull();
+  });
+
+  it('trims what a copied link arrives with', () => {
+    expect(parseNationFilter(' ESP ')).toBe('ESP');
+  });
+
+  it('refuses a value too long to be a nation', () => {
+    // The endpoint matches name, nationality or short code with a LIKE, so an
+    // unbounded value is an unbounded scan for something that cannot match.
+    expect(parseNationFilter('x'.repeat(200))).toBeNull();
+  });
+
+  it('keeps a full nation name, since the endpoint accepts one', () => {
+    // `?nation=` matches name, nationality or short code — the links send the
+    // short code, but a hand-typed name is a legitimate thing to arrive with.
+    expect(parseNationFilter('Portugal')).toBe('Portugal');
+  });
+});

--- a/lib/nation-param.ts
+++ b/lib/nation-param.ts
@@ -1,0 +1,34 @@
+/** Longer than any nation name or code, short enough to bound the LIKE. */
+const MAX_NATION_FILTER = 60;
+
+/**
+ * The nation carried in `/footballer-management?nation=<code>`.
+ *
+ * The nations analytics page links every row here, so this arrives from a URL
+ * and can be anything. `/data/footballers/` matches it against name,
+ * nationality or short code with a LIKE, so the risk is not a bad query but an
+ * unbounded one — and a blank value would read as a filter that is switched on
+ * while narrowing nothing.
+ *
+ * The links send the short code. A hand-typed full name is equally valid,
+ * because the endpoint accepts both.
+ */
+export function parseNationFilter(raw: string | null | undefined): string | null {
+  const value = (raw ?? '').trim();
+  if (!value || value.length > MAX_NATION_FILTER) {
+    return null;
+  }
+  return value;
+}
+
+/**
+ * Where a nation's footballers can be seen and edited.
+ *
+ * The other end of `parseNationFilter`, kept in the same module so the two
+ * halves of the link cannot drift apart. The short code rather than the id:
+ * `/data/footballers/` filters by name, nationality or short code, and the id
+ * is not one of them.
+ */
+export function nationFootballersHref(short: string): string {
+  return `/footballer-management?nation=${encodeURIComponent(short)}`;
+}

--- a/lib/reports-api.ts
+++ b/lib/reports-api.ts
@@ -16,6 +16,7 @@ import type {
   LineupsAnalyticsResponse,
   MultiplayerResponse,
   NationGapsResponse,
+  NationOrdering,
   PatternsResponse,
   PlayerDetailResponse,
   ProgressResponse,
@@ -166,27 +167,38 @@ export class ReportsAPI {
    * changed in a window, and offering a date filter would imply the number
    * moves with it.
    */
-  static async getNationGaps(limit?: number): Promise<NationGapsResponse> {
-    return apiFetcher<NationGapsResponse>(`core/analytics/football-data/nations/${buildQuery({ limit })}`);
+  static async getNationGaps(
+    limit?: number,
+    pageSize?: number,
+    page?: number,
+    ordering?: NationOrdering,
+  ): Promise<NationGapsResponse> {
+    return apiFetcher<NationGapsResponse>(
+      `core/analytics/football-data/nations/${buildQuery({ limit, page_size: pageSize, page, ordering })}`,
+    );
   }
 
   /**
    * GET /core/analytics/football-data/teams/ — empty teams, the review queue,
    * and one page of the squad-depth table.
    *
-   * `limit` is the page size of that table AND the cap on the empty-team
-   * worklist — the endpoint takes one for both. `page` is clamped server-side,
-   * so an out-of-range page shows the last one instead of an empty table, and
-   * an unknown `ordering` is a 400 rather than a silently different sort.
+   * `limit` caps the empty-team worklist; `pageSize` sizes the depth table.
+   * Two parameters because they answer to different controls — sharing one
+   * meant the table's row-count dropdown also rewrote the worklist.
+   *
+   * `page` is clamped server-side, so an out-of-range page shows the last one
+   * instead of an empty table, and an unknown `ordering` is a 400 rather than a
+   * silently different sort.
    */
   static async getTeamGaps(
     limit?: number,
     search?: string,
     page?: number,
     ordering?: TeamOrdering,
+    pageSize?: number,
   ): Promise<TeamGapsResponse> {
     return apiFetcher<TeamGapsResponse>(
-      `core/analytics/football-data/teams/${buildQuery({ limit, search, page, ordering })}`,
+      `core/analytics/football-data/teams/${buildQuery({ limit, search, page, ordering, page_size: pageSize })}`,
     );
   }
 

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -1182,10 +1182,25 @@ export type CappedRows<T> = {
 /** Counts by non-approved status. Empty when nothing is waiting. */
 export type ReviewQueue = Record<string, number>;
 
+/** Who a nation is, in any of the three lists on the nations page. */
+export type NationRow = {
+  id: number;
+  name: string;
+  /** The three-letter code. Doubles as the fallback when there is no flag. */
+  short: string;
+  /** 230 of 233 active nations have one, so expect this to be set. */
+  flag: string | null;
+};
+
+/** How the ranked nation table may be ordered. Rejected server-side if unknown. */
+export type NationOrdering = 'footballers' | 'footballers_asc' | 'name';
+
 export type NationGapsResponse = {
-  nations_without_footballers: CappedRows<{ name: string; short: string }>;
-  nations_without_teams: CappedRows<{ name: string; short: string }>;
-  nations_by_footballers: CappedRows<{ name: string; short: string; footballers: number }>;
+  nations_without_footballers: CappedRows<NationRow>;
+  nations_without_teams: CappedRows<NationRow>;
+  nations_by_footballers: PagedRows<NationRow & { footballers: number }>;
+  /** Echoed so the header can mark the column the server actually sorted by. */
+  ordering?: NationOrdering | null;
 };
 
 /**


### PR DESCRIPTION
The teams treatment applied to nations, with the pieces both pages now share pulled out rather than copied.

## Where the catalogue is deepest

That panel was a capped list of names and counts. It is now the same sortable, paged, linked table as squad depth: flag, name, short code, and the count as the figure. Both headers sort through the server.

It is a much shorter table than teams — around 233 nations against 4,402 teams — so paging matters less here than the sort does. Reading it by name and reading it by depth are two different questions, and it could previously answer neither.

Every row opens `/footballer-management?nation=<code>`, which lists that nation's footballers with the existing filters and inline editing. **No new page and no new endpoint**: `/data/footballers/` already filters by name, nationality or short code, and that screen already shows everything a nation-players page would have. Teams needed their own page because a squad shows the years each footballer was there; a nation's footballers is a filtered footballer list.

## The two gap lists

Chips with flags, kept apart because they are different jobs. Footballer-less nations link to the same filtered list — an empty one, which is the honest view of the gap, with the Add form on the same screen.

Team-less nations link to the Django admin's add-team form with the nation prefilled. The one external link on the page, and it is there because nothing in this app creates a team: the alternative is a chip naming a job with nowhere to do it.

## Shared, not copied

`IdentityTile` holds what the two crests do the same — resolve against the API, load lazily, step aside for text when absent or broken. `TeamCrest` falls back to initials and `NationCrest` to the short code, which is what a nation is already called in every other column. The existing `TeamCrest` tests pass unchanged, which is what makes the extraction safe.

`useRankedTable` holds the page/size/sort/search rules and the reset that keeps them consistent; `useTeamTable` and `useNationTable` are the toggles on top. `SortableHeader` and `TableControls` are the markup. `sortState` reads both tables' orderings, since they name them the same way.

## Page size is not the worklist cap

One `limit` used to size the table *and* cap the lists beside it, so the row-count dropdown quietly rewrote them — on nations it would have rewritten two at once. Both pages now hold a separate worklist limit, and "show more" on a worklist no longer resizes the table.

## Depends on

https://github.com/FootballExtraTime/App/pull/1520 — the `id`/`flag` on nation rows, the paging, and the `page_size` parameter. Until it deploys the nations panels render from the old capped shape, and `NationDepth` returns null rather than breaking if `page` is absent.

## Verification

- 821 tests pass, `tsc --noEmit` clean, `lint:reports` and `app/analytics components/analytics` both clean at `--max-warnings 0`, `next build` compiles with no errors or warnings.
- Four guards mutation-tested: the name column's sort direction, the nation sort toggle, the nation filter's length bound, and the admin link on team-less nations.

Refs https://github.com/FootballExtraTime/App/issues/1474

🤖 Generated with [Claude Code](https://claude.com/claude-code)