### PR TITLE
Link nations by id, which is what the filter accepts

### DIFF
--- a/app/footballer-management/page.tsx
+++ b/app/footballer-management/page.tsx
@@ -30,7 +30,7 @@ import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useAuth } from '@/lib/auth';
 import { FootballerAPI } from '@/lib/footballer-api';
-import { parseNationFilter } from '@/lib/nation-param';
+import { parseNationId } from '@/lib/nation-param';
 
 export default function FootballerManagementPage() {
   const { isLoading, isAuthenticated } = useAuth();
@@ -54,10 +54,12 @@ export default function FootballerManagementPage() {
 
   // Filter and search states
   const [searchQuery, setSearchQuery] = useState('');
-  // Set from `?nation=<code>` by the nations analytics page, which links every
-  // row and every gap chip here. Not a control in the filter bar: it arrives
+  // Set from `?nation=<id>` by the nations analytics page, which links every
+  // row and every gap chip here. An id rather than a code: `nation` is filtered
+  // through a ModelChoiceFilter on the ForeignKey, so anything else comes back
+  // as "Select a valid choice". Not a control in the filter bar — it arrives
   // with the link and is cleared with the others.
-  const [nationFilter, setNationFilter] = useState('');
+  const [nationFilter, setNationFilter] = useState<number | null>(null);
   const [statusFilter, setStatusFilter] = useState('all');
   const [retiredFilter, setRetiredFilter] = useState('all');
   const [isPlayerFilter, setIsPlayerFilter] = useState('all');
@@ -162,7 +164,7 @@ export default function FootballerManagementPage() {
     if (consumedNationParam.current || !isAuthenticated) {
       return;
     }
-    const fromUrl = parseNationFilter(searchParams?.get('nation'));
+    const fromUrl = parseNationId(searchParams?.get('nation'));
     if (fromUrl === null) {
       return;
     }
@@ -178,7 +180,7 @@ export default function FootballerManagementPage() {
     // The deep-link effect fetches in the same tick it sets the filter, so the
     // state it just set is not readable yet. Passing the value avoids a fetch
     // that silently ignores the nation it was opened for.
-    nationOverride?: string,
+    nationOverride?: number,
   ) => {
     setLoading(true);
     setError(null);
@@ -197,9 +199,8 @@ export default function FootballerManagementPage() {
       }
 
       // Add filters
-      const nation = (nationOverride ?? nationFilter).trim();
-      if (nation) {
-        // Matched server-side against name, nationality or short code.
+      const nation = nationOverride ?? nationFilter;
+      if (nation !== null) {
         params.nation = nation;
       }
       if (statusFilter && statusFilter !== 'all') {
@@ -654,7 +655,7 @@ export default function FootballerManagementPage() {
 
   const handleClearFilters = () => {
     setSearchQuery('');
-    setNationFilter('');
+    setNationFilter(null);
     setStatusFilter('all');
     setRetiredFilter('all');
     setIsPlayerFilter('all');
@@ -675,9 +676,12 @@ export default function FootballerManagementPage() {
       filters.push(`Search: "${searchQuery}"`);
     }
     // Listed like any other filter, because it is one — arriving by link should
-    // not leave a narrowing nobody can see and nobody can clear.
-    if (nationFilter.trim()) {
-      filters.push(`Nation: ${nationFilter.trim()}`);
+    // not leave a narrowing nobody can see and nobody can clear. Named rather
+    // than numbered: the nations are already loaded for the create form, and
+    // "Nation: 5" tells the reader nothing.
+    if (nationFilter !== null) {
+      const named = nations.find(n => n.id === nationFilter);
+      filters.push(`Nation: ${named ? named.name : `#${nationFilter}`}`);
     }
     if (statusFilter !== 'all') {
       const statusLabels = {

--- a/components/analytics/__tests__/NationGaps.test.tsx
+++ b/components/analytics/__tests__/NationGaps.test.tsx
@@ -52,14 +52,15 @@ describe('nationDepth', () => {
     expect(within(rows[0]).getByText('21')).toBeInTheDocument();
   });
 
-  it('sends every nation to its footballers', () => {
-    // The short code, not the id: `/data/footballers/` filters by name,
-    // nationality or short code, and the id is not one of them.
+  it('sends every nation to its footballers, by id', () => {
+    // The id, not the short code: `/data/footballers/` filters `nation`
+    // through a ModelChoiceFilter, so a code is rejected outright with
+    // "Select a valid choice" rendered as a page-level error.
     render(<NationDepth data={data()} {...depthProps} />);
 
     expect(screen.getByRole('link', { name: /Italy/ })).toHaveAttribute(
       'href',
-      '/footballer-management?nation=ITA',
+      '/footballer-management?nation=1',
     );
   });
 
@@ -102,7 +103,7 @@ describe('nationGaps', () => {
 
     expect(screen.getByRole('link', { name: /Tuvalu/ })).toHaveAttribute(
       'href',
-      '/footballer-management?nation=TUV',
+      '/footballer-management?nation=40',
     );
   });
 

--- a/components/analytics/panels/NationDepth.tsx
+++ b/components/analytics/panels/NationDepth.tsx
@@ -89,7 +89,7 @@ export function NationDepth({ data, ordering, onSort, onPageChange, onPageSizeCh
                           </td>
                           <td className="px-2 py-1.5">
                             <Link
-                              href={nationFootballersHref(row.short)}
+                              href={nationFootballersHref(row.id)}
                               className="flex items-center gap-2.5 rounded-md py-0.5"
                             >
                               <NationCrest short={row.short} flag={row.flag} />

--- a/components/analytics/panels/NationGaps.tsx
+++ b/components/analytics/panels/NationGaps.tsx
@@ -70,7 +70,7 @@ export function NationGaps({ data, onExpand, expanded }: {
                 <li key={row.short}>
                   {/* Lands on an empty filtered list, which is the honest view
                       of the gap — and the Add form is on the same screen. */}
-                  <Link href={nationFootballersHref(row.short)} className={CHIP}>
+                  <Link href={nationFootballersHref(row.id)} className={CHIP}>
                     <NationChip row={row} />
                   </Link>
                 </li>

--- a/lib/__tests__/nation-param.test.ts
+++ b/lib/__tests__/nation-param.test.ts
@@ -1,32 +1,32 @@
 import { describe, expect, it } from 'vitest';
-import { parseNationFilter } from '@/lib/nation-param';
+import { nationFootballersHref, parseNationId } from '@/lib/nation-param';
 
-describe('parseNationFilter', () => {
-  it('reads a nation code out of the query string', () => {
-    expect(parseNationFilter('ITA')).toBe('ITA');
+describe('parseNationId', () => {
+  it('reads a nation id out of the query string', () => {
+    expect(parseNationId('5')).toBe(5);
+  });
+
+  it('refuses a short code, which the endpoint cannot use', () => {
+    // `/data/footballers/` filters `nation` through a django-filter
+    // ModelChoiceFilter, so the value has to be a primary key. A code gets
+    // "Select a valid choice. That choice is not one of the available choices."
+    // rendered at the top of the page, which reads as the page being broken.
+    //
+    // The name/nationality/short-code form of this filter exists, but on
+    // `FootballerSearchView` — a different endpoint from the one this page uses.
+    expect(parseNationId('ENG')).toBeNull();
+    expect(parseNationId('England')).toBeNull();
   });
 
   it('ignores a missing or blank parameter', () => {
-    // Blank is not a filter: sending `nation=` would look like a filter that is
-    // on while narrowing nothing.
-    expect(parseNationFilter(null)).toBeNull();
-    expect(parseNationFilter(undefined)).toBeNull();
-    expect(parseNationFilter('   ')).toBeNull();
+    expect(parseNationId(null)).toBeNull();
+    expect(parseNationId(undefined)).toBeNull();
+    expect(parseNationId('   ')).toBeNull();
   });
+});
 
-  it('trims what a copied link arrives with', () => {
-    expect(parseNationFilter(' ESP ')).toBe('ESP');
-  });
-
-  it('refuses a value too long to be a nation', () => {
-    // The endpoint matches name, nationality or short code with a LIKE, so an
-    // unbounded value is an unbounded scan for something that cannot match.
-    expect(parseNationFilter('x'.repeat(200))).toBeNull();
-  });
-
-  it('keeps a full nation name, since the endpoint accepts one', () => {
-    // `?nation=` matches name, nationality or short code — the links send the
-    // short code, but a hand-typed name is a legitimate thing to arrive with.
-    expect(parseNationFilter('Portugal')).toBe('Portugal');
+describe('nationFootballersHref', () => {
+  it('links by id, because that is what the filter accepts', () => {
+    expect(nationFootballersHref(5)).toBe('/footballer-management?nation=5');
   });
 });

--- a/lib/__tests__/url-params.test.ts
+++ b/lib/__tests__/url-params.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { parsePositiveIntParam } from '@/lib/url-params';
+
+describe('parsePositiveIntParam', () => {
+  it('reads a row id out of the query string', () => {
+    expect(parsePositiveIntParam('1042')).toBe(1042);
+  });
+
+  it('ignores a missing parameter', () => {
+    expect(parsePositiveIntParam(null)).toBeNull();
+    expect(parsePositiveIntParam(undefined)).toBeNull();
+    expect(parsePositiveIntParam('')).toBeNull();
+  });
+
+  it('refuses anything that is not a whole positive number', () => {
+    // These go into a path or a primary-key filter, so a value that is not an
+    // id is a request that can only fail — and the failure arrives as a Django
+    // validation message that reads like the page is broken.
+    for (const raw of ['abc', '12abc', '0', '-3', '1.5', 'Infinity', 'NaN', 'ENG']) {
+      expect(parsePositiveIntParam(raw), raw).toBeNull();
+    }
+  });
+
+  it('tolerates the whitespace a copied-and-pasted value arrives with', () => {
+    expect(parsePositiveIntParam(' 7 ')).toBe(7);
+  });
+});

--- a/lib/nation-param.ts
+++ b/lib/nation-param.ts
@@ -1,34 +1,28 @@
-/** Longer than any nation name or code, short enough to bound the LIKE. */
-const MAX_NATION_FILTER = 60;
+import { parsePositiveIntParam } from '@/lib/url-params';
 
 /**
- * The nation carried in `/footballer-management?nation=<code>`.
+ * The nation carried in `/footballer-management?nation=<id>`.
  *
- * The nations analytics page links every row here, so this arrives from a URL
- * and can be anything. `/data/footballers/` matches it against name,
- * nationality or short code with a LIKE, so the risk is not a bad query but an
- * unbounded one — and a blank value would read as a filter that is switched on
- * while narrowing nothing.
+ * An id, not a short code. `/data/footballers/` filters `nation` through a
+ * django-filter `ModelChoiceFilter` built from the ForeignKey, so the value has
+ * to be a primary key — `?nation=ENG` comes back as "Select a valid choice.
+ * That choice is not one of the available choices." and the page renders it as
+ * a top-level error, which reads as the page being broken.
  *
- * The links send the short code. A hand-typed full name is equally valid,
- * because the endpoint accepts both.
+ * The name/nationality/short-code form of this filter does exist, but on
+ * `FootballerSearchView`, which is a different endpoint from the one this page
+ * lists with. Every nations analytics row carries the id anyway.
  */
-export function parseNationFilter(raw: string | null | undefined): string | null {
-  const value = (raw ?? '').trim();
-  if (!value || value.length > MAX_NATION_FILTER) {
-    return null;
-  }
-  return value;
+export function parseNationId(raw: string | null | undefined): number | null {
+  return parsePositiveIntParam(raw);
 }
 
 /**
  * Where a nation's footballers can be seen and edited.
  *
- * The other end of `parseNationFilter`, kept in the same module so the two
- * halves of the link cannot drift apart. The short code rather than the id:
- * `/data/footballers/` filters by name, nationality or short code, and the id
- * is not one of them.
+ * The other end of `parseNationId`, kept in the same module so the two halves
+ * of the link cannot drift apart.
  */
-export function nationFootballersHref(short: string): string {
-  return `/footballer-management?nation=${encodeURIComponent(short)}`;
+export function nationFootballersHref(id: number): string {
+  return `/footballer-management?nation=${id}`;
 }

--- a/lib/team-id-param.ts
+++ b/lib/team-id-param.ts
@@ -1,3 +1,5 @@
+import { parsePositiveIntParam } from '@/lib/url-params';
+
 /**
  * The team id carried in `/team-players?teamId=<id>`.
  *
@@ -7,17 +9,7 @@
  * endpoint answers a nonsense id with a 404 which the page explains as "the
  * backend may not have this deployed yet". True for a real missing endpoint,
  * an actively misleading thing to say about a typo.
- *
- * So it is validated here rather than trusted: a whole positive number, or
- * nothing at all.
  */
 export function parseTeamId(raw: string | null | undefined): number | null {
-  if (!raw) {
-    return null;
-  }
-  const parsed = Number(raw);
-  if (!Number.isInteger(parsed) || parsed <= 0) {
-    return null;
-  }
-  return parsed;
+  return parsePositiveIntParam(raw);
 }

--- a/lib/url-params.ts
+++ b/lib/url-params.ts
@@ -1,0 +1,24 @@
+/**
+ * A row id carried in a query string.
+ *
+ * These arrive from links on other pages, so they can be anything, and they go
+ * straight into a URL path or a primary-key filter. A value that is not an id
+ * cannot fail quietly: `/data/team/<id>/players/` answers with a 404 the page
+ * explains as "the backend may not have this deployed yet", and
+ * `/data/footballers/?nation=` answers with a Django validation message
+ * rendered at the top of the screen. Both read as the page being broken rather
+ * than the link being wrong.
+ *
+ * So it is validated here rather than trusted: a whole positive number, or
+ * nothing at all.
+ */
+export function parsePositiveIntParam(raw: string | null | undefined): number | null {
+  if (!raw) {
+    return null;
+  }
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return null;
+  }
+  return parsed;
+}


### PR DESCRIPTION
`/footballer-management?nation=ENG` rendered **"Select a valid choice. That choice is not one of the available choices."** across the top of the page. Reported on production after #149.

## Root cause

`FootballerFilter` lists `nation` in `Meta.fields`, and it is a ForeignKey — so django-filter builds a `ModelChoiceFilter` keyed on the **primary key**. A short code fails validation before the view body ever runs.

Verified against the running endpoint rather than inferred:

```
England id = 5
?nation=ENG -> HTTP 400 | {'nation': ['Select a valid choice. That choice is not one of the available choices.'], ...}
?nation=5   -> HTTP 200 | 467
```

The name/nationality/short-code filter I built the link around is real, but it belongs to `FootballerSearchView` — a different endpoint from the one this page lists with. I read its `OpenApiParameter` block and attributed it to `/data/footballers/`.

## Fix

Every nations analytics row already carries the id, so both panels link by it and the page parses it as one. No backend change.

The active-filter chip resolves the name from the nations the page already loads for the create form, so it still reads "Nation: England" rather than "Nation: 5".

The "an id from a URL must be a whole positive number" rule now lives once, in `parsePositiveIntParam`, with `parseTeamId` and `parseNationId` on top of it. Both endpoints punish a bad id in a way that reads as the page being broken rather than the link being wrong — a 404 the team page explains as "not deployed yet", and this validation error.

## Verification

- 824 tests pass, `tsc --noEmit` clean, `lint:reports` clean, `next build` compiles with no errors or warnings.
- The guard is mutation-tested: removing the validation fails tests in all three modules.
- `app/footballer-management` lint warnings are unchanged at 4 — same before and after this branch.

Refs https://github.com/FootballExtraTime/App/issues/1474

🤖 Generated with [Claude Code](https://claude.com/claude-code)