### PR TITLE
Filter the nations table, and put the gaps under it

### DIFF
--- a/app/analytics/football-data/nations/page.tsx
+++ b/app/analytics/football-data/nations/page.tsx
@@ -30,7 +30,13 @@ export default function NationsAnalyticsPage() {
   const [worklistLimit, setWorklistLimit] = useState(WORKLIST);
 
   const state = useReport(
-    () => ReportsAPI.getNationGaps(worklistLimit, table.pageSize, table.page, table.ordering),
+    () => ReportsAPI.getNationGaps(
+      worklistLimit,
+      table.pageSize,
+      table.page,
+      table.ordering,
+      table.search || undefined,
+    ),
     {},
     enabled,
     'The nation gaps endpoint',
@@ -41,27 +47,32 @@ export default function NationsAnalyticsPage() {
   return (
     <AnalyticsShell
       title="Nations"
-      description="Which nations nothing points at, and where the catalogue is deepest."
+      description="Where the catalogue is deepest, and which nations nothing points at."
     >
+      {/* The table first. It is what the page is for — the two worklists below
+          are the follow-up, and at the top they pushed the ranking under the
+          fold on every laptop. */}
+      <ReportPanel state={state} skeletonClassName="h-96 w-full">
+        {data => (
+          <NationDepth
+            data={data}
+            search={table.search}
+            onSearchChange={table.setSearch}
+            ordering={table.ordering}
+            onSort={table.sortBy}
+            onPageChange={table.setPage}
+            onPageSizeChange={table.setPageSize}
+            busy={state.isLoading}
+          />
+        )}
+      </ReportPanel>
+
       <ReportPanel state={state} skeletonClassName="h-80 w-full">
         {data => (
           <NationGaps
             data={data}
             expanded={worklistLimit >= EXPANDED}
             onExpand={() => setWorklistLimit(EXPANDED)}
-          />
-        )}
-      </ReportPanel>
-
-      <ReportPanel state={state} skeletonClassName="h-96 w-full">
-        {data => (
-          <NationDepth
-            data={data}
-            ordering={table.ordering}
-            onSort={table.sortBy}
-            onPageChange={table.setPage}
-            onPageSizeChange={table.setPageSize}
-            busy={state.isLoading}
           />
         )}
       </ReportPanel>

--- a/components/analytics/__tests__/NationGaps.test.tsx
+++ b/components/analytics/__tests__/NationGaps.test.tsx
@@ -1,5 +1,5 @@
 import type { NationGapsResponse } from '@/types/reports';
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { NationDepth } from '@/components/analytics/panels/NationDepth';
 import { NationGaps } from '@/components/analytics/panels/NationGaps';
@@ -32,6 +32,8 @@ function data(over: Partial<NationGapsResponse> = {}): NationGapsResponse {
 }
 
 const depthProps = {
+  search: '',
+  onSearchChange: vi.fn(),
   ordering: 'footballers' as const,
   onSort: vi.fn(),
   onPageChange: vi.fn(),
@@ -83,6 +85,58 @@ describe('nationDepth', () => {
     expect(screen.getByText('Showing 2 of 178 results')).toBeInTheDocument();
     expect(screen.getByLabelText('Rows per page')).toBeInTheDocument();
   });
+
+  it('names what the filter box filters', () => {
+    // The box sits on the card rather than in a page filter bar, so its
+    // accessible name is the only thing saying WHICH of the three lists it
+    // narrows. A placeholder cannot do that job — it disappears on the first
+    // keystroke.
+    render(<NationDepth data={data()} {...depthProps} />);
+
+    expect(screen.getByLabelText('Filter nations in this table')).toBeInTheDocument();
+  });
+
+  it('debounces the filter instead of firing a request per keystroke', async () => {
+    vi.useFakeTimers();
+    try {
+      const onSearchChange = vi.fn();
+      render(<NationDepth data={data()} {...depthProps} onSearchChange={onSearchChange} />);
+
+      const box = screen.getByLabelText('Filter nations in this table');
+
+      fireEvent.change(box, { target: { value: 'i' } });
+      fireEvent.change(box, { target: { value: 'it' } });
+      fireEvent.change(box, { target: { value: 'ita' } });
+
+      // Nothing yet: "ita" as three requests can also answer out of order.
+      expect(onSearchChange).not.toHaveBeenCalled();
+
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+
+      expect(onSearchChange).toHaveBeenCalledTimes(1);
+      expect(onSearchChange).toHaveBeenCalledWith('ita');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('tells an empty search apart from an empty catalogue', () => {
+    // "No footballers are assigned to a nation yet" under a filter that matched
+    // nothing reads as the data having vanished.
+    const empty = data({
+      nations_by_footballers: { ...data().nations_by_footballers, items: [], total: 0 },
+    });
+
+    const { rerender } = render(<NationDepth data={empty} {...depthProps} search="zz" />);
+
+    expect(screen.getByText('No nation matches "zz".')).toBeInTheDocument();
+
+    rerender(<NationDepth data={empty} {...depthProps} search="" />);
+
+    expect(screen.getByText('No footballers are assigned to a nation yet.')).toBeInTheDocument();
+  });
 });
 
 describe('nationGaps', () => {
@@ -125,5 +179,41 @@ describe('nationGaps', () => {
 
     expect(screen.getByText('Showing 1 of 55')).toBeInTheDocument();
     expect(screen.getByText('Showing 1 of 61')).toBeInTheDocument();
+  });
+
+  it('leads with the count, because the count is the signal', () => {
+    // The list is a sample — rows 40 to 55 are identical in kind — so the
+    // number is the thing to read first, not 12px grey text under the chips.
+    render(<NationGaps data={data()} />);
+
+    expect(screen.getByText('55')).toBeInTheDocument();
+    expect(screen.getByText('61')).toBeInTheDocument();
+  });
+
+  it('reads zero as good news rather than as a blank panel', () => {
+    render(
+      <NationGaps
+        data={data({
+          nations_without_footballers: { items: [], total: 0, limit: 10 },
+          nations_without_teams: { items: [], total: 0, limit: 10 },
+        })}
+      />,
+    );
+
+    expect(screen.getByText('Every active nation has at least one footballer.')).toBeInTheDocument();
+    expect(screen.getByText('Every active nation has at least one team.')).toBeInTheDocument();
+    // No "Showing 0 of 0" and no expand button to press.
+    expect(screen.queryByRole('button', { name: /Show/ })).not.toBeInTheDocument();
+  });
+
+  it('says the admin link leaves the app', () => {
+    // The one link on the page that opens a new tab. Unannounced, it reads as
+    // the page having jumped somewhere on its own.
+    render(<NationGaps data={data()} />);
+
+    expect(screen.getByRole('link', { name: /opens the Django admin in a new tab/ })).toHaveAttribute(
+      'target',
+      '_blank',
+    );
   });
 });

--- a/components/analytics/panels/NationDepth.tsx
+++ b/components/analytics/panels/NationDepth.tsx
@@ -4,28 +4,32 @@ import type { NationGapsResponse, NationOrdering } from '@/types/reports';
 import Link from 'next/link';
 import { NationCrest } from '@/components/analytics/NationCrest';
 import { SortableHeader, TableControls } from '@/components/analytics/RankedTable';
+import { SearchBox } from '@/components/reports/filters/SearchBox';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { nationFootballersHref } from '@/lib/nation-param';
 
 /**
  * Where the catalogue is deepest.
  *
- * Context for the two gap lists beside it: those say what cannot be used at
+ * Context for the two gap lists below it: those say what cannot be used at
  * all, this says what the games will actually feel like to play. A nation with
  * four footballers is not a gap, but it is not depth either, and only a ranked
  * table shows you where the falloff starts.
  *
- * Paged and sorted by the server, like the teams table. There are far fewer
- * nations than teams — around 233 against 4,402 — so this is a shorter table,
- * but the sort is the point: reading it by name and reading it by depth are two
- * different questions.
+ * Paged, sorted and filtered by the server, like the teams table. There are far
+ * fewer nations than teams — around 233 against 4,402 — so this is a shorter
+ * table, but the sort is the point: reading it by name and reading it by depth
+ * are two different questions, and finding one nation among 233 is a third.
  */
-export function NationDepth({ data, ordering, onSort, onPageChange, onPageSizeChange, busy }: {
+export function NationDepth({ data, search, onSearchChange, ordering, onSort, onPageChange, onPageSizeChange, busy }: {
   data: NationGapsResponse;
+  search: string;
+  onSearchChange: (next: string) => void;
   ordering: NationOrdering;
   onSort: (column: string) => void;
   onPageChange: (page: number) => void;
   onPageSizeChange: (size: number) => void;
+  /** A request is in flight — the controls stay visible but inert. */
   busy?: boolean;
 }) {
   const ranked = data.nations_by_footballers;
@@ -40,18 +44,32 @@ export function NationDepth({ data, ordering, onSort, onPageChange, onPageSizeCh
 
   return (
     <Card>
-      <CardHeader>
-        <CardTitle>Where the catalogue is deepest</CardTitle>
-        <CardDescription>
-          Context for the gaps above: this is what the games will actually feel like to play.
-          Every row opens that nation's footballers.
-        </CardDescription>
+      <CardHeader className="gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-1.5">
+          <CardTitle>Where the catalogue is deepest</CardTitle>
+          <CardDescription>
+            Context for the gaps below: this is what the games will actually feel like to play.
+            Every row opens that nation's footballers.
+          </CardDescription>
+        </div>
+        {/* ON this card, like the squad-depth one. In the page filter bar it
+            would sit with nothing to say which of the three lists it narrows —
+            and it narrows only this one. */}
+        <SearchBox
+          value={search}
+          onChange={onSearchChange}
+          label="Filter nations in this table"
+          placeholder="Name or code…"
+          className="w-full shrink-0 sm:w-56"
+        />
       </CardHeader>
       <CardContent className="space-y-4">
         {ranked.total === 0
           ? (
               <p className="text-sm text-muted-foreground">
-                No footballers are assigned to a nation yet.
+                {search
+                  ? `No nation matches "${search}".`
+                  : 'No footballers are assigned to a nation yet.'}
               </p>
             )
           : (

--- a/components/analytics/panels/NationGaps.tsx
+++ b/components/analytics/panels/NationGaps.tsx
@@ -1,14 +1,40 @@
 'use client';
 
+import type { LucideIcon } from 'lucide-react';
+import type { ReactNode } from 'react';
 import type { NationGapsResponse, NationRow } from '@/types/reports';
+import { Check, ExternalLink, ShieldOff, UserRoundX } from 'lucide-react';
 import Link from 'next/link';
 import { NationCrest } from '@/components/analytics/NationCrest';
 import { CappedList } from '@/components/reports/primitives/CappedList';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import config from '@/lib/config';
 import { nationFootballersHref } from '@/lib/nation-param';
+import { cn } from '@/lib/utils';
 
-const CHIP = 'inline-flex items-center gap-2 rounded-md bg-muted/60 px-2 py-1 text-sm ring-1 ring-inset ring-border transition-colors hover:bg-muted';
+/**
+ * One accent per gap, so the two cards are told apart before they are read.
+ *
+ * `chart-2` and `chart-3` rather than raw Tailwind colours: both are redefined
+ * under `.dark` in `globals.css`, so this survives the theme switch. Written
+ * out in full because Tailwind scans for literal class names — building
+ * `bg-chart-${n}/10` would emit nothing and fail silently, which is the
+ * failure the content globs in `tailwind.config.ts` are commented about.
+ */
+const ACCENTS = {
+  amber: {
+    tile: 'bg-chart-3/10 text-chart-3 ring-chart-3/20',
+    figure: 'text-chart-3',
+    chip: 'hover:border-chart-3/40 hover:bg-chart-3/5',
+  },
+  sky: {
+    tile: 'bg-chart-2/10 text-chart-2 ring-chart-2/20',
+    figure: 'text-chart-2',
+    chip: 'hover:border-chart-2/40 hover:bg-chart-2/5',
+  },
+} as const;
+
+const CHIP = 'inline-flex items-center gap-2 rounded-lg border bg-card px-2.5 py-1.5 text-sm transition-colors';
 
 /**
  * Where a team for this nation can be created.
@@ -25,10 +51,98 @@ function addTeamHref(nationId: number) {
 function NationChip({ row }: { row: NationRow }) {
   return (
     <>
-      <NationCrest short={row.short} flag={row.flag} className="size-6 rounded" />
+      <NationCrest short={row.short} flag={row.flag} className="size-7 rounded-md" />
       <span className="font-medium text-foreground">{row.name}</span>
-      <span className="text-xs text-muted-foreground">{row.short}</span>
+      {/* The code set apart rather than greyed: it is a different KIND of name,
+          and it is what the table above prints under every row.
+
+          Dropped when there is no flag, because then the crest has ALREADY
+          fallen back to the code and the chip reads "TUV Tuvalu TUV". Three of
+          233 active nations, so it is rare rather than never. */}
+      {row.flag && (
+        <span className="rounded bg-muted px-1 py-px font-mono text-[0.65rem] uppercase tracking-wide text-muted-foreground">
+          {row.short}
+        </span>
+      )}
     </>
+  );
+}
+
+/**
+ * One gap: what it is, how big it is, and a sample you can act on.
+ *
+ * The count is the headline because the count is the signal — the backend caps
+ * these lists on purpose and sends `total` alongside, since rows 40 to 101 of a
+ * worklist are identical in kind. It used to be 12px grey text under the chips,
+ * which is the wrong way round.
+ */
+function GapCard({ title, description, icon: Icon, accent, total, shown, emptyLabel, onExpand, expanded, children }: {
+  title: string;
+  description: string;
+  icon: LucideIcon;
+  accent: keyof typeof ACCENTS;
+  total: number;
+  shown: number;
+  emptyLabel: string;
+  onExpand?: () => void;
+  expanded?: boolean;
+  children: ReactNode;
+}) {
+  const empty = total === 0;
+  const tone = ACCENTS[accent];
+
+  return (
+    <Card>
+      <CardHeader className="flex-row items-start justify-between gap-4 space-y-0">
+        <div className="flex min-w-0 gap-3">
+          <span
+            aria-hidden
+            className={cn('flex size-9 shrink-0 items-center justify-center rounded-lg ring-1 ring-inset', empty ? 'bg-primary/10 text-primary ring-primary/20' : tone.tile)}
+          >
+            <Icon className="size-4" />
+          </span>
+          <div className="min-w-0 space-y-1.5">
+            <CardTitle>{title}</CardTitle>
+            <CardDescription>{description}</CardDescription>
+          </div>
+        </div>
+        {/* Zero is the goal here, so it reads in the brand green rather than in
+            the warning colour the other counts use. */}
+        <div className="shrink-0 text-right">
+          <p className={cn('text-2xl font-semibold leading-none tabular-nums', empty ? 'text-primary' : tone.figure)}>
+            {total.toLocaleString()}
+          </p>
+          <p className="mt-1 text-[0.7rem] text-muted-foreground">
+            {total === 1 ? 'nation' : 'nations'}
+          </p>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {empty
+          ? (
+              // Not an error and not a blank: for a gap list, zero is the goal,
+              // and a flat grey sentence reads like something failed to load.
+              <p className="flex items-center gap-2 rounded-lg bg-primary/5 px-3 py-2 text-sm text-muted-foreground ring-1 ring-inset ring-primary/15">
+                <Check className="size-4 shrink-0 text-primary" aria-hidden />
+                {emptyLabel}
+              </p>
+            )
+          : (
+              <CappedList
+                total={total}
+                shown={shown}
+                onExpand={onExpand}
+                expanded={expanded}
+                // Unreachable — the zero case is handled above, where it can be
+                // more than a sentence. Kept because the prop is required and
+                // the two have to agree.
+                emptyLabel={emptyLabel}
+              >
+                {children}
+              </CappedList>
+            )}
+      </CardContent>
+    </Card>
   );
 }
 
@@ -40,6 +154,10 @@ function NationChip({ row }: { row: NationRow }) {
  * no nation criterion. A nation with no teams cannot appear in club-based
  * content. They overlap heavily, and fixing one does not fix the other.
  *
+ * Below the ranked table rather than above it: the table is what the page is
+ * for, and two worklists at the top pushed it under the fold. These are the
+ * follow-up — read the depth, then see what has none.
+ *
  * Active nations only. A defunct country with no footballers is not a gap to
  * fill — mixing the two turns a worklist into a list nobody will action.
  */
@@ -50,68 +168,61 @@ export function NationGaps({ data, onExpand, expanded }: {
 }) {
   return (
     <div className="grid gap-4 lg:grid-cols-2">
-      <Card>
-        <CardHeader>
-          <CardTitle>Nations with no footballers</CardTitle>
-          <CardDescription>
-            Nothing nation-scoped can use these — no national-team clue, no nation criterion.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <CappedList
-            total={data.nations_without_footballers.total}
-            shown={data.nations_without_footballers.items.length}
-            onExpand={onExpand}
-            expanded={expanded}
-            emptyLabel="Every active nation has at least one footballer."
-          >
-            <ul className="flex flex-wrap gap-1.5">
-              {data.nations_without_footballers.items.map(row => (
-                <li key={row.short}>
-                  {/* Lands on an empty filtered list, which is the honest view
-                      of the gap — and the Add form is on the same screen. */}
-                  <Link href={nationFootballersHref(row.id)} className={CHIP}>
-                    <NationChip row={row} />
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          </CappedList>
-        </CardContent>
-      </Card>
+      <GapCard
+        title="Nations with no footballers"
+        description="Nothing nation-scoped can use these — no national-team clue, no nation criterion."
+        icon={UserRoundX}
+        accent="amber"
+        total={data.nations_without_footballers.total}
+        shown={data.nations_without_footballers.items.length}
+        onExpand={onExpand}
+        expanded={expanded}
+        emptyLabel="Every active nation has at least one footballer."
+      >
+        <ul className="flex flex-wrap gap-1.5">
+          {data.nations_without_footballers.items.map(row => (
+            <li key={row.short}>
+              {/* Lands on an empty filtered list, which is the honest view
+                  of the gap — and the Add form is on the same screen. */}
+              <Link href={nationFootballersHref(row.id)} className={cn(CHIP, ACCENTS.amber.chip)}>
+                <NationChip row={row} />
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </GapCard>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Nations with no teams</CardTitle>
-          <CardDescription>
-            A separate gap: club-based content needs a team in the country, not just a player from it.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <CappedList
-            total={data.nations_without_teams.total}
-            shown={data.nations_without_teams.items.length}
-            onExpand={onExpand}
-            expanded={expanded}
-            emptyLabel="Every active nation has at least one team."
-          >
-            <ul className="flex flex-wrap gap-1.5">
-              {data.nations_without_teams.items.map(row => (
-                <li key={row.short}>
-                  <a
-                    href={addTeamHref(row.id)}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className={CHIP}
-                  >
-                    <NationChip row={row} />
-                  </a>
-                </li>
-              ))}
-            </ul>
-          </CappedList>
-        </CardContent>
-      </Card>
+      <GapCard
+        title="Nations with no teams"
+        description="A separate gap: club-based content needs a team in the country, not just a player from it."
+        icon={ShieldOff}
+        accent="sky"
+        total={data.nations_without_teams.total}
+        shown={data.nations_without_teams.items.length}
+        onExpand={onExpand}
+        expanded={expanded}
+        emptyLabel="Every active nation has at least one team."
+      >
+        <ul className="flex flex-wrap gap-1.5">
+          {data.nations_without_teams.items.map(row => (
+            <li key={row.short}>
+              <a
+                href={addTeamHref(row.id)}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={cn(CHIP, ACCENTS.sky.chip)}
+              >
+                <NationChip row={row} />
+                {/* Marked, because it is the one link on the page that leaves
+                    the app — an unannounced new tab reads as the page having
+                    jumped somewhere on its own. */}
+                <ExternalLink className="size-3 shrink-0 text-muted-foreground" aria-hidden />
+                <span className="sr-only">(opens the Django admin in a new tab)</span>
+              </a>
+            </li>
+          ))}
+        </ul>
+      </GapCard>
     </div>
   );
 }

--- a/lib/reports-api.ts
+++ b/lib/reports-api.ts
@@ -166,15 +166,20 @@ export class ReportsAPI {
    * No range parameter: these describe the catalogue as it stands, not what
    * changed in a window, and offering a date filter would imply the number
    * moves with it.
+   *
+   * `search` narrows the ranked table only — matching name or short code — and
+   * leaves the two worklists at their full counts. They are jobs to do, not
+   * rows to browse.
    */
   static async getNationGaps(
     limit?: number,
     pageSize?: number,
     page?: number,
     ordering?: NationOrdering,
+    search?: string,
   ): Promise<NationGapsResponse> {
     return apiFetcher<NationGapsResponse>(
-      `core/analytics/football-data/nations/${buildQuery({ limit, page_size: pageSize, page, ordering })}`,
+      `core/analytics/football-data/nations/${buildQuery({ limit, page_size: pageSize, page, ordering, search })}`,
     );
   }
 

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -1199,6 +1199,11 @@ export type NationGapsResponse = {
   nations_without_footballers: CappedRows<NationRow>;
   nations_without_teams: CappedRows<NationRow>;
   nations_by_footballers: PagedRows<NationRow & { footballers: number }>;
+  /**
+   * Echoed. Narrows the ranked table only — the two worklists keep their full
+   * counts, because they are jobs to do rather than rows to browse.
+   */
+  search?: string | null;
   /** Echoed so the header can mark the column the server actually sorted by. */
   ordering?: NationOrdering | null;
 };


### PR DESCRIPTION
Three changes to `/analytics/football-data/nations`, all pointing the same way: the ranked table is what the page is for.

### Search, debounced

The same `SearchBox` the squad-depth table has — 300ms, spinner while pending, clear button. On the card rather than in a page filter bar, because it narrows one of three lists and its accessible name (`Filter nations in this table`) is the only thing that says which one.

Matches **name or short code**, since the code is printed under every row and typing what is on screen has to find it.

`useRankedTable` already carried `search`, already included it in `requestKey`, and already reset to page one when it changed. The page simply never passed it — so this is mostly wiring.

### The gaps move below the table

They were first, which pushed the ranking under the fold on a laptop. The ranking is what you come here to read; the gaps are the follow-up. `NationDepth`'s description said "the gaps **above**", which is now true again in the other direction.

### The gap cards, redesigned

Before: two flat lists of grey chips, with the count in 12px text underneath.

- **The count leads.** It *is* the signal — the endpoint caps these lists on purpose, because rows 40 to 101 of a worklist are identical in kind. It reads as a figure now, not a footnote.
- **An icon and an accent per card**, so the two jobs are distinguished before they are read. `chart-3` and `chart-2` rather than raw Tailwind colours: both are redefined under `.dark`, so it survives the theme switch. Class names are written out in full — building `bg-chart-${n}/10` emits nothing and fails silently, which is the trap `tailwind.config.ts` is already commented about.
- **Zero reads as good news**, in the brand green with a check, instead of a grey sentence that looks like something failed to load.
- **The admin chips say they leave the app.** They are the only links on the page that open a new tab and they announced nothing, visually or to a screen reader.
- **The code is dropped from a chip whose nation has no flag** — the crest has already fallen back to it, so the chip read "TUV Tuvalu TUV". Three of 233 active nations, so rare rather than never. It showed up the moment it was rendered.

Both cards are now one `GapCard`, which is where the duplication between them was.

### Verified in the browser

Rendered against fixture data in light and dark, including the zero state. That is how the doubled short code was found.

### Depends on

**FootballExtraTime/App#1521** — merge that first. Without it DRF ignores `?search=`, so the box types and nothing narrows. FE-first is a dead filter, not a break; BE-first is invisible.

### Gate

`check-lockfile` → `check-types:app` → `lint:reports` → `test:run` → `build`, all green. **830 tests passed** (up from 824). The changed analytics files were linted explicitly, since `lint:reports` does not reach `components/analytics`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)