### PR TITLE
Add a second matrix: the countries footballers played in

### DIFF
--- a/app/analytics/football-data/footballers/page.tsx
+++ b/app/analytics/football-data/footballers/page.tsx
@@ -18,6 +18,9 @@ import { useAuth } from '@/lib/auth';
 import { rangeToParams } from '@/lib/report-range';
 import { ReportsAPI } from '@/lib/reports-api';
 
+/** One cut, so the panel drops its group-by toggle. */
+const CLUB_DIMENSION = [{ key: 'club_nation', label: 'By country played in' }];
+
 const PAGE = 10;
 const EXPANDED = 100;
 
@@ -37,6 +40,14 @@ export default function FootballersAnalyticsPage() {
   const [matrixDifficulty, setMatrixDifficulty] = useState<string | null>(null);
   const [matrixLimit, setMatrixLimit] = useState(PAGE);
 
+  // The club-nation cut has its own state rather than sharing the matrix
+  // toggle's. It answers a different question and is read alongside the first
+  // table, not instead of it — a shared filter would clear one while reading
+  // the other.
+  const [clubSearch, setClubSearch] = useState('');
+  const [clubDifficulty, setClubDifficulty] = useState<string | null>(null);
+  const [clubLimit, setClubLimit] = useState(PAGE);
+
   const { filters, update } = useReportFilters({
     range: { window: 90 },
     includeBots: false,
@@ -49,6 +60,19 @@ export default function FootballersAnalyticsPage() {
   const params = useMemo(
     () => ({ ...rangeToParams(range), include_bots: includeBots }),
     [range, includeBots],
+  );
+
+  const clubMatrix = useReport(
+    () => ReportsAPI.getDifficultyMatrix(
+      'club_nation',
+      clubLimit,
+      clubSearch || undefined,
+      clubDifficulty ?? undefined,
+    ),
+    {},
+    enabled,
+    'The difficulty matrix endpoint',
+    `club_nation:${clubLimit}:${clubSearch}:${clubDifficulty ?? ''}`,
   );
 
   const matrix = useReport(
@@ -121,6 +145,26 @@ export default function FootballersAnalyticsPage() {
             onDifficultyChange={setMatrixDifficulty}
             expanded={matrixLimit > PAGE}
             onExpand={() => setMatrixLimit(EXPANDED)}
+          />
+        )}
+      </ReportPanel>
+
+      <ReportPanel state={clubMatrix} skeletonClassName="h-[30rem] w-full">
+        {clubData => (
+          <FootballerMatrix
+            data={clubData}
+            title="Footballers by the country they played in"
+            description="Distinct footballers with at least one club in each country, by difficulty. A different question from the table above: the catalogue is thick with Brazilians and thin on anyone who played in Brazil, and a club-based game only cares about the second. Someone who played in England and Italy is in both rows, so these sum to more than the catalogue holds. Approved footballers only."
+            palette="deep"
+            dimension="club_nation"
+            onDimensionChange={() => {}}
+            dimensions={CLUB_DIMENSION}
+            search={clubSearch}
+            onSearchChange={setClubSearch}
+            difficulty={clubDifficulty}
+            onDifficultyChange={setClubDifficulty}
+            expanded={clubLimit > PAGE}
+            onExpand={() => setClubLimit(EXPANDED)}
           />
         )}
       </ReportPanel>

--- a/components/analytics/__tests__/FootballerMatrix.test.tsx
+++ b/components/analytics/__tests__/FootballerMatrix.test.tsx
@@ -74,3 +74,51 @@ describe('footballerMatrix', () => {
     }
   });
 });
+
+describe('footballerMatrix as a second cut', () => {
+  it('drops the group-by toggle when there is only one cut', () => {
+    // A group of one is a control that cannot do anything.
+    render(
+      <FootballerMatrix
+        {...props}
+        data={data()}
+        dimension="club_nation"
+        dimensions={[{ key: 'club_nation', label: 'By country played in' }]}
+      />,
+    );
+
+    expect(screen.queryByRole('group', { name: 'Group footballers by' })).not.toBeInTheDocument();
+  });
+
+  it('takes its own heading, for a cut that is not "by <dimension>"', () => {
+    render(
+      <FootballerMatrix
+        {...props}
+        data={data()}
+        title="Footballers by the country they played in"
+        description="Distinct footballers with at least one club in each country."
+      />,
+    );
+
+    expect(screen.getByText('Footballers by the country they played in')).toBeInTheDocument();
+  });
+
+  it('paints the tiles in the deeper set, so two matrices are told apart', () => {
+    // Two tables of identical pale tiles read as the same table twice.
+    const { container } = render(
+      <FootballerMatrix {...props} data={data()} palette="deep" />,
+    );
+    const tile = container.querySelector('[data-difficulty="EASY"]');
+
+    expect(tile?.className).toContain('emerald');
+    expect(tile?.className).not.toContain('bg-green-100');
+  });
+
+  it('keeps the original set by default', () => {
+    const { container } = render(<FootballerMatrix {...props} data={data()} />);
+    const tile = container.querySelector('[data-difficulty="EASY"]');
+
+    expect(tile?.className).toContain('green');
+    expect(tile?.className).not.toContain('emerald');
+  });
+});

--- a/components/analytics/panels/FootballerMatrix.tsx
+++ b/components/analytics/panels/FootballerMatrix.tsx
@@ -4,7 +4,7 @@ import type { DifficultyMatrixResponse } from '@/types/reports';
 import { TileMatrix } from '@/components/analytics/panels/TileMatrix';
 import { SearchBox } from '@/components/reports/filters/SearchBox';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { difficultyTier as tier } from '@/lib/data-colours';
+import { difficultyTier as tier, difficultyTierDeep as tierDeep } from '@/lib/data-colours';
 import { cn } from '@/lib/utils';
 
 /**
@@ -20,7 +20,7 @@ const DIMENSIONS = [
   { key: 'team', label: 'By team' },
 ];
 
-export function FootballerMatrix({ data, dimension, onDimensionChange, search, onSearchChange, difficulty, onDifficultyChange, onExpand, expanded }: {
+export function FootballerMatrix({ data, dimension, onDimensionChange, search, onSearchChange, difficulty, onDifficultyChange, onExpand, expanded, title, description, dimensions, palette }: {
   data: DifficultyMatrixResponse;
   dimension: string;
   onDimensionChange: (next: string) => void;
@@ -30,44 +30,58 @@ export function FootballerMatrix({ data, dimension, onDimensionChange, search, o
   onDifficultyChange: (next: string | null) => void;
   onExpand?: () => void;
   expanded?: boolean;
+  /** Overrides the heading, for a cut whose name is not "by <dimension>". */
+  title?: string;
+  description?: string;
+  /**
+   * Which cuts to offer. A single-dimension panel passes one and the toggle
+   * disappears — a group of one is a control that cannot do anything.
+   */
+  dimensions?: { key: string; label: string }[];
+  /** `deep` for a second matrix on the same page — see `TileMatrix`. */
+  palette?: 'default' | 'deep';
 }) {
   const { matrix, difficulty_order: order } = data;
+  const options = dimensions ?? DIMENSIONS;
+  const tierFor = palette === 'deep' ? tierDeep : tier;
 
   return (
     <Card>
       <CardHeader className="gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="space-y-1.5">
-          <CardTitle>{`Footballers by ${data.dimension} and difficulty`}</CardTitle>
+          <CardTitle>{title ?? `Footballers by ${data.dimension} and difficulty`}</CardTitle>
           <CardDescription>
-            {data.rows_double_count
+            {description ?? (data.rows_double_count
               // Said outright, because the same footballer legitimately appears
               // in several rows here and the column will not add up.
               ? 'A footballer belongs to every club they played for, so these rows deliberately sum to more than the catalogue holds. Approved footballers only, which is why a squad here is smaller than on the teams page.'
-              : 'A footballer has one nation, so these rows add up. Approved footballers only.'}
+              : 'A footballer has one nation, so these rows add up. Approved footballers only.')}
             {difficulty
-              ? ` Ranked by ${tier(difficulty).label} — every tier is still shown beside it.`
+              ? ` Ranked by ${tierFor(difficulty).label} — every tier is still shown beside it.`
               : ' Ranked by total.'}
           </CardDescription>
         </div>
         <div className="flex shrink-0 flex-col gap-2 sm:items-end">
-          <div className="flex gap-1" role="group" aria-label="Group footballers by">
-            {DIMENSIONS.map(option => (
-              <button
-                key={option.key}
-                type="button"
-                aria-pressed={dimension === option.key}
-                onClick={() => onDimensionChange(option.key)}
-                className={cn(
-                  'rounded-md px-2.5 py-1 text-xs font-medium ring-1 ring-inset transition-colors',
-                  dimension === option.key
-                    ? 'bg-primary text-primary-foreground ring-transparent'
-                    : 'text-muted-foreground ring-border hover:bg-muted',
-                )}
-              >
-                {option.label}
-              </button>
-            ))}
-          </div>
+          {options.length > 1 && (
+            <div className="flex gap-1" role="group" aria-label="Group footballers by">
+              {options.map(option => (
+                <button
+                  key={option.key}
+                  type="button"
+                  aria-pressed={dimension === option.key}
+                  onClick={() => onDimensionChange(option.key)}
+                  className={cn(
+                    'rounded-md px-2.5 py-1 text-xs font-medium ring-1 ring-inset transition-colors',
+                    dimension === option.key
+                      ? 'bg-primary text-primary-foreground ring-transparent'
+                      : 'text-muted-foreground ring-border hover:bg-muted',
+                  )}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+          )}
           <SearchBox
             value={search}
             onChange={onSearchChange}
@@ -100,6 +114,7 @@ export function FootballerMatrix({ data, dimension, onDimensionChange, search, o
       </CardHeader>
       <CardContent>
         <TileMatrix
+          palette={palette}
           rows={matrix.items}
           order={order}
           rankedBy={difficulty}

--- a/components/analytics/panels/TileMatrix.tsx
+++ b/components/analytics/panels/TileMatrix.tsx
@@ -2,7 +2,7 @@
 
 import type { ReactNode } from 'react';
 import { CappedList } from '@/components/reports/primitives/CappedList';
-import { difficultyTier as tier } from '@/lib/data-colours';
+import { difficultyTier, difficultyTierDeep } from '@/lib/data-colours';
 import { cn } from '@/lib/utils';
 
 /**
@@ -26,7 +26,7 @@ export type TileRow = {
   extra?: number | null;
 };
 
-export function TileMatrix({ rows, order, rowHeading, total, shown, onExpand, expanded, emptyLabel, extraHeading, extraLabel, rankedBy, onRankBy }: {
+export function TileMatrix({ rows, order, rowHeading, total, shown, onExpand, expanded, emptyLabel, extraHeading, extraLabel, rankedBy, onRankBy, palette = 'default' }: {
   rows: TileRow[];
   order: string[];
   /**
@@ -59,7 +59,13 @@ export function TileMatrix({ rows, order, rowHeading, total, shown, onExpand, ex
    * Called with null when the active column is clicked again, matching the chips.
    */
   onRankBy?: (difficulty: string | null) => void;
+  /**
+   * Which tier colours to use. `deep` is for a second matrix on the same page:
+   * two tables of identical pale tiles read as the same table twice.
+   */
+  palette?: 'default' | 'deep';
 }): ReactNode {
+  const tier = palette === 'deep' ? difficultyTierDeep : difficultyTier;
   return (
     <CappedList
       total={total}
@@ -147,6 +153,7 @@ export function TileMatrix({ rows, order, rowHeading, total, shown, onExpand, ex
                     count={count}
                     index={index}
                     ranked={rankedBy === order[index]}
+                    palette={palette}
                   />
                 ))}
                 <td className="p-0 pl-2">
@@ -182,13 +189,14 @@ export function TileMatrix({ rows, order, rowHeading, total, shown, onExpand, ex
   );
 }
 
-function Tile({ difficulty, count, index, ranked }: {
+function Tile({ difficulty, count, index, ranked, palette = 'default' }: {
   difficulty: string;
   count: number;
   index: number;
   ranked?: boolean;
+  palette?: 'default' | 'deep';
 }) {
-  const style = tier(difficulty);
+  const style = palette === 'deep' ? difficultyTierDeep(difficulty) : difficultyTier(difficulty);
 
   // A dash, not a zero. An empty tier is the thing you are looking for, and the
   // gaps are the reason to read this table — so it keeps the tile's shape while

--- a/lib/data-colours.ts
+++ b/lib/data-colours.ts
@@ -136,6 +136,64 @@ export const DIFFICULTY_TIERS: Record<string, DataTier> = {
   },
 };
 
+/**
+ * The same four tiers, deeper and in a shifted hue set.
+ *
+ * For the second matrix on a page that already has one. Two tables of identical
+ * pale tiles read as the same table twice, and the reader has to go back to the
+ * heading to work out which is which — so the second one differs in weight AND
+ * in hue: emerald, indigo, amber, rose against green, blue, orange, red.
+ *
+ * Deeper in both themes, not just one. The 100/900 pair the first matrix uses
+ * sits close to the card behind it, which is right for a table read alongside
+ * others and too quiet for one meant to be told apart at a glance.
+ *
+ * Text flips with the surface — near-black on the light tiles, near-white on
+ * the dark ones — because a fixed foreground fails at one end or the other.
+ */
+export const DIFFICULTY_TIERS_DEEP: Record<string, DataTier> = {
+  EASY: {
+    label: 'Easy',
+    bar: 'bg-gradient-to-r from-emerald-400 to-emerald-500',
+    track: 'bg-emerald-400/20',
+    chip: 'bg-emerald-300 text-emerald-950 ring-1 ring-inset ring-emerald-500/40 dark:bg-emerald-700 dark:text-emerald-50 dark:ring-emerald-400/30',
+    chipAlt: 'bg-emerald-400 text-emerald-950 ring-1 ring-inset ring-emerald-500/40 dark:bg-emerald-600 dark:text-emerald-50 dark:ring-emerald-400/30',
+    head: 'text-emerald-700 dark:text-emerald-300',
+    dot: 'bg-emerald-500',
+    hex: '#10b981',
+  },
+  NORMAL: {
+    label: 'Normal',
+    bar: 'bg-gradient-to-r from-indigo-400 to-indigo-500',
+    track: 'bg-indigo-400/20',
+    chip: 'bg-indigo-300 text-indigo-950 ring-1 ring-inset ring-indigo-500/40 dark:bg-indigo-700 dark:text-indigo-50 dark:ring-indigo-400/30',
+    chipAlt: 'bg-indigo-400 text-indigo-950 ring-1 ring-inset ring-indigo-500/40 dark:bg-indigo-600 dark:text-indigo-50 dark:ring-indigo-400/30',
+    head: 'text-indigo-700 dark:text-indigo-300',
+    dot: 'bg-indigo-500',
+    hex: '#6366f1',
+  },
+  HARD: {
+    label: 'Hard',
+    bar: 'bg-gradient-to-r from-amber-400 to-amber-500',
+    track: 'bg-amber-400/20',
+    chip: 'bg-amber-300 text-amber-950 ring-1 ring-inset ring-amber-500/40 dark:bg-amber-600 dark:text-amber-50 dark:ring-amber-400/30',
+    chipAlt: 'bg-amber-400 text-amber-950 ring-1 ring-inset ring-amber-500/40 dark:bg-amber-500 dark:text-amber-950 dark:ring-amber-400/30',
+    head: 'text-amber-700 dark:text-amber-300',
+    dot: 'bg-amber-500',
+    hex: '#f59e0b',
+  },
+  EXTREME: {
+    label: 'Extreme',
+    bar: 'bg-gradient-to-r from-rose-400 to-rose-500',
+    track: 'bg-rose-400/20',
+    chip: 'bg-rose-300 text-rose-950 ring-1 ring-inset ring-rose-500/40 dark:bg-rose-700 dark:text-rose-50 dark:ring-rose-400/30',
+    chipAlt: 'bg-rose-400 text-rose-950 ring-1 ring-inset ring-rose-500/40 dark:bg-rose-600 dark:text-rose-50 dark:ring-rose-400/30',
+    head: 'text-rose-700 dark:text-rose-300',
+    dot: 'bg-rose-500',
+    hex: '#f43f5e',
+  },
+};
+
 /** An unknown tier still renders, in a colour that claims nothing. */
 const UNKNOWN_TIER: DataTier = {
   label: '',
@@ -150,6 +208,11 @@ const UNKNOWN_TIER: DataTier = {
 
 export function difficultyTier(difficulty: string): DataTier {
   return DIFFICULTY_TIERS[difficulty] ?? { ...UNKNOWN_TIER, label: difficulty };
+}
+
+/** The deeper set, for a second matrix that has to be told from the first. */
+export function difficultyTierDeep(difficulty: string): DataTier {
+  return DIFFICULTY_TIERS_DEEP[difficulty] ?? { ...UNKNOWN_TIER, label: difficulty };
 }
 
 /** Still playing against retired: two states of a whole, not a scale. */


### PR DESCRIPTION
Under "Footballers by nation and difficulty", a table asking the other question — **how many distinct footballers have played for a club in each country**, split by the same four tiers.

They are not the same question and rarely the same answer:

| Nation (nationality) | | Country played in | |
|---|---|---|---|
| England | 467 | England | 2814 |
| Spain | 445 | Italy | 1818 |
| Brazil | 440 | Spain | 1800 |
| France | 421 | France | 1486 |

Brazil is third by nationality and outside the top eight by club; Turkey and Portugal appear in one table and not the other. A club-based game only cares about the second, because Career Path and Grid build from club history.

## Its own panel, not a third toggle option

The two are read alongside each other, and a shared control would clear one while the reader is looking at the other. It has its own search and tier filter for the same reason.

## Deeper tiles, different hues

Two tables of identical pale tiles read as the same table twice — the reader has to go back to the heading to work out which is which. The second matrix uses a deeper set in a shifted hue family: **emerald, indigo, amber, rose** against green, blue, orange, red.

Deeper in **both** themes. The 100/900 pair the first matrix uses sits close to the card behind it, which is right for a table read among others and too quiet for one meant to be told apart at a glance. Text flips with the surface — near-black on the light tiles, near-white on the dark ones — because a fixed foreground fails at one end or the other.

The palette is a prop on `TileMatrix`, so this is a second set rather than a second component. The group-by toggle disappears when a panel is given one cut: a group of one is a control that cannot do anything.

## Depends on

**FootballExtraTime/App#1524** — adds the `club_nation` dimension. Merge that first; until it deploys this panel's request is rejected as an unknown dimension.

## Verification

- 882 tests pass, four new.
- The palette is mutation-tested: ignoring the prop and falling back to the pale set breaks a test.
- Types, `lint:reports` and the analytics tree clean at `--max-warnings 0`, `next build` compiles with no errors or warnings.

## Not visually verified

I have not seen the deeper tiles rendered in either theme. Worth a look on the preview — particularly whether amber HARD holds enough contrast against the light card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)