### PR TITLE
feat: Grid content analytics page, tied into reports both ways

### DIFF
--- a/app/analytics/grid/page.tsx
+++ b/app/analytics/grid/page.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import type { RangeState } from '@/lib/report-range';
+import { ArrowRight } from 'lucide-react';
+import Link from 'next/link';
+import { useMemo } from 'react';
+import { GridCriteria, GridCriterionTypes, GridTeams } from '@/components/analytics/panels/GridContent';
+import { GridModes } from '@/components/analytics/panels/GridModes';
+import { GridPool } from '@/components/analytics/panels/GridPool';
+import { AnalyticsShell } from '@/components/analytics/shell/AnalyticsShell';
+import { FilterBar } from '@/components/reports/filters/FilterBar';
+import { RangePicker } from '@/components/reports/filters/RangePicker';
+import { ReportPanel } from '@/components/reports/primitives/ReportPanel';
+import { SectionHeader } from '@/components/reports/primitives/SectionHeader';
+import { useReport } from '@/hooks/use-report';
+import { useReportFilters } from '@/hooks/use-report-filters';
+import { useAuth } from '@/lib/auth';
+import { rangeToParams } from '@/lib/report-range';
+import { ReportsAPI } from '@/lib/reports-api';
+
+/**
+ * Grid content quality — modes first, then the two worklists.
+ *
+ * Grid's puzzles are generated, so there is no "broken puzzle" to find; what
+ * an admin tunes is what generation draws from. The page leads with the mode
+ * and variation health (is a newly composed mode playable at all), then the
+ * criterion worklist (which criteria mislead — the single most actionable
+ * signal here), then the footballer pool (data bugs and dead weight).
+ *
+ * Player BEHAVIOUR for Grid — volume, retention, session length — stays in
+ * /reports/games/grid, which this page links to and which links back: one
+ * question per surface, one home for each.
+ */
+export default function GridAnalyticsPage() {
+  const { isAuthenticated, user } = useAuth();
+  const enabled = isAuthenticated && !!(user?.is_staff || user?.is_superuser);
+
+  // 90 days like the other content pages: criteria need 25 sessions before a
+  // rate is stated, and the long tail of criterion identities is exactly what
+  // this page exists to reach.
+  const { filters, update } = useReportFilters({
+    range: { window: 90 },
+    includeBots: false,
+    game: null,
+    metric: 'games_started',
+  });
+  const { range, includeBots } = filters;
+  const setRange = (next: RangeState) => update({ range: next });
+  const setIncludeBots = (next: boolean) => update({ includeBots: next });
+  const params = useMemo(
+    () => ({ ...rangeToParams(range), include_bots: includeBots }),
+    [range, includeBots],
+  );
+
+  const state = useReport(
+    ReportsAPI.getGridAnalytics,
+    params,
+    enabled,
+    'The Grid analytics endpoint',
+  );
+
+  return (
+    <AnalyticsShell
+      title="Grid content"
+      description="Which criteria mislead, which pool footballers are broken or dead weight, and whether each mode and variation actually plays."
+    >
+      <div className="flex flex-wrap items-center gap-3">
+        <Link
+          href="/reports/games/grid"
+          className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
+        >
+          Player behaviour for Grid lives in Reports
+          <ArrowRight className="size-4" />
+        </Link>
+      </div>
+
+      <FilterBar>
+        <RangePicker
+          value={range}
+          onChange={setRange}
+          includeBots={includeBots}
+          onIncludeBotsChange={setIncludeBots}
+        />
+      </FilterBar>
+
+      <ReportPanel state={state} skeletonClassName="h-96 w-full">
+        {data => <GridModes data={data} />}
+      </ReportPanel>
+
+      <SectionHeader
+        title="The content worklists"
+        description="Ordered worst first — these tables exist to be worked through, not browsed."
+      />
+
+      <ReportPanel state={state} skeletonClassName="h-96 w-full">
+        {data => <GridCriteria data={data} />}
+      </ReportPanel>
+
+      <ReportPanel state={state} skeletonClassName="h-80 w-full">
+        {data => <GridPool data={data} />}
+      </ReportPanel>
+
+      <SectionHeader
+        title="Reach"
+        description="What players actually see most — types and clubs by volume."
+      />
+
+      <ReportPanel state={state} skeletonClassName="h-80 w-full">
+        {data => <GridCriterionTypes data={data} />}
+      </ReportPanel>
+
+      <ReportPanel state={state} skeletonClassName="h-80 w-full">
+        {data => <GridTeams data={data} />}
+      </ReportPanel>
+    </AnalyticsShell>
+  );
+}

--- a/app/reports/games/[key]/page.tsx
+++ b/app/reports/games/[key]/page.tsx
@@ -2,7 +2,7 @@
 
 import type { RangeState } from '@/lib/report-range';
 import type { Granularity } from '@/types/reports';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, ArrowRight } from 'lucide-react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { useMemo, useState } from 'react';
@@ -26,6 +26,7 @@ import { useGameColor, useGameMeta } from '@/hooks/use-game-meta';
 import { useReport } from '@/hooks/use-report';
 import { useReportFilters } from '@/hooks/use-report-filters';
 import { useAuth } from '@/lib/auth';
+import { CONTENT_ANALYTICS_BY_GAME } from '@/lib/global-nav';
 import { compareToParams, rangeToParams } from '@/lib/report-range';
 import { ReportsAPI } from '@/lib/reports-api';
 
@@ -104,6 +105,18 @@ export default function GameDetailPage() {
           <ArrowLeft className="size-4" />
           All games
         </Link>
+        {/* The other half of this game's story: this page is behaviour, the
+            analytics page is content quality. Games without a content page
+            simply don't offer the link. */}
+        {CONTENT_ANALYTICS_BY_GAME[gameKey] && (
+          <Link
+            href={CONTENT_ANALYTICS_BY_GAME[gameKey]}
+            className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
+          >
+            Content analytics
+            <ArrowRight className="size-4" />
+          </Link>
+        )}
       </div>
 
       <FilterBar>

--- a/components/analytics/__tests__/GridAnalytics.test.tsx
+++ b/components/analytics/__tests__/GridAnalytics.test.tsx
@@ -1,0 +1,200 @@
+import type {
+  GridAnalyticsResponse,
+  GridCriterionRow,
+  GridFootballerRow,
+  GridModeRow,
+} from '@/types/reports';
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { GridCriteria, GridCriterionTypes, GridTeams } from '@/components/analytics/panels/GridContent';
+import { GridModes } from '@/components/analytics/panels/GridModes';
+import { GridPool } from '@/components/analytics/panels/GridPool';
+
+function mode(over: Partial<GridModeRow>): GridModeRow {
+  return {
+    difficulty: 'HARD',
+    footballer_status: 'BOTH',
+    grid_size: '4x4',
+    sessions: 3758,
+    finished: 3161,
+    completion_pct: 84.1,
+    perfect: 77,
+    perfect_pct: 2.4,
+    avg_score: 11.6,
+    wrong_guesses: 49844,
+    ...over,
+  };
+}
+
+function criterion(over: Partial<GridCriterionRow> & Pick<GridCriterionRow, 'label'>): GridCriterionRow {
+  return {
+    criterion_type: 'NATIONALITY',
+    sessions: 55,
+    attempts: 171,
+    wrong: 158,
+    wrong_pct: 92.4,
+    ...over,
+  };
+}
+
+function footballer(over: Partial<GridFootballerRow> & Pick<GridFootballerRow, 'footballer_id' | 'name'>): GridFootballerRow {
+  return {
+    shown: 40,
+    placed: 10,
+    wrong: 25,
+    skipped: 5,
+    wrong_pct: 62.5,
+    skip_pct: 12.5,
+    ...over,
+  };
+}
+
+function response(over: Partial<GridAnalyticsResponse> = {}): GridAnalyticsResponse {
+  return {
+    start: '2026-06-01',
+    end: '2026-08-28',
+    days: 89,
+    window: 90,
+    game_type: null,
+    include_bots: false,
+    modes: [],
+    variations: [],
+    footballers: [],
+    criteria: [],
+    criterion_types: [],
+    teams: [],
+    ...over,
+  };
+}
+
+describe('GridModes', () => {
+  it('composes the mode label from difficulty, roster and size', () => {
+    render(
+      <GridModes
+        data={response({
+          modes: [
+            mode({}),
+            mode({ difficulty: 'EASY', footballer_status: 'NOT_ACTIVE', grid_size: '3x3', sessions: 12 }),
+          ],
+        })}
+      />,
+    );
+
+    // The wire vocabulary never leaks: EASY reads Standard, NOT_ACTIVE reads
+    // Retired, BOTH adds nothing.
+    expect(screen.getByText('Hard · 4x4')).toBeInTheDocument();
+    expect(screen.getByText('Standard · Retired · 3x3')).toBeInTheDocument();
+    expect(screen.queryByText(/NOT_ACTIVE|BOTH/)).not.toBeInTheDocument();
+  });
+
+  it('never hides an unclassified bucket', () => {
+    // difficulty null is a data bug when it appears — the row must render,
+    // not vanish, or the bug stays invisible.
+    render(<GridModes data={response({ modes: [mode({ difficulty: null })] })} />);
+
+    expect(screen.getByText('Unclassified · 4x4')).toBeInTheDocument();
+  });
+
+  it('renders variations with the same outcome columns', () => {
+    render(
+      <GridModes
+        data={response({
+          modes: [mode({})],
+          variations: [{
+            variation_id: null,
+            variation: 'Default',
+            sessions: 6888,
+            finished: 5616,
+            completion_pct: 81.5,
+            perfect: 232,
+            perfect_pct: 4.1,
+            avg_score: 12.6,
+          }],
+        })}
+      />,
+    );
+    const row = screen.getByText('Default').closest('tr')!;
+
+    expect(within(row).getByText('81.5%')).toBeInTheDocument();
+  });
+
+  it('shows an empty state when nothing was played', () => {
+    render(<GridModes data={response()} />);
+
+    expect(screen.getByText('No Grid session in this window.')).toBeInTheDocument();
+  });
+});
+
+describe('GridCriteria', () => {
+  it('renders the worklist with wrong rates', () => {
+    render(
+      <GridCriteria
+        data={response({ criteria: [criterion({ label: 'ABW' })] })}
+      />,
+    );
+    const row = screen.getByText('ABW').closest('tr')!;
+
+    expect(within(row).getByText('92.4%')).toBeInTheDocument();
+    expect(within(row).getByText('NATIONALITY')).toBeInTheDocument();
+  });
+});
+
+describe('GridCriterionTypes', () => {
+  it('states reach via attempts and identities', () => {
+    render(
+      <GridCriterionTypes
+        data={response({
+          criterion_types: [{
+            criterion_type: 'PLAYED_FOR_CLUB',
+            identities: 287,
+            attempts: 66330,
+            wrong: 42711,
+            wrong_pct: 64.4,
+          }],
+        })}
+      />,
+    );
+    const row = screen.getByText('PLAYED_FOR_CLUB').closest('tr')!;
+
+    expect(within(row).getByText('287')).toBeInTheDocument();
+    expect(within(row).getByText('66,330')).toBeInTheDocument();
+  });
+});
+
+describe('GridTeams', () => {
+  it('renders clubs without the redundant type column', () => {
+    render(
+      <GridTeams
+        data={response({
+          teams: [criterion({ label: 'Man Utd', criterion_type: 'PLAYED_FOR_CLUB', wrong_pct: 33.0 })],
+        })}
+      />,
+    );
+
+    expect(screen.getByText('Man Utd')).toBeInTheDocument();
+    // Every row here is PLAYED_FOR_CLUB — a type column would be noise.
+    expect(screen.queryByText('PLAYED_FOR_CLUB')).not.toBeInTheDocument();
+  });
+});
+
+describe('GridPool', () => {
+  it('renders the outcome split for each footballer', () => {
+    render(
+      <GridPool
+        data={response({
+          footballers: [footballer({ footballer_id: 1, name: 'Ray Stewart' })],
+        })}
+      />,
+    );
+    const row = screen.getByText('Ray Stewart').closest('tr')!;
+
+    expect(within(row).getByText('62.5%')).toBeInTheDocument();
+    expect(within(row).getByText('12.5%')).toBeInTheDocument();
+  });
+
+  it('shows the threshold hint when nothing qualifies', () => {
+    render(<GridPool data={response()} />);
+
+    expect(screen.getByText(/25 decided appearances/)).toBeInTheDocument();
+  });
+});

--- a/components/analytics/panels/GridContent.tsx
+++ b/components/analytics/panels/GridContent.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import type { GridAnalyticsResponse, GridCriterionRow } from '@/types/reports';
+import { EmptyState } from '@/components/reports/primitives/EmptyState';
+import { MetricInfo } from '@/components/reports/primitives/MetricInfo';
+import { ReportHead, ReportRow, ReportTable, Td, Th } from '@/components/reports/primitives/ReportTable';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+/**
+ * The criterion worklist — Grid's most actionable content signal.
+ *
+ * A grid is generated, so nobody edits a grid; what an admin tunes is the
+ * criterion (its weights, its entity data). A criterion whose cells attract
+ * wrong placements at a high rate is either ambiguous or its entity data is
+ * wrong — a missing transfer, a dual nationality — and that is a fix in the
+ * football data, findable from this table.
+ */
+
+/** At or above this wrong rate, a criterion deserves an editor's look. */
+const NOTABLE_WRONG_PCT = 60;
+
+function CriterionTable({ rows, showType = true }: { rows: GridCriterionRow[]; showType?: boolean }) {
+  return (
+    <ReportTable>
+      <ReportHead>
+        <Th>Criterion</Th>
+        {showType && <Th>Type</Th>}
+        <Th align="right" title="Distinct sessions that placed into a cell carrying it">Sessions</Th>
+        <Th align="right" title="Placements into cells carrying it">Attempts</Th>
+        <Th align="right">Wrong</Th>
+        <Th align="right" title="Wrong placements as a share of attempts">Wrong rate</Th>
+      </ReportHead>
+      <tbody>
+        {rows.map(row => (
+          <ReportRow key={`${row.criterion_type}:${row.label}`}>
+            <Td strong>{row.label}</Td>
+            {showType && (
+              <Td className="text-muted-foreground">{row.criterion_type}</Td>
+            )}
+            <Td align="right">{row.sessions.toLocaleString()}</Td>
+            <Td align="right">{row.attempts.toLocaleString()}</Td>
+            <Td align="right">{row.wrong.toLocaleString()}</Td>
+            <Td
+              align="right"
+              strong
+              className={cn(
+                row.wrong_pct >= NOTABLE_WRONG_PCT && 'text-amber-600 dark:text-amber-500',
+              )}
+            >
+              {`${row.wrong_pct}%`}
+            </Td>
+          </ReportRow>
+        ))}
+      </tbody>
+    </ReportTable>
+  );
+}
+
+export function GridCriteria({ data }: { data: GridAnalyticsResponse }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          Criteria that mislead
+          <MetricInfo metric="grid_wrong_pct" />
+        </CardTitle>
+        <CardDescription>
+          Wrong placements are attributed to the cell the player chose — the
+          criteria that misled the click. A persistently high rate usually
+          means the entity data is wrong or ambiguous, not that the puzzle is
+          hard: the fix lives in the football data.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="overflow-x-auto">
+        {data.criteria.length === 0
+          ? (
+              <EmptyState hint="Criteria need 25 sessions before their rate is stated.">
+                Nothing crossed the volume threshold in this window.
+              </EmptyState>
+            )
+          : <CriterionTable rows={data.criteria} />}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function GridCriterionTypes({ data }: { data: GridAnalyticsResponse }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Reach by criterion type</CardTitle>
+        <CardDescription>
+          Every criterion type by how much play it carries. Reach is stated
+          via attempts — session counts do not add across identities, so a
+          per-type session total would double-count.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="overflow-x-auto">
+        {data.criterion_types.length === 0
+          ? <EmptyState>No placements in this window.</EmptyState>
+          : (
+              <ReportTable>
+                <ReportHead>
+                  <Th>Type</Th>
+                  <Th align="right" title="Distinct criterion identities of this type that were played">Identities</Th>
+                  <Th align="right">Attempts</Th>
+                  <Th align="right">Wrong</Th>
+                  <Th align="right">Wrong rate</Th>
+                </ReportHead>
+                <tbody>
+                  {data.criterion_types.map(row => (
+                    <ReportRow key={row.criterion_type}>
+                      <Td strong>{row.criterion_type}</Td>
+                      <Td align="right">{row.identities.toLocaleString()}</Td>
+                      <Td align="right">{row.attempts.toLocaleString()}</Td>
+                      <Td align="right">{row.wrong.toLocaleString()}</Td>
+                      <Td align="right">{`${row.wrong_pct}%`}</Td>
+                    </ReportRow>
+                  ))}
+                </tbody>
+              </ReportTable>
+            )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function GridTeams({ data }: { data: GridAnalyticsResponse }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Most displayed clubs</CardTitle>
+        <CardDescription>
+          The club-criterion slice by reach — which teams players see most,
+          and how often placing into their cells goes wrong.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="overflow-x-auto">
+        {data.teams.length === 0
+          ? <EmptyState>No club criterion crossed the threshold in this window.</EmptyState>
+          : <CriterionTable rows={data.teams} showType={false} />}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/analytics/panels/GridModes.tsx
+++ b/components/analytics/panels/GridModes.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import type { GridAnalyticsResponse, GridModeRow, GridVariationRow } from '@/types/reports';
+import { EmptyState } from '@/components/reports/primitives/EmptyState';
+import { MetricInfo } from '@/components/reports/primitives/MetricInfo';
+import { MetricRow } from '@/components/reports/primitives/MetricRow';
+import { ReportHead, ReportRow, ReportTable, Td, Th } from '@/components/reports/primitives/ReportTable';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+/**
+ * How each Grid mode and variation actually plays.
+ *
+ * A mode bucket is difficulty × roster × size — the exact thing an admin
+ * composes in the Grid admin. A freshly composed mode shows up here the day
+ * people start playing it, which is how it gets judged before anyone
+ * complains: low completion or a wrong-guess pile in one bucket is a
+ * composition problem, not a player problem.
+ */
+
+/** Below this, completion is worth a look whatever the mode promises. */
+const LOW_COMPLETION_PCT = 60;
+
+function modeLabel(row: GridModeRow): string {
+  const difficulty = row.difficulty === 'EASY'
+    ? 'Standard'
+    : row.difficulty === 'HARD'
+      ? 'Hard'
+      : row.difficulty ?? 'Unclassified';
+  const roster = row.footballer_status === 'ACTIVE'
+    ? ' · Active'
+    : row.footballer_status === 'NOT_ACTIVE'
+      ? ' · Retired'
+      : '';
+  return `${difficulty}${roster} · ${row.grid_size}`;
+}
+
+function OutcomeCells({ row }: { row: GridModeRow | GridVariationRow }) {
+  return (
+    <>
+      <Td align="right">{row.sessions.toLocaleString()}</Td>
+      <Td align="right">{row.finished.toLocaleString()}</Td>
+      <Td
+        align="right"
+        strong
+        className={cn(
+          row.completion_pct < LOW_COMPLETION_PCT && row.sessions >= 30
+          && 'text-amber-600 dark:text-amber-500',
+        )}
+      >
+        {`${row.completion_pct}%`}
+      </Td>
+      <Td align="right">
+        {`${row.perfect_pct}%`}
+        <span className="ml-1 text-xs text-muted-foreground">{`(${row.perfect.toLocaleString()})`}</span>
+      </Td>
+      <Td align="right">{row.avg_score ?? '—'}</Td>
+    </>
+  );
+}
+
+export function GridModes({ data }: { data: GridAnalyticsResponse }) {
+  const totalSessions = data.modes.reduce((sum, row) => sum + row.sessions, 0);
+  const totalFinished = data.modes.reduce((sum, row) => sum + row.finished, 0);
+  const totalPerfect = data.modes.reduce((sum, row) => sum + row.perfect, 0);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          Modes and variations
+          <MetricInfo metric="grid_perfect_pct" />
+        </CardTitle>
+        <CardDescription>
+          Every difficulty × roster × size bucket that was played, and every
+          variation. A new mode appears here the day it gets its first player —
+          judge it on completion and errors before anyone has to complain.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4 overflow-x-auto">
+        <MetricRow
+          columns={3}
+          metrics={[
+            { label: 'Sessions', value: totalSessions.toLocaleString() },
+            {
+              label: 'Completion',
+              value: totalSessions === 0 ? '—' : `${Math.round((totalFinished / totalSessions) * 100)}%`,
+            },
+            {
+              label: 'Perfect grids',
+              value: totalPerfect.toLocaleString(),
+              metric: 'grid_perfect_pct',
+            },
+          ]}
+        />
+
+        {data.modes.length === 0
+          ? (
+              <EmptyState hint="Try a wider date range.">
+                No Grid session in this window.
+              </EmptyState>
+            )
+          : (
+              <ReportTable>
+                <ReportHead>
+                  <Th>Mode</Th>
+                  <Th align="right">Sessions</Th>
+                  <Th align="right">Finished</Th>
+                  <Th align="right" title="Finished as a share of started">Completion</Th>
+                  <Th align="right" title="Every cell correct, as a share of finished">Perfect</Th>
+                  <Th align="right" title="Average score of finished sessions">Avg score</Th>
+                  <Th align="right" title="Player-made wrong placements (Extra-Time excluded)">Wrong guesses</Th>
+                </ReportHead>
+                <tbody>
+                  {data.modes.map(row => (
+                    <ReportRow key={`${row.difficulty}-${row.footballer_status}-${row.grid_size}`}>
+                      <Td strong>{modeLabel(row)}</Td>
+                      <OutcomeCells row={row} />
+                      <Td align="right" className="text-muted-foreground">
+                        {row.wrong_guesses.toLocaleString()}
+                      </Td>
+                    </ReportRow>
+                  ))}
+                </tbody>
+              </ReportTable>
+            )}
+
+        {data.variations.length > 0 && (
+          <ReportTable>
+            <ReportHead>
+              <Th>Variation</Th>
+              <Th align="right">Sessions</Th>
+              <Th align="right">Finished</Th>
+              <Th align="right">Completion</Th>
+              <Th align="right">Perfect</Th>
+              <Th align="right">Avg score</Th>
+            </ReportHead>
+            <tbody>
+              {data.variations.map(row => (
+                <ReportRow key={row.variation_id ?? 'default'}>
+                  <Td strong>{row.variation}</Td>
+                  <OutcomeCells row={row} />
+                </ReportRow>
+              ))}
+            </tbody>
+          </ReportTable>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/analytics/panels/GridPool.tsx
+++ b/components/analytics/panels/GridPool.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import type { GridAnalyticsResponse } from '@/types/reports';
+import { EmptyState } from '@/components/reports/primitives/EmptyState';
+import { MetricInfo } from '@/components/reports/primitives/MetricInfo';
+import { ReportHead, ReportRow, ReportTable, Td, Th } from '@/components/reports/primitives/ReportTable';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+/**
+ * Pool footballers by outcome — the most displayed players and what
+ * happened when they appeared.
+ *
+ * Two different problems surface in one table: a footballer everyone
+ * places WRONGLY is a data bug (their career says they fit a cell they
+ * don't, or vice versa), while one everyone SKIPS is dead weight nobody
+ * can use. Both are fixes to the pool, not to any grid.
+ */
+
+/** At or above this wrong rate a footballer smells like a data bug. */
+const NOTABLE_WRONG_PCT = 50;
+
+/** At or above this skip rate a footballer is dead weight in the pool. */
+const NOTABLE_SKIP_PCT = 60;
+
+export function GridPool({ data }: { data: GridAnalyticsResponse }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          The footballer pool
+          <MetricInfo metric="grid_shown" />
+        </CardTitle>
+        <CardDescription>
+          Every appearance a player decided on — placed, misplaced or
+          deliberately skipped. High wrong rate reads as a data bug; high skip
+          rate reads as dead weight. Ordered worst first.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="overflow-x-auto">
+        {data.footballers.length === 0
+          ? (
+              <EmptyState hint="A footballer needs 25 decided appearances before their split is stated.">
+                Nothing crossed the volume threshold in this window.
+              </EmptyState>
+            )
+          : (
+              <ReportTable>
+                <ReportHead>
+                  <Th>Footballer</Th>
+                  <Th align="right" title="Appearances a player decided on: placement or deliberate skip">Shown</Th>
+                  <Th align="right">Placed</Th>
+                  <Th align="right">Wrong</Th>
+                  <Th align="right">Skipped</Th>
+                  <Th align="right" title="Wrong placements as a share of shown">Wrong rate</Th>
+                  <Th align="right" title="Deliberate skips as a share of shown">Skip rate</Th>
+                </ReportHead>
+                <tbody>
+                  {data.footballers.map(row => (
+                    <ReportRow key={row.footballer_id}>
+                      <Td strong>{row.name}</Td>
+                      <Td align="right">{row.shown.toLocaleString()}</Td>
+                      <Td align="right">{row.placed.toLocaleString()}</Td>
+                      <Td align="right">{row.wrong.toLocaleString()}</Td>
+                      <Td align="right">{row.skipped.toLocaleString()}</Td>
+                      <Td
+                        align="right"
+                        strong
+                        className={cn(
+                          row.wrong_pct >= NOTABLE_WRONG_PCT && 'text-amber-600 dark:text-amber-500',
+                        )}
+                      >
+                        {`${row.wrong_pct}%`}
+                      </Td>
+                      <Td
+                        align="right"
+                        className={cn(
+                          row.skip_pct >= NOTABLE_SKIP_PCT && 'text-amber-600 dark:text-amber-500',
+                        )}
+                      >
+                        {`${row.skip_pct}%`}
+                      </Td>
+                    </ReportRow>
+                  ))}
+                </tbody>
+              </ReportTable>
+            )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/analytics/shell/AnalyticsNav.tsx
+++ b/components/analytics/shell/AnalyticsNav.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { NavGroup, NavItem } from '@/components/admin/SectionNav';
-import { Database, Flag, HelpCircle, Route, Shield, User, Users } from 'lucide-react';
+import { Database, Flag, Grid3x3, HelpCircle, Route, Shield, User, Users } from 'lucide-react';
 
 /**
  * Analytics, which is not Reports and should not be folded into it.
@@ -13,9 +13,9 @@ import { Database, Flag, HelpCircle, Route, Shield, User, Users } from 'lucide-r
  * weekly by whoever is deciding what to build, and this is read by whoever is
  * writing content, when they are writing it.
  *
- * Grouped rather than flat because one more is coming (App#1475) and a
- * heading that appears later reorganises the section under someone who had
- * learned where things were.
+ * Grouped so a per-game page that arrives later (Grid did, App#1545; more
+ * will) slots into an existing heading instead of reorganising the section
+ * under someone who had learned where things were.
  */
 export const ANALYTICS_NAV_GROUPS: NavGroup[] = [
   {
@@ -23,6 +23,7 @@ export const ANALYTICS_NAV_GROUPS: NavGroup[] = [
     items: [
       { href: '/analytics/career-path', label: 'Career Path', icon: Route },
       { href: '/analytics/lineups', label: 'Lineups', icon: Users },
+      { href: '/analytics/grid', label: 'Grid', icon: Grid3x3 },
     ],
   },
   {

--- a/lib/global-nav.ts
+++ b/lib/global-nav.ts
@@ -4,6 +4,7 @@ import {
   Database,
   Flag,
   Gamepad2,
+  Grid3x3,
   HelpCircle,
   LayoutGrid,
   Repeat,
@@ -51,7 +52,20 @@ export const ANALYTICS_CHILDREN: NavigationPage[] = [
   { label: 'Questions', href: '/analytics/football-data/questions', icon: HelpCircle, description: 'How big the question bank is, and which questions are broken' },
   { label: 'Career Path', href: '/analytics/career-path', icon: Route, description: 'Which footballers make everyone take a hint' },
   { label: 'Lineups', href: '/analytics/lineups', icon: Users2, description: 'Which slots cost the most guesses' },
+  { label: 'Grid', href: '/analytics/grid', icon: Grid3x3, description: 'Which criteria mislead, and which pool footballers are broken' },
 ];
+
+/**
+ * Reports ↔ Analytics ties for games that have a content-analytics page.
+ * Keyed by the BE registry's game_type — the reports game page uses this to
+ * offer "content analytics" beside its behavioural view, so the two surfaces
+ * point at each other instead of the reader knowing both exist.
+ */
+export const CONTENT_ANALYTICS_BY_GAME: Record<string, string> = {
+  career_path: '/analytics/career-path',
+  missing11: '/analytics/lineups',
+  grid: '/analytics/grid',
+};
 
 /**
  * Every reports/analytics destination the global nav offers. Guarded against

--- a/lib/reports-api.ts
+++ b/lib/reports-api.ts
@@ -14,6 +14,7 @@ import type {
   FirstSessionResponse,
   GamesResponse,
   GlossaryResponse,
+  GridAnalyticsResponse,
   GrowthResponse,
   LineupsAnalyticsResponse,
   MultiplayerResponse,
@@ -182,6 +183,11 @@ export class ReportsAPI {
   /** GET /core/analytics/lineups/ — Missing11 slot and lineup difficulty. */
   static async getLineupsAnalytics(params?: ReportParams): Promise<LineupsAnalyticsResponse> {
     return apiFetcher<LineupsAnalyticsResponse>(`core/analytics/lineups/${buildQuery(params)}`);
+  }
+
+  /** GET /core/analytics/grid/ — Grid content, mode and pool health. */
+  static async getGridAnalytics(params?: ReportParams): Promise<GridAnalyticsResponse> {
+    return apiFetcher<GridAnalyticsResponse>(`core/analytics/grid/${buildQuery(params)}`);
   }
 
   /** GET /core/analytics/football-data/ — data completeness where it is used. */

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -1233,6 +1233,77 @@ export type LineupsAnalyticsResponse = {
   };
 } & ResolvedRange;
 
+/** One Grid mode bucket: difficulty × roster × size, with its outcomes. */
+export type GridModeRow = {
+  /** EASY | HARD; null only on legacy data bugs — surfaced, never hidden. */
+  difficulty: string | null;
+  /** BOTH = the classic mixed pool; ACTIVE / NOT_ACTIVE are the roster modes. */
+  footballer_status: string;
+  grid_size: string;
+  sessions: number;
+  finished: number;
+  completion_pct: number;
+  perfect: number;
+  perfect_pct: number;
+  avg_score: number | null;
+  /** Player-made wrong placements in this bucket (Extra-Time excluded). */
+  wrong_guesses: number;
+};
+
+export type GridVariationRow = {
+  variation_id: number | null;
+  variation: string;
+  sessions: number;
+  finished: number;
+  completion_pct: number;
+  perfect: number;
+  perfect_pct: number;
+  avg_score: number | null;
+};
+
+/** One pool footballer's outcome split, wrong-rate ordered (worklist). */
+export type GridFootballerRow = {
+  footballer_id: number;
+  name: string;
+  shown: number;
+  placed: number;
+  wrong: number;
+  skipped: number;
+  wrong_pct: number;
+  skip_pct: number;
+};
+
+/**
+ * One criterion identity: (type, display text) — merges the same criterion
+ * across generated grids while keeping era/threshold variants apart.
+ */
+export type GridCriterionRow = {
+  criterion_type: string;
+  label: string;
+  sessions: number;
+  attempts: number;
+  wrong: number;
+  wrong_pct: number;
+};
+
+export type GridCriterionTypeRow = {
+  criterion_type: string;
+  identities: number;
+  attempts: number;
+  wrong: number;
+  wrong_pct: number;
+};
+
+export type GridAnalyticsResponse = {
+  modes: GridModeRow[];
+  variations: GridVariationRow[];
+  footballers: GridFootballerRow[];
+  criteria: GridCriterionRow[];
+  criterion_types: GridCriterionTypeRow[];
+  /** The PLAYED_FOR_CLUB slice by reach — the most displayed clubs. */
+  teams: GridCriterionRow[];
+} & ResolvedRange;
+
 /**
  * One completeness check on the football data.
  *


### PR DESCRIPTION
The Grid entry in the analytics section — the per-game page the nav comment reserved. Backed by App#1545 (`core/analytics/grid/`, deployed).

## What

**`/analytics/grid`** — Grid content quality, on the same foundations as Career Path and Lineups:

- **Modes and variations** — every difficulty × roster × size bucket and every variation, with sessions / finished / completion / perfect (rate + count) / avg score / wrong-guess volume. A newly composed mode gets judged here the day it has players. Wire vocabulary never leaks (EASY→Standard, NOT_ACTIVE→Retired); an unclassified (null-difficulty) bucket renders rather than hides — that's a data bug being surfaced.
- **Criteria that mislead** — the worklist: criterion identities by wrong-placement rate (attributed to the cell the player *chose*), amber at ≥60%. This is Grid's most actionable content signal — a persistent high rate means broken/ambiguous entity data, fixable in football data.
- **The footballer pool** — most displayed footballers with their outcome split (placed / wrong / skipped): high wrong rate reads as a data bug, high skip rate as dead weight.
- **Reach** — criterion types by attempts (session counts deliberately not summed across identities), and the most displayed clubs (the PLAYED_FOR_CLUB slice).
- Glossary wired: `grid_shown`, `grid_wrong_pct`, `grid_perfect_pct` via `MetricInfo`.

**Tied into reports both ways:**
- This page links to `/reports/games/grid` ("player behaviour lives in Reports").
- `/reports/games/[key]` gains a generic **"Content analytics"** link driven by a new `CONTENT_ANALYTICS_BY_GAME` map — so Grid, Career Path *and* Lineups game reports now all point at their content page. One question per surface, one home for each, cross-linked.
- Nav: `AnalyticsNav` "Per game" group + global nav `ANALYTICS_CHILDREN` (both nav guards pass).

## Testing

- 9 new panel tests (label composition incl. the never-hide-unclassified rule, outcome columns, empty states, threshold hints, redundant-column suppression).
- Full suite: **920 tests, 134 files, all passing** (includes the nav cross-guards and the response-fields-used guard over the new types).
- `tsc --noEmit` clean.