### PR TITLE
feat: popularity charts — games, grid modes and variations side by side

### DIFF
--- a/app/analytics/grid/page.tsx
+++ b/app/analytics/grid/page.tsx
@@ -7,6 +7,7 @@ import { useMemo } from 'react';
 import { GridCriteria, GridCriterionTypes, GridTeams } from '@/components/analytics/panels/GridContent';
 import { GridModes } from '@/components/analytics/panels/GridModes';
 import { GridPool } from '@/components/analytics/panels/GridPool';
+import { GridPopularity } from '@/components/analytics/panels/GridPopularity';
 import { AnalyticsShell } from '@/components/analytics/shell/AnalyticsShell';
 import { FilterBar } from '@/components/reports/filters/FilterBar';
 import { RangePicker } from '@/components/reports/filters/RangePicker';
@@ -82,6 +83,10 @@ export default function GridAnalyticsPage() {
           onIncludeBotsChange={setIncludeBots}
         />
       </FilterBar>
+
+      <ReportPanel state={state} skeletonClassName="h-72 w-full">
+        {data => <GridPopularity data={data} />}
+      </ReportPanel>
 
       <ReportPanel state={state} skeletonClassName="h-96 w-full">
         {data => <GridModes data={data} />}

--- a/app/reports/games/page.tsx
+++ b/app/reports/games/page.tsx
@@ -4,6 +4,7 @@ import type { RangeState } from '@/lib/report-range';
 import type { GameRowWithDuration, GameSortKey } from '@/lib/report-sort';
 import { ArrowDown, ArrowUp } from 'lucide-react';
 import { useMemo, useState } from 'react';
+import { PopularityBars } from '@/components/analytics/charts/PopularityBars';
 import { DurationHistogram } from '@/components/reports/charts/DurationHistogram';
 import { FavouredVsPlayedChart } from '@/components/reports/favourites/FavouredVsPlayedChart';
 import { FilterBar } from '@/components/reports/filters/FilterBar';
@@ -26,7 +27,7 @@ import { Sparkline } from '@/components/reports/primitives/Sparkline';
 import { ReportsShell } from '@/components/reports/shell/ReportsShell';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { useFavouredVsPlayed } from '@/hooks/use-favoured-vs-played';
-import { useGameMeta } from '@/hooks/use-game-meta';
+import { gameName, useGameColor, useGameMeta } from '@/hooks/use-game-meta';
 import { useReport } from '@/hooks/use-report';
 import { useReportFilters } from '@/hooks/use-report-filters';
 import { useAuth } from '@/lib/auth';
@@ -76,6 +77,7 @@ export default function GamesIndexPage() {
   );
 
   const { meta } = useGameMeta(enabled);
+  const colorFor = useGameColor();
   // Session length is a per-game property but lives on another endpoint, so the
   // comparison table had to be read beside a second page to answer "which game
   // holds attention". Merged in here instead.
@@ -175,6 +177,32 @@ export default function GamesIndexPage() {
       <ReportPanel state={state} skeletonClassName="h-96 w-full">
         {data => (
           <>
+            {/* The glance before the tables: which games are big, as lengths
+              on one baseline. Everything else on this page assumes the
+              reader already knows the answer to this. */}
+            <Card>
+              <CardHeader>
+                <CardTitle>What people play</CardTitle>
+                <CardDescription>
+                  Games started in the window, side by side. Hover for the
+                  share of all play.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <PopularityBars
+                  ariaLabel="Games started by game"
+                  rows={[...data.by_game]
+                    .sort((a, b) => b.games_started - a.games_started)
+                    .map(row => ({
+                      key: row.game_type,
+                      label: gameName(meta[row.game_type], row.game_type),
+                      value: row.games_started,
+                      colour: colorFor(meta, row.game_type),
+                    }))}
+                />
+              </CardContent>
+            </Card>
+
             {/* Reach and depth say which games are worth attention; this says
               where the recoverable sessions actually are, which is a
               different question and the one nobody could answer from a

--- a/components/analytics/__tests__/GridAnalytics.test.tsx
+++ b/components/analytics/__tests__/GridAnalytics.test.tsx
@@ -198,3 +198,42 @@ describe('GridPool', () => {
     expect(screen.getByText(/25 decided appearances/)).toBeInTheDocument();
   });
 });
+
+describe('GridPopularity', () => {
+  it('renders both charts with accessible summaries, largest first', async () => {
+    const { GridPopularity } = await import('@/components/analytics/panels/GridPopularity');
+    render(
+      <GridPopularity
+        data={response({
+          modes: [
+            mode({ sessions: 10, difficulty: 'EASY', grid_size: '3x3' }),
+            mode({ sessions: 3758 }),
+          ],
+          variations: [{
+            variation_id: null,
+            variation: 'Default',
+            sessions: 3768,
+            finished: 3000,
+            completion_pct: 79.6,
+            perfect: 100,
+            perfect_pct: 3.3,
+            avg_score: 12.0,
+          }],
+        })}
+      />,
+    );
+
+    expect(screen.getByText('Modes people pick')).toBeInTheDocument();
+    expect(screen.getByText('Variations people pick')).toBeInTheDocument();
+    // The sr-only summary carries the ranked values — largest mode first.
+    expect(screen.getByText(/Grid sessions by mode: Hard · 4x4 3758/)).toBeInTheDocument();
+    expect(screen.getByText(/Grid sessions by variation: Default 3768/)).toBeInTheDocument();
+  });
+
+  it('shows an empty state when nothing was played', async () => {
+    const { GridPopularity } = await import('@/components/analytics/panels/GridPopularity');
+    render(<GridPopularity data={response()} />);
+
+    expect(screen.getByText('No Grid session in this window.')).toBeInTheDocument();
+  });
+});

--- a/components/analytics/charts/PopularityBars.tsx
+++ b/components/analytics/charts/PopularityBars.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { useTheme } from 'next-themes';
+import { Bar, BarChart, CartesianGrid, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { chartTheme } from '@/lib/chart-theme';
+
+/**
+ * One ranked series, one bar per thing, identity colours — the "what do
+ * people actually like" chart.
+ *
+ * Deliberately NOT a table restated: the tables around it answer "how does
+ * this one perform", this answers "which of these is big", which is a
+ * length comparison and nothing else. Values ride in the tooltip with the
+ * share of the whole, because a bar without its share invites the reader
+ * to eyeball percentages off pixel heights.
+ */
+
+export type PopularityRow = {
+  key: string;
+  label: string;
+  value: number;
+  colour: string;
+};
+
+function ShareTooltip({ active, payload, total }: {
+  active?: boolean;
+  payload?: { payload?: PopularityRow }[];
+  total: number;
+}) {
+  const row = payload?.[0]?.payload;
+  if (!active || !row) {
+    return null;
+  }
+  const pct = total > 0 ? Math.round((row.value / total) * 1000) / 10 : null;
+  return (
+    <div className="rounded-lg border border-border bg-popover px-3 py-2 text-xs shadow-md">
+      <p className="mb-1 font-medium text-foreground">{row.label}</p>
+      <p className="flex items-center gap-1.5 text-muted-foreground">
+        <span aria-hidden className="size-2 rounded-full" style={{ backgroundColor: row.colour }} />
+        <span className="font-medium text-foreground tabular-nums">{row.value.toLocaleString()}</span>
+        {pct !== null && <span className="tabular-nums">{`(${pct}% of the total)`}</span>}
+      </p>
+    </div>
+  );
+}
+
+export function PopularityBars({ rows, ariaLabel, height = 'h-64' }: {
+  rows: PopularityRow[];
+  /** What is being compared — read by screen readers with every value. */
+  ariaLabel: string;
+  height?: string;
+}) {
+  const { resolvedTheme } = useTheme();
+  const theme = chartTheme(resolvedTheme === 'dark');
+  const total = rows.reduce((sum, row) => sum + row.value, 0);
+  const angled = rows.length > 5;
+
+  return (
+    <div className={`flex flex-col ${height}`}>
+      <ResponsiveContainer width="100%" height="100%" className="min-h-0 flex-1">
+        <BarChart data={rows} margin={{ top: 8, right: 8, bottom: 8, left: -12 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke={theme.grid.stroke} vertical={false} />
+          <XAxis
+            dataKey="label"
+            tick={theme.tick}
+            interval={0}
+            angle={angled ? -35 : 0}
+            textAnchor={angled ? 'end' : 'middle'}
+            height={angled ? 64 : 30}
+          />
+          <YAxis tick={theme.tick} allowDecimals={false} width={48} />
+          <Tooltip content={<ShareTooltip total={total} />} cursor={theme.tooltip.cursor} />
+          <Bar dataKey="value" radius={[3, 3, 0, 0]}>
+            {rows.map(row => (
+              <Cell key={row.key} fill={row.colour} />
+            ))}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+      <span className="sr-only">
+        {`${ariaLabel}: ${rows.map((row) => {
+          const pct = total > 0 ? Math.round((row.value / total) * 1000) / 10 : 0;
+          return `${row.label} ${row.value} (${pct}%)`;
+        }).join(', ')}`}
+      </span>
+    </div>
+  );
+}

--- a/components/analytics/panels/GridPopularity.tsx
+++ b/components/analytics/panels/GridPopularity.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import type { GridAnalyticsResponse, GridModeRow } from '@/types/reports';
+import { PopularityBars } from '@/components/analytics/charts/PopularityBars';
+import { EmptyState } from '@/components/reports/primitives/EmptyState';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { useGameColor, useGameMeta } from '@/hooks/use-game-meta';
+import { difficultyTier } from '@/lib/data-colours';
+
+/**
+ * What Grid players actually pick — modes and variations as lengths on one
+ * baseline, side by side.
+ *
+ * Two charts rather than one: a variation session is ALSO in some mode
+ * bucket, so a single combined chart would count the same play twice and
+ * invite exactly the wrong comparison. Side by side, each chart's bars sum
+ * to the window's play and the eye can still hop between them.
+ *
+ * Mode bars borrow the difficulty palette (Standard green, Hard orange) so
+ * the chart reads with the same colour vocabulary as every difficulty
+ * surface here; variation bars use the game's registry colour — ranking is
+ * the message there, not identity.
+ */
+
+function modeLabel(row: GridModeRow): string {
+  const difficulty = row.difficulty === 'EASY'
+    ? 'Standard'
+    : row.difficulty === 'HARD'
+      ? 'Hard'
+      : row.difficulty ?? 'Unclassified';
+  const roster = row.footballer_status === 'ACTIVE'
+    ? ' · Active'
+    : row.footballer_status === 'NOT_ACTIVE'
+      ? ' · Retired'
+      : '';
+  return `${difficulty}${roster} · ${row.grid_size}`;
+}
+
+export function GridPopularity({ data }: { data: GridAnalyticsResponse }) {
+  const { meta } = useGameMeta(true);
+  const colorFor = useGameColor();
+
+  if (data.modes.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>What people pick</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <EmptyState hint="Try a wider date range.">
+            No Grid session in this window.
+          </EmptyState>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const modeRows = [...data.modes]
+    .sort((a, b) => b.sessions - a.sessions)
+    .map(row => ({
+      key: `${row.difficulty}-${row.footballer_status}-${row.grid_size}`,
+      label: modeLabel(row),
+      value: row.sessions,
+      colour: difficultyTier(row.difficulty ?? '').hex,
+    }));
+
+  const variationRows = [...data.variations]
+    .sort((a, b) => b.sessions - a.sessions)
+    .map(row => ({
+      key: String(row.variation_id ?? 'default'),
+      label: row.variation,
+      value: row.sessions,
+      colour: colorFor(meta, 'grid'),
+    }));
+
+  return (
+    <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+      <Card>
+        <CardHeader>
+          <CardTitle>Modes people pick</CardTitle>
+          <CardDescription>
+            Sessions per difficulty × roster × size bucket. Hover for the
+            share of all Grid play.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <PopularityBars ariaLabel="Grid sessions by mode" rows={modeRows} />
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>Variations people pick</CardTitle>
+          <CardDescription>
+            Sessions per variation — Default is the un-themed game. The same
+            sessions as the modes chart, cut the other way.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <PopularityBars ariaLabel="Grid sessions by variation" rows={variationRows} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
Mission 3 of the Grid integration loop: the comparison graphs — "so I can compare what people actually like", with real numbers.

## What

New reusable **`PopularityBars`** chart (Recharts, `chartTheme`, per-bar identity colours, share-of-total tooltip, sr-only ranked summary), used twice:

- **`/reports/games` — "What people play"**: every game side by side by games started, coloured by each game's registry colour, placed above the tables as the glance the rest of the page assumes. No BE change — it reads the summary data the page already fetches.
- **`/analytics/grid` — "What people pick"**: two charts side by side — sessions per **mode** (difficulty × roster × size, coloured with the difficulty palette) and per **variation** (registry colour). Deliberately two charts, not one: a variation session is also in some mode bucket, so one combined chart would double-count the same play. Placed at the top of the Grid analytics page.

## Testing

- 2 new panel tests (ranked sr-only summaries largest-first, empty state); full suite **922 tests, 134 files, all passing**; `tsc --noEmit` clean.

Note on review: Copilot review is currently non-functional on this repo (requests are silently dropped; #157 and #158 both went unreviewed — flagged to Kalin). Self-review substituted as on #158.