### PR TITLE
feat: grid assists panel — where extra times and skips get spent

### DIFF
--- a/app/analytics/grid/page.tsx
+++ b/app/analytics/grid/page.tsx
@@ -4,6 +4,7 @@ import type { RangeState } from '@/lib/report-range';
 import { ArrowRight } from 'lucide-react';
 import Link from 'next/link';
 import { useMemo } from 'react';
+import { GridAssists } from '@/components/analytics/panels/GridAssists';
 import { GridCriteria, GridCriterionTypes, GridTeams } from '@/components/analytics/panels/GridContent';
 import { GridModes } from '@/components/analytics/panels/GridModes';
 import { GridPool } from '@/components/analytics/panels/GridPool';
@@ -103,6 +104,10 @@ export default function GridAnalyticsPage() {
 
       <ReportPanel state={state} skeletonClassName="h-80 w-full">
         {data => <GridPool data={data} />}
+      </ReportPanel>
+
+      <ReportPanel state={state} skeletonClassName="h-96 w-full">
+        {data => <GridAssists data={data} />}
       </ReportPanel>
 
       <SectionHeader

--- a/components/analytics/__tests__/GridAnalytics.test.tsx
+++ b/components/analytics/__tests__/GridAnalytics.test.tsx
@@ -63,6 +63,22 @@ function response(over: Partial<GridAnalyticsResponse> = {}): GridAnalyticsRespo
     criteria: [],
     criterion_types: [],
     teams: [],
+    assists: {
+      summary: {
+        et_used: 0,
+        et_wasted: 0,
+        et_hits_earned: 0,
+        sessions_using_et: 0,
+        avg_et_position_pct: null,
+        deliberate_skips: 0,
+        distractor_skips: 0,
+        penalty_skips: 0,
+        sessions_skipping: 0,
+      },
+      et_footballers: [],
+      skip_footballers: [],
+      et_criteria: [],
+    },
     ...over,
   };
 }
@@ -235,5 +251,73 @@ describe('GridPopularity', () => {
     render(<GridPopularity data={response()} />);
 
     expect(screen.getByText('No Grid session in this window.')).toBeInTheDocument();
+  });
+});
+
+describe('GridAssists', () => {
+  const assists = {
+    summary: {
+      et_used: 4070,
+      et_wasted: 2027,
+      et_hits_earned: 5165,
+      sessions_using_et: 2771,
+      avg_et_position_pct: 28.0,
+      deliberate_skips: 59217,
+      distractor_skips: 22887,
+      penalty_skips: 31526,
+      sessions_skipping: 4966,
+    },
+    et_footballers: [{ footballer_id: 1, name: 'Luis Hernandez', et_uses: 11, wasted: 6 }],
+    skip_footballers: [{ footballer_id: 2, name: 'Carlos Ruiz', skips: 81 }],
+    et_criteria: [{ criterion_type: 'CLUB_GOALS_GTE', label: '150+ Club Goals', placements: 43 }],
+  };
+
+  it('splits the summary the way the numbers mean', async () => {
+    const { GridAssists } = await import('@/components/analytics/panels/GridAssists');
+    render(<GridAssists data={{ ...response(), assists }} />);
+
+    // Wasted rides with its share; placeable skips are the ranked number,
+    // distractors and penalties are context.
+    expect(screen.getByText('2,027 (50%)')).toBeInTheDocument();
+    expect(screen.getByText('36,330')).toBeInTheDocument();
+    expect(screen.getByText('28% into the run')).toBeInTheDocument();
+  });
+
+  it('renders the three worklists', async () => {
+    const { GridAssists } = await import('@/components/analytics/panels/GridAssists');
+    render(<GridAssists data={{ ...response(), assists }} />);
+
+    expect(screen.getByText('Luis Hernandez')).toBeInTheDocument();
+    expect(screen.getByText('Carlos Ruiz')).toBeInTheDocument();
+    expect(screen.getByText('150+ Club Goals')).toBeInTheDocument();
+  });
+
+  it('shows the empty state when nothing was spent', async () => {
+    const { GridAssists } = await import('@/components/analytics/panels/GridAssists');
+    render(
+      <GridAssists
+        data={{
+          ...response(),
+          assists: {
+            summary: {
+              et_used: 0,
+              et_wasted: 0,
+              et_hits_earned: 0,
+              sessions_using_et: 0,
+              avg_et_position_pct: null,
+              deliberate_skips: 0,
+              distractor_skips: 0,
+              penalty_skips: 0,
+              sessions_skipping: 0,
+            },
+            et_footballers: [],
+            skip_footballers: [],
+            et_criteria: [],
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByText('No Extra Time or skip in this window.')).toBeInTheDocument();
   });
 });

--- a/components/analytics/panels/GridAssists.tsx
+++ b/components/analytics/panels/GridAssists.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+import type { GridAnalyticsResponse } from '@/types/reports';
+import { EmptyState } from '@/components/reports/primitives/EmptyState';
+import { MetricInfo } from '@/components/reports/primitives/MetricInfo';
+import { MetricRow } from '@/components/reports/primitives/MetricRow';
+import { ReportHead, ReportRow, ReportTable, Td, Th } from '@/components/reports/primitives/ReportTable';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+/**
+ * Where the help gets spent — Extra Times and skips as suffering signals.
+ *
+ * The splits carry the meaning, not the totals: a WASTED Extra Time (no
+ * open valid cell existed — it bought nothing) is sharper than a used one,
+ * and a skip only signals pain when the footballer was placeable —
+ * distractor skips are correct play and stay in the summary. On dev data
+ * half of all ET uses were wasted, which is exactly the kind of number
+ * this panel exists to surface.
+ */
+
+/** Above this share of uses wasted, a footballer's row goes amber. */
+const NOTABLE_WASTE_PCT = 50;
+
+export function GridAssists({ data }: { data: GridAnalyticsResponse }) {
+  const { summary, et_footballers, skip_footballers, et_criteria } = data.assists;
+  const nothingSpent = summary.et_used === 0 && summary.deliberate_skips === 0
+    && summary.penalty_skips === 0;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          Where the help gets spent
+          <MetricInfo metric="grid_et_used" />
+        </CardTitle>
+        <CardDescription>
+          Extra Times and skips, split by what they say: a wasted Extra Time
+          bought nothing, a skip only counts as suffering when the footballer
+          had a cell to go to — correctly skipped distractors and penalty
+          auto-skips are reported, not ranked.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4 overflow-x-auto">
+        <MetricRow
+          columns={4}
+          metrics={[
+            {
+              label: 'Extra Times used',
+              value: summary.et_used.toLocaleString(),
+              metric: 'grid_et_used',
+            },
+            {
+              label: 'Wasted',
+              value: summary.et_used === 0
+                ? '—'
+                : `${summary.et_wasted.toLocaleString()} (${Math.round((summary.et_wasted / summary.et_used) * 100)}%)`,
+            },
+            { label: 'ET Hits earned', value: summary.et_hits_earned.toLocaleString() },
+            {
+              label: 'Typical burn point',
+              value: summary.avg_et_position_pct === null
+                ? '—'
+                : `${summary.avg_et_position_pct}% into the run`,
+            },
+          ]}
+        />
+        <MetricRow
+          columns={4}
+          metrics={[
+            {
+              label: 'Skips (placeable)',
+              value: (summary.deliberate_skips - summary.distractor_skips).toLocaleString(),
+              metric: 'grid_skips',
+            },
+            { label: 'Distractor skips', value: summary.distractor_skips.toLocaleString() },
+            { label: 'Penalty auto-skips', value: summary.penalty_skips.toLocaleString() },
+            {
+              label: 'Sessions helped',
+              value: `${summary.sessions_using_et.toLocaleString()} ET · ${summary.sessions_skipping.toLocaleString()} skip`,
+            },
+          ]}
+        />
+
+        {nothingSpent
+          ? (
+              <EmptyState hint="Try a wider date range.">
+                No Extra Time or skip in this window.
+              </EmptyState>
+            )
+          : (
+              <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
+                <div>
+                  <h4 className="mb-2 text-sm font-medium text-muted-foreground">
+                    Footballers people burn an Extra Time on
+                  </h4>
+                  <ReportTable>
+                    <ReportHead>
+                      <Th>Footballer</Th>
+                      <Th align="right">ET uses</Th>
+                      <Th align="right" title="Uses where no open valid cell existed — the Extra Time bought nothing">Wasted</Th>
+                    </ReportHead>
+                    <tbody>
+                      {et_footballers.map(row => (
+                        <ReportRow key={row.footballer_id}>
+                          <Td strong>{row.name}</Td>
+                          <Td align="right">{row.et_uses.toLocaleString()}</Td>
+                          <Td
+                            align="right"
+                            className={cn(
+                              row.et_uses > 0
+                              && (row.wasted / row.et_uses) * 100 >= NOTABLE_WASTE_PCT
+                              && 'text-amber-600 dark:text-amber-500',
+                            )}
+                          >
+                            {row.wasted.toLocaleString()}
+                          </Td>
+                        </ReportRow>
+                      ))}
+                    </tbody>
+                  </ReportTable>
+                </div>
+                <div>
+                  <h4 className="mb-2 text-sm font-medium text-muted-foreground">
+                    Placeable footballers people skip
+                  </h4>
+                  <ReportTable>
+                    <ReportHead>
+                      <Th>Footballer</Th>
+                      <Th align="right" title='"Placeable" is judged against the grid — the cell may already have been filled at the moment of the skip'>Skips</Th>
+                    </ReportHead>
+                    <tbody>
+                      {skip_footballers.map(row => (
+                        <ReportRow key={row.footballer_id}>
+                          <Td strong>{row.name}</Td>
+                          <Td align="right">{row.skips.toLocaleString()}</Td>
+                        </ReportRow>
+                      ))}
+                    </tbody>
+                  </ReportTable>
+                </div>
+              </div>
+            )}
+
+        {et_criteria.length > 0 && (
+          <div>
+            <h4 className="mb-2 text-sm font-medium text-muted-foreground">
+              Cells Extra Times had to rescue
+            </h4>
+            <ReportTable>
+              <ReportHead>
+                <Th>Criterion</Th>
+                <Th>Type</Th>
+                <Th align="right" title="ET placements that landed in a cell carrying this criterion">Rescues</Th>
+              </ReportHead>
+              <tbody>
+                {et_criteria.map(row => (
+                  <ReportRow key={`${row.criterion_type}:${row.label}`}>
+                    <Td strong>{row.label}</Td>
+                    <Td className="text-muted-foreground">{row.criterion_type}</Td>
+                    <Td align="right">{row.placements.toLocaleString()}</Td>
+                  </ReportRow>
+                ))}
+              </tbody>
+            </ReportTable>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -1294,6 +1294,29 @@ export type GridCriterionTypeRow = {
   wrong_pct: number;
 };
 
+/**
+ * Where the help gets spent. A wasted ET bought nothing (no open valid
+ * cell existed); a "placeable" skip is the suffering signal — distractor
+ * skips are correct play and live only in the summary.
+ */
+export type GridAssists = {
+  summary: {
+    et_used: number;
+    et_wasted: number;
+    et_hits_earned: number;
+    sessions_using_et: number;
+    /** How deep into the run an ET is typically burned. Null when unused. */
+    avg_et_position_pct: number | null;
+    deliberate_skips: number;
+    distractor_skips: number;
+    penalty_skips: number;
+    sessions_skipping: number;
+  };
+  et_footballers: { footballer_id: number; name: string; et_uses: number; wasted: number }[];
+  skip_footballers: { footballer_id: number; name: string; skips: number }[];
+  et_criteria: { criterion_type: string; label: string; placements: number }[];
+};
+
 export type GridAnalyticsResponse = {
   modes: GridModeRow[];
   variations: GridVariationRow[];
@@ -1302,6 +1325,7 @@ export type GridAnalyticsResponse = {
   criterion_types: GridCriterionTypeRow[];
   /** The PLAYED_FOR_CLUB slice by reach — the most displayed clubs. */
   teams: GridCriterionRow[];
+  assists: GridAssists;
 } & ResolvedRange;
 
 /**


### PR DESCRIPTION
Mission 4's automation half (BE merged + deployed as App#1546). Completes the "when people use ET Hits or skips, and what they suffer most" item.

## What

New **"Where the help gets spent"** panel on `/analytics/grid`, between the pool worklist and the Reach section:

- **Two summary rows**: ET uses with the **wasted share** beside it (on dev, 50% of Extra Times bought nothing — no open valid cell existed), ET Hits earned, the typical burn point ("28% into the run" — the opening footballers are the wall), and skips split three ways: **placeable** (the ranked suffering number), **distractor** (correct play), **penalty** (auto).
- **Three worklists**: footballers people burn an Extra Time on (wasted count goes amber at ≥50%), placeable footballers people skip (with the judged-against-the-grid caveat in the column tooltip), and the criteria of cells ET placements had to rescue.
- Glossary wired (`grid_et_used`, `grid_skips` — shipped in App#1546).

## Testing

3 new panel tests (summary split math incl. the 36,330 placeable-skips derivation, worklists, empty state) — full suite **925 tests, 134 files, all passing**; `tsc` clean.

Self-review (Copilot off limits per Kalin): diff is the 4 intended files; every new response field is rendered (guard passes); no palette steps beyond the amber status hue; fixture defaults keep older tests honest.