### PR TITLE
chore: analytics dirs join every reports-grade CI gate

### DIFF
--- a/components/analytics/IdentityTile.tsx
+++ b/components/analytics/IdentityTile.tsx
@@ -32,7 +32,7 @@ export function IdentityTile({ image, fallback, className }: {
     <span
       className={cn(
         'flex size-8 shrink-0 items-center justify-center overflow-hidden rounded-md',
-        'bg-muted text-[0.65rem] font-semibold text-muted-foreground ring-1 ring-inset ring-border',
+        'bg-muted text-[0.65rem] font-semibold text-muted-foreground ring-1 ring-border ring-inset',
         className,
       )}
     >

--- a/components/analytics/charts/DifficultyBars.tsx
+++ b/components/analytics/charts/DifficultyBars.tsx
@@ -32,7 +32,7 @@ function BucketTooltip({ active, payload, label, share }: {
           <p key={entry.name} className="flex items-center gap-1.5 text-muted-foreground">
             <span aria-hidden className="size-2 rounded-full" style={{ backgroundColor: entry.color }} />
             {entry.name}
-            <span className="font-medium tabular-nums text-foreground">
+            <span className="font-medium text-foreground tabular-nums">
               {(entry.value ?? 0).toLocaleString()}
             </span>
             {pct !== null && <span className="tabular-nums">{`(${pct}%)`}</span>}

--- a/components/analytics/panels/CategoryMatrix.tsx
+++ b/components/analytics/panels/CategoryMatrix.tsx
@@ -78,7 +78,7 @@ export function CategoryMatrix({ data, onExpand, expanded, search, onSearchChang
                   aria-pressed={active}
                   onClick={() => onDifficultyChange(active ? null : tierKey)}
                   className={cn(
-                    'rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset transition-colors',
+                    'rounded-md px-2 py-1 text-xs font-medium ring-1 transition-colors ring-inset',
                     active
                       ? cn('ring-transparent', tier(tierKey).chip)
                       : 'text-muted-foreground ring-border hover:bg-muted',

--- a/components/analytics/panels/DifficultyCatalogue.tsx
+++ b/components/analytics/panels/DifficultyCatalogue.tsx
@@ -51,7 +51,7 @@ export function DifficultyCatalogue({ data }: { data: CoverageResponse }) {
               <div key={tier.difficulty} className="space-y-1">
                 <div className="flex items-baseline justify-between gap-2">
                   <dt className="text-sm text-muted-foreground">{tierLabel(tier.difficulty)}</dt>
-                  <dd className="text-sm font-medium tabular-nums text-foreground">
+                  <dd className="text-sm font-medium text-foreground tabular-nums">
                     {tier.footballers.toLocaleString()}
                   </dd>
                 </div>
@@ -100,7 +100,7 @@ function PictureRow({ tier }: { tier: DifficultyTier }) {
     <div className="space-y-1">
       <div className="flex items-baseline justify-between gap-2">
         <dt className="text-sm text-muted-foreground">{tierLabel(tier.difficulty)}</dt>
-        <dd className="text-sm tabular-nums text-foreground">
+        <dd className="text-sm text-foreground tabular-nums">
           {empty
             ? <span className="text-muted-foreground">No footballers</span>
             : (

--- a/components/analytics/panels/FootballerBreakdown.tsx
+++ b/components/analytics/panels/FootballerBreakdown.tsx
@@ -62,7 +62,7 @@ function Row({ label, value, total, colour, track }: { label: string; value: num
     <div className="space-y-1">
       <div className="flex items-baseline justify-between gap-2">
         <dt className="text-sm text-muted-foreground">{label}</dt>
-        <dd className="text-sm tabular-nums text-foreground">
+        <dd className="text-sm text-foreground tabular-nums">
           <span className="font-medium">{value.toLocaleString()}</span>
           {pct !== null && <span className="ml-1.5 text-xs text-muted-foreground">{`${pct}%`}</span>}
         </dd>

--- a/components/analytics/panels/FootballerContent.tsx
+++ b/components/analytics/panels/FootballerContent.tsx
@@ -126,7 +126,7 @@ function FootballerRow({ row, minAppearances }: {
                 // gives the eye nothing to anchor on.
                 <span className="flex flex-col gap-1">
                   <OutcomeBar outcome={row.outcome} plays={plays} className="h-2.5" />
-                  <span className="text-xs tabular-nums text-muted-foreground">
+                  <span className="text-xs text-muted-foreground tabular-nums">
                     {`${solvedPct(row.outcome, plays)}% solved`}
                   </span>
                 </span>

--- a/components/analytics/panels/FootballerMatrix.tsx
+++ b/components/analytics/panels/FootballerMatrix.tsx
@@ -73,7 +73,7 @@ export function FootballerMatrix({ data, dimension, onDimensionChange, search, o
                   aria-pressed={dimension === option.key}
                   onClick={() => onDimensionChange(option.key)}
                   className={cn(
-                    'rounded-md px-2.5 py-1 text-xs font-medium ring-1 ring-inset transition-colors',
+                    'rounded-md px-2.5 py-1 text-xs font-medium ring-1 transition-colors ring-inset',
                     dimension === option.key
                       ? 'bg-primary text-primary-foreground ring-transparent'
                       : 'text-muted-foreground ring-border hover:bg-muted',
@@ -101,7 +101,7 @@ export function FootballerMatrix({ data, dimension, onDimensionChange, search, o
                   aria-pressed={active}
                   onClick={() => onDifficultyChange(active ? null : tierKey)}
                   className={cn(
-                    'rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset transition-colors',
+                    'rounded-md px-2 py-1 text-xs font-medium ring-1 transition-colors ring-inset',
                     active
                       ? cn('ring-transparent', tier(tierKey).chip)
                       : 'text-muted-foreground ring-border hover:bg-muted',

--- a/components/analytics/panels/NationGaps.tsx
+++ b/components/analytics/panels/NationGaps.tsx
@@ -60,7 +60,7 @@ function NationChip({ row }: { row: NationRow }) {
           fallen back to the code and the chip reads "TUV Tuvalu TUV". Three of
           233 active nations, so it is rare rather than never. */}
       {row.flag && (
-        <span className="rounded bg-muted px-1 py-px font-mono text-[0.65rem] uppercase tracking-wide text-muted-foreground">
+        <span className="rounded bg-muted px-1 py-px font-mono text-[0.65rem] tracking-wide text-muted-foreground uppercase">
           {row.short}
         </span>
       )}
@@ -109,7 +109,7 @@ function GapCard({ title, description, icon: Icon, accent, total, shown, emptyLa
         {/* Zero is the goal here, so it reads in the brand green rather than in
             the warning colour the other counts use. */}
         <div className="shrink-0 text-right">
-          <p className={cn('text-2xl font-semibold leading-none tabular-nums', empty ? 'text-primary' : tone.figure)}>
+          <p className={cn('text-2xl leading-none font-semibold tabular-nums', empty ? 'text-primary' : tone.figure)}>
             {total.toLocaleString()}
           </p>
           <p className="mt-1 text-[0.7rem] text-muted-foreground">
@@ -122,7 +122,7 @@ function GapCard({ title, description, icon: Icon, accent, total, shown, emptyLa
           ? (
               // Not an error and not a blank: for a gap list, zero is the goal,
               // and a flat grey sentence reads like something failed to load.
-              <p className="flex items-center gap-2 rounded-lg bg-primary/5 px-3 py-2 text-sm text-muted-foreground ring-1 ring-inset ring-primary/15">
+              <p className="flex items-center gap-2 rounded-lg bg-primary/5 px-3 py-2 text-sm text-muted-foreground ring-1 ring-primary/15 ring-inset">
                 <Check className="size-4 shrink-0 text-primary" aria-hidden />
                 {emptyLabel}
               </p>

--- a/components/analytics/panels/TileMatrix.tsx
+++ b/components/analytics/panels/TileMatrix.tsx
@@ -241,7 +241,9 @@ function Tile({ difficulty, count, index, ranked, palette = 'default' }: {
           'flex h-14 items-center justify-center rounded-lg text-sm font-bold tabular-nums',
           // Hover lifts the colour as well as the size. Scale alone reads as a
           // rendering quirk; a brightness change reads as a response.
-          'hover:scale-1.03 animate-data-rise transition-all duration-150 hover:brightness-125',
+          // v4 numeric scale is a PERCENTAGE: scale-103 = grow 3%. The class this
+          // replaces ('scale-1.03') read as 1.03% — a tile shrinking to a dot.
+          'animate-data-rise transition-all duration-150 hover:scale-103 hover:brightness-125',
           // Alternating direction: slate-to-hue, then hue-to-slate. Two
           // neighbours meet light against dark instead of repeating, so the
           // seam is legible without a border between them.

--- a/lib/__tests__/no-orphaned-components.test.ts
+++ b/lib/__tests__/no-orphaned-components.test.ts
@@ -15,7 +15,13 @@ import { describe, expect, it } from 'vitest';
  */
 
 const ROOT = process.cwd();
-const COMPONENT_DIR = join(ROOT, 'components', 'reports');
+// Both surfaces: analytics joined the guard once its component count grew
+// past the point where an orphan could hide (the reports blind spot this
+// test closed existed there too — same primitives, same bucketing).
+const COMPONENT_DIRS = [
+  join(ROOT, 'components', 'reports'),
+  join(ROOT, 'components', 'analytics'),
+];
 
 /** Directories that can legitimately reference a component. */
 const SEARCH_DIRS = ['app', 'components', 'hooks', 'lib'];
@@ -49,7 +55,7 @@ describe('report components', () => {
     // matched, so every component's own source counted as a render of itself
     // and the guard passed for everything — including a genuinely orphaned
     // component, which is the one thing it exists to catch.
-    const components = walk(COMPONENT_DIR)
+    const components = COMPONENT_DIRS.flatMap(dir => walk(dir))
       .filter(path => path.endsWith('.tsx'))
       .map(path => ({ path, name: path.split('/').pop()!.replace(/\.tsx$/, '') }));
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "check-lockfile": "node scripts/check-lockfile.mjs",
     "type-check": "npm run check-types",
     "lint": "eslint .",
-    "lint:reports": "eslint app/reports components/reports components/admin lib hooks scripts --max-warnings 0",
+    "lint:reports": "eslint app/reports app/analytics components/reports components/analytics components/admin lib hooks scripts --max-warnings 0",
     "test": "vitest",
     "test:run": "vitest run",
     "prepare": "husky"

--- a/scripts/check-types.mjs
+++ b/scripts/check-types.mjs
@@ -35,7 +35,7 @@ const IGNORED_PREFIXES = [];
  * Where unused locals are an error today. Everywhere else still owes the
  * cleanup — see the header.
  */
-const UNUSED_SCOPE = ['app/reports/', 'components/reports/', 'components/admin/', 'hooks/', 'lib/'];
+const UNUSED_SCOPE = ['app/reports/', 'app/analytics/', 'components/reports/', 'components/analytics/', 'components/admin/', 'hooks/', 'lib/'];
 
 /**
  * True when a tsc error line belongs to a scoped path.


### PR DESCRIPTION
Mission 5 improvement: `app/analytics` + `components/analytics` were outside all three quality gates that guard the reports surface — new analytics code (three PRs' worth now) shipped unlinted, un-unused-checked, and un-orphan-guarded.

## What

- **`lint:reports`** (the CI-gated lint scope) now includes both analytics dirs. Debt surfaced: 25 auto-fixable classname-order warnings + **one real bug the gate caught on arrival** — `hover:scale-1.03` on the TileMatrix. In Tailwind v4's dynamic numeric scale that parses as **1.03%** — a tile shrinking to a dot on hover (pre-v4 it was silently dead). Fixed to `scale-103` (grow 3%), with a comment so nobody "simplifies" it back.
- **`check-types.mjs` UNUSED_SCOPE** now covers both dirs (passes clean).
- **The orphaned-components guard** now walks `components/analytics` too (passes clean).

CI and the pre-commit hook already invoke `lint:reports` + `check-types:app`, so widening the scripts widens the pipeline with no workflow change.

## Testing

Widened lint scope: clean at `--max-warnings 0` · types OK · full suite **925 tests, 134 files, all passing** (orphan guard included).

Self-review (Copilot off limits per Kalin): diff is gates + the auto-fix fallout + the one behavioural class fix; no component or page logic touched beyond class strings.