### PR TITLE
chore: grid analytics page reads whole in the jump list

### DIFF
--- a/app/analytics/grid/page.tsx
+++ b/app/analytics/grid/page.tsx
@@ -85,6 +85,14 @@ export default function GridAnalyticsPage() {
         />
       </FilterBar>
 
+      {/* Four sections so OnThisPage reads the WHOLE page: with only two
+          headings the jump list hid the top half and filed the assists
+          panel under "worklists", which it is not. */}
+      <SectionHeader
+        title="What people pick"
+        description="Popularity first — every other number on this page assumes you know which modes are big."
+      />
+
       <ReportPanel state={state} skeletonClassName="h-72 w-full">
         {data => <GridPopularity data={data} />}
       </ReportPanel>
@@ -105,6 +113,11 @@ export default function GridAnalyticsPage() {
       <ReportPanel state={state} skeletonClassName="h-80 w-full">
         {data => <GridPool data={data} />}
       </ReportPanel>
+
+      <SectionHeader
+        title="Where the help goes"
+        description="Extra Times and skips — what players pay to get past."
+      />
 
       <ReportPanel state={state} skeletonClassName="h-96 w-full">
         {data => <GridAssists data={data} />}


### PR DESCRIPTION
Mission 5 polish: `OnThisPage` uses section headings once a page has two or more — `/analytics/grid` had exactly two, so the jump list hid the entire top half (popularity, modes) and filed the assists panel under "The content worklists", which it is not.

The page now has four honest sections, each a jump target:

1. **What people pick** — popularity charts + modes/variations table
2. **The content worklists** — misleading criteria + the footballer pool
3. **Where the help goes** — the ET/skip panel
4. **Reach** — criterion types + clubs

No component changes — page structure only. Gates green (lint scope now covers this dir per #161), full suite **925 tests passing**.

Self-review (Copilot off limits): single-file diff, headings match what their sections contain, section copy doesn't restate card copy.