### PR TITLE
feat: pool stock panel — is every composed mode actually stocked

### DIFF
--- a/app/analytics/grid/page.tsx
+++ b/app/analytics/grid/page.tsx
@@ -8,6 +8,7 @@ import { GridAssists } from '@/components/analytics/panels/GridAssists';
 import { GridCriteria, GridCriterionTypes, GridTeams } from '@/components/analytics/panels/GridContent';
 import { GridModes } from '@/components/analytics/panels/GridModes';
 import { GridPool } from '@/components/analytics/panels/GridPool';
+import { GridPools } from '@/components/analytics/panels/GridPools';
 import { GridPopularity } from '@/components/analytics/panels/GridPopularity';
 import { AnalyticsShell } from '@/components/analytics/shell/AnalyticsShell';
 import { FilterBar } from '@/components/reports/filters/FilterBar';
@@ -121,6 +122,15 @@ export default function GridAnalyticsPage() {
 
       <ReportPanel state={state} skeletonClassName="h-96 w-full">
         {data => <GridAssists data={data} />}
+      </ReportPanel>
+
+      <SectionHeader
+        title="The engine room"
+        description="Operational, not editorial — whether the pre-generation pools behind every mode are stocked."
+      />
+
+      <ReportPanel state={state} skeletonClassName="h-80 w-full">
+        {data => <GridPools data={data} />}
       </ReportPanel>
 
       <SectionHeader

--- a/components/analytics/__tests__/GridAnalytics.test.tsx
+++ b/components/analytics/__tests__/GridAnalytics.test.tsx
@@ -79,6 +79,7 @@ function response(over: Partial<GridAnalyticsResponse> = {}): GridAnalyticsRespo
       skip_footballers: [],
       et_criteria: [],
     },
+    pools: [],
     ...over,
   };
 }
@@ -319,5 +320,60 @@ describe('GridAssists', () => {
     );
 
     expect(screen.getByText('No Extra Time or skip in this window.')).toBeInTheDocument();
+  });
+});
+
+describe('GridPools', () => {
+  const pool = {
+    grid_size: '3x3',
+    difficulty: 'HARD',
+    footballer_status: 'NOT_ACTIVE',
+    variation: null,
+    admin_only: false,
+    active: 0,
+    retired: 3,
+    target_pool_size: 2,
+    max_pool_size: 6,
+    auto_size_enabled: true,
+    exhausted_count: 5,
+    last_exhausted_at: '2026-08-28T10:00:00+00:00',
+  };
+
+  it('labels the bucket and flags under-floor stock', async () => {
+    const { GridPools } = await import('@/components/analytics/panels/GridPools');
+    render(<GridPools data={{ ...response(), pools: [pool] }} />);
+
+    expect(screen.getByText('Hard · Retired · 3x3')).toBeInTheDocument();
+
+    const stock = screen.getByText('0 / 2');
+
+    expect(stock).toHaveClass('text-amber-600');
+    expect(screen.getByText('last 2026-08-28')).toBeInTheDocument();
+    expect(screen.getByText('auto')).toBeInTheDocument();
+  });
+
+  it('marks admin test pools and pinned sizing', async () => {
+    const { GridPools } = await import('@/components/analytics/panels/GridPools');
+    render(
+      <GridPools
+        data={{
+          ...response(),
+          pools: [{
+            ...pool,
+            admin_only: true,
+            auto_size_enabled: false,
+            active: 4,
+            last_exhausted_at: null,
+            variation: 'World Cup',
+          }],
+        }}
+      />,
+    );
+
+    expect(screen.getByText('test pool')).toBeInTheDocument();
+    expect(screen.getByText('pinned')).toBeInTheDocument();
+    expect(screen.getByText('Hard · Retired · 3x3 · World Cup')).toBeInTheDocument();
+    // At/above floor: no amber.
+    expect(screen.getByText('4 / 2')).not.toHaveClass('text-amber-600');
   });
 });

--- a/components/analytics/panels/GridPools.tsx
+++ b/components/analytics/panels/GridPools.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import type { GridAnalyticsResponse, GridPoolRow } from '@/types/reports';
+import { EmptyState } from '@/components/reports/primitives/EmptyState';
+import { ReportHead, ReportRow, ReportTable, Td, Th } from '@/components/reports/primitives/ReportTable';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+/**
+ * Whether every composed mode is actually stocked.
+ *
+ * A bucket under its floor serves slow on-demand starts until the next
+ * pre-generation tick catches up; a bucket that keeps exhausting is one
+ * its heavy players have outgrown. Both were only visible in the Django
+ * admin before this table — and an EMPTY bucket is the finding this
+ * table exists to surface, so nothing is hidden for being zero.
+ *
+ * Current state, not windowed: the page's range picker deliberately does
+ * not apply here.
+ */
+
+function bucketLabel(row: GridPoolRow): string {
+  const difficulty = row.difficulty === 'EASY'
+    ? 'Standard'
+    : row.difficulty === 'HARD'
+      ? 'Hard'
+      : row.difficulty ?? 'Any';
+  const roster = row.footballer_status === 'ACTIVE'
+    ? ' · Active'
+    : row.footballer_status === 'NOT_ACTIVE'
+      ? ' · Retired'
+      : '';
+  const variation = row.variation ? ` · ${row.variation}` : '';
+  return `${difficulty}${roster} · ${row.grid_size}${variation}`;
+}
+
+export function GridPools({ data }: { data: GridAnalyticsResponse }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Pool stock</CardTitle>
+        <CardDescription>
+          Ready-to-serve grids per active pre-generation bucket, against the
+          floor the beat task keeps topped up. Under-floor buckets serve slow
+          on-demand starts until the next tick; repeated exhaustion means the
+          heavy players have played everything. Unaffected by the date range.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="overflow-x-auto">
+        {data.pools.length === 0
+          ? <EmptyState>No active pre-generation config.</EmptyState>
+          : (
+              <ReportTable>
+                <ReportHead>
+                  <Th>Bucket</Th>
+                  <Th align="right" title="Pool-active grids vs the floor the beat task tops up to">Stock / floor</Th>
+                  <Th align="right" title="Ceiling on pool-active grids">Max</Th>
+                  <Th align="right" title="Rotated out — still playable for existing sessions">Retired</Th>
+                  <Th align="right" title="Times a player had played every grid in the pool">Exhausted</Th>
+                  <Th>Sizing</Th>
+                </ReportHead>
+                <tbody>
+                  {data.pools.map(row => (
+                    <ReportRow key={`${row.grid_size}-${row.difficulty}-${row.footballer_status}-${row.variation ?? ''}-${row.admin_only}`}>
+                      <Td strong>
+                        {bucketLabel(row)}
+                        {row.admin_only && (
+                          <span className="ml-1.5 text-xs font-normal text-muted-foreground">test pool</span>
+                        )}
+                      </Td>
+                      <Td
+                        align="right"
+                        strong
+                        className={cn(
+                          row.active < row.target_pool_size
+                          && 'text-amber-600 dark:text-amber-500',
+                        )}
+                      >
+                        {`${row.active} / ${row.target_pool_size}`}
+                      </Td>
+                      <Td align="right">{row.max_pool_size}</Td>
+                      <Td align="right" className="text-muted-foreground">{row.retired.toLocaleString()}</Td>
+                      <Td align="right">
+                        {row.exhausted_count.toLocaleString()}
+                        {row.last_exhausted_at && (
+                          <span className="ml-1.5 text-xs text-muted-foreground">
+                            {`last ${row.last_exhausted_at.slice(0, 10)}`}
+                          </span>
+                        )}
+                      </Td>
+                      <Td className="text-muted-foreground">
+                        {row.auto_size_enabled ? 'auto' : 'pinned'}
+                      </Td>
+                    </ReportRow>
+                  ))}
+                </tbody>
+              </ReportTable>
+            )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -1317,6 +1317,22 @@ export type GridAssists = {
   et_criteria: { criterion_type: string; label: string; placements: number }[];
 };
 
+/** Current stock of one pre-generation bucket. Not windowed. */
+export type GridPoolRow = {
+  grid_size: string;
+  difficulty: string | null;
+  footballer_status: string;
+  variation: string | null;
+  admin_only: boolean;
+  active: number;
+  retired: number;
+  target_pool_size: number;
+  max_pool_size: number;
+  auto_size_enabled: boolean;
+  exhausted_count: number;
+  last_exhausted_at: string | null;
+};
+
 export type GridAnalyticsResponse = {
   modes: GridModeRow[];
   variations: GridVariationRow[];
@@ -1326,6 +1342,8 @@ export type GridAnalyticsResponse = {
   /** The PLAYED_FOR_CLUB slice by reach — the most displayed clubs. */
   teams: GridCriterionRow[];
   assists: GridAssists;
+  /** Pool stock per active pre-generation bucket — current state, unwindowed. */
+  pools: GridPoolRow[];
 } & ResolvedRange;
 
 /**


### PR DESCRIPTION
Automation half of App#1548 (merged + deployed). New **"The engine room"** section on `/analytics/grid` with the **Pool stock** table: every active pre-generation bucket with stock vs floor (amber when under — those buckets serve slow on-demand starts), ceiling, retired count, exhaustion (with last-exhausted date inline), auto/pinned sizing, and a "test pool" marker on admin buckets. Empty buckets are shown deliberately — an unstocked mode is the finding. The section copy states it ignores the page's date range (current state).

This gives the roster rollout its missing observability: whether the 12 new buckets are actually being kept stocked by the beat task, without opening the Django admin.

Gates green (the widened lint scope caught 4 findings in my own test file before commit — the #161 investment already paying), full suite **927 tests, 134 files, all passing**; `tsc` clean.

Self-review (Copilot off limits): 4-file diff; every new response field rendered (guard passes); amber only via the status hue; bucket label reuses the established wire-vocabulary translation.