### PR TITLE
feat: grid worklist names link to the footballer editor

### DIFF
--- a/components/analytics/__tests__/GridAnalytics.test.tsx
+++ b/components/analytics/__tests__/GridAnalytics.test.tsx
@@ -377,3 +377,28 @@ describe('GridPools', () => {
     expect(screen.getByText('4 / 2')).not.toHaveClass('text-amber-600');
   });
 });
+
+describe('worklist footballer links', () => {
+  it('every footballer name links to the editor', async () => {
+    const { GridPool } = await import('@/components/analytics/panels/GridPool');
+    const { GridAssists } = await import('@/components/analytics/panels/GridAssists');
+    render(<GridPool data={response({ footballers: [footballer({ footballer_id: 7, name: 'Ray Stewart' })] })} />);
+    render(
+      <GridAssists
+        data={{
+          ...response(),
+          assists: {
+            ...response().assists,
+            summary: { ...response().assists.summary, et_used: 1 },
+            et_footballers: [{ footballer_id: 8, name: 'Luis Hernandez', et_uses: 3, wasted: 1 }],
+            skip_footballers: [{ footballer_id: 9, name: 'Carlos Ruiz', skips: 4 }],
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByRole('link', { name: 'Ray Stewart' })).toHaveAttribute('href', '/footballer-management?edit=7');
+    expect(screen.getByRole('link', { name: 'Luis Hernandez' })).toHaveAttribute('href', '/footballer-management?edit=8');
+    expect(screen.getByRole('link', { name: 'Carlos Ruiz' })).toHaveAttribute('href', '/footballer-management?edit=9');
+  });
+});

--- a/components/analytics/panels/GridAssists.tsx
+++ b/components/analytics/panels/GridAssists.tsx
@@ -1,11 +1,13 @@
 'use client';
 
 import type { GridAnalyticsResponse } from '@/types/reports';
+import Link from 'next/link';
 import { EmptyState } from '@/components/reports/primitives/EmptyState';
 import { MetricInfo } from '@/components/reports/primitives/MetricInfo';
 import { MetricRow } from '@/components/reports/primitives/MetricRow';
 import { ReportHead, ReportRow, ReportTable, Td, Th } from '@/components/reports/primitives/ReportTable';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { editFootballerHref } from '@/lib/footballer-links';
 import { cn } from '@/lib/utils';
 
 /**
@@ -103,7 +105,11 @@ export function GridAssists({ data }: { data: GridAnalyticsResponse }) {
                     <tbody>
                       {et_footballers.map(row => (
                         <ReportRow key={row.footballer_id}>
-                          <Td strong>{row.name}</Td>
+                          <Td strong>
+                            <Link href={editFootballerHref(row.footballer_id)} className="hover:text-primary hover:underline">
+                              {row.name}
+                            </Link>
+                          </Td>
                           <Td align="right">{row.et_uses.toLocaleString()}</Td>
                           <Td
                             align="right"
@@ -132,7 +138,11 @@ export function GridAssists({ data }: { data: GridAnalyticsResponse }) {
                     <tbody>
                       {skip_footballers.map(row => (
                         <ReportRow key={row.footballer_id}>
-                          <Td strong>{row.name}</Td>
+                          <Td strong>
+                            <Link href={editFootballerHref(row.footballer_id)} className="hover:text-primary hover:underline">
+                              {row.name}
+                            </Link>
+                          </Td>
                           <Td align="right">{row.skips.toLocaleString()}</Td>
                         </ReportRow>
                       ))}

--- a/components/analytics/panels/GridPool.tsx
+++ b/components/analytics/panels/GridPool.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import type { GridAnalyticsResponse } from '@/types/reports';
+import Link from 'next/link';
 import { EmptyState } from '@/components/reports/primitives/EmptyState';
 import { MetricInfo } from '@/components/reports/primitives/MetricInfo';
 import { ReportHead, ReportRow, ReportTable, Td, Th } from '@/components/reports/primitives/ReportTable';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { editFootballerHref } from '@/lib/footballer-links';
 import { cn } from '@/lib/utils';
 
 /**
@@ -58,7 +60,14 @@ export function GridPool({ data }: { data: GridAnalyticsResponse }) {
                 <tbody>
                   {data.footballers.map(row => (
                     <ReportRow key={row.footballer_id}>
-                      <Td strong>{row.name}</Td>
+                      {/* A worklist row's endpoint is the edit form: a high
+                          wrong rate is usually a career-data gap, and the fix
+                          lives there — same click Career Path names offer. */}
+                      <Td strong>
+                        <Link href={editFootballerHref(row.footballer_id)} className="hover:text-primary hover:underline">
+                          {row.name}
+                        </Link>
+                      </Td>
                       <Td align="right">{row.shown.toLocaleString()}</Td>
                       <Td align="right">{row.placed.toLocaleString()}</Td>
                       <Td align="right">{row.wrong.toLocaleString()}</Td>


### PR DESCRIPTION
Mission 5: close the workflow gap between finding and fixing. The Grid worklists exist to surface content problems (a footballer everyone places wrongly is usually a career-data gap), but acting on a row meant manually searching the footballer editor. Career Path analytics already links names into `/footballer-management` — Grid now does the same.

- **All three Grid footballer worklists** (the pool outcome table, ET-burned footballers, placeable-skip footballers) link each name to `editFootballerHref(id)` — the editor pre-loaded with that footballer, via the established deep-link helper.
- Same hover affordance as the Career Path table.

One behavioural test asserts all three tables produce the editor href. Gates green, full suite **928 tests, 134 files, all passing**, `tsc` clean.

Self-review (Copilot off limits): 3-file diff; reuses `editFootballerHref` rather than a hand-built URL (the nation-param test suite exists precisely because hand-built params drifted before); no styling beyond the shared link classes.