### PR TITLE
feat: fold the behaviour glance into the grid analytics page

### DIFF
--- a/app/analytics/grid/page.tsx
+++ b/app/analytics/grid/page.tsx
@@ -1,10 +1,9 @@
 'use client';
 
 import type { RangeState } from '@/lib/report-range';
-import { ArrowRight } from 'lucide-react';
-import Link from 'next/link';
 import { useMemo } from 'react';
 import { GridAssists } from '@/components/analytics/panels/GridAssists';
+import { GridBehaviourStrip } from '@/components/analytics/panels/GridBehaviourStrip';
 import { GridCriteria, GridCriterionTypes, GridTeams } from '@/components/analytics/panels/GridContent';
 import { GridModes } from '@/components/analytics/panels/GridModes';
 import { GridPool } from '@/components/analytics/panels/GridPool';
@@ -61,22 +60,19 @@ export default function GridAnalyticsPage() {
     enabled,
     'The Grid analytics endpoint',
   );
+  // The behaviour glance folded in from reporting — same range, Grid only.
+  const summary = useReport(
+    ReportsAPI.getSummary,
+    useMemo(() => ({ ...params, game_type: 'grid' }), [params]),
+    enabled,
+    'The reporting summary endpoint',
+  );
 
   return (
     <AnalyticsShell
       title="Grid content"
       description="Which criteria mislead, which pool footballers are broken or dead weight, and whether each mode and variation actually plays."
     >
-      <div className="flex flex-wrap items-center gap-3">
-        <Link
-          href="/reports/games/grid"
-          className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
-        >
-          Player behaviour for Grid lives in Reports
-          <ArrowRight className="size-4" />
-        </Link>
-      </div>
-
       <FilterBar>
         <RangePicker
           value={range}
@@ -86,7 +82,11 @@ export default function GridAnalyticsPage() {
         />
       </FilterBar>
 
-      {/* Four sections so OnThisPage reads the WHOLE page: with only two
+      <ReportPanel state={summary} skeletonClassName="h-28 w-full">
+        {data => <GridBehaviourStrip data={data} />}
+      </ReportPanel>
+
+      {/* Five sections so OnThisPage reads the WHOLE page: with only two
           headings the jump list hid the top half and filed the assists
           panel under "worklists", which it is not. */}
       <SectionHeader

--- a/components/analytics/__tests__/GridAnalytics.test.tsx
+++ b/components/analytics/__tests__/GridAnalytics.test.tsx
@@ -402,3 +402,39 @@ describe('worklist footballer links', () => {
     expect(screen.getByRole('link', { name: 'Carlos Ruiz' })).toHaveAttribute('href', '/footballer-management?edit=9');
   });
 });
+
+describe('GridBehaviourStrip', () => {
+  it('renders the four behaviour figures for grid and links to reports', async () => {
+    const { GridBehaviourStrip } = await import('@/components/analytics/panels/GridBehaviourStrip');
+    render(
+      <GridBehaviourStrip
+        data={{
+          by_game: [{
+            game_type: 'grid',
+            completion_pct: 84.1,
+            sessions_per_player: 3.2,
+            share_pct: 18.5,
+            repeat_players: 41,
+            repeat_rate_pct: 22.4,
+            previous_games_started: 100,
+            trend_pct: 4.2,
+            games_started: 120,
+            games_finished: 101,
+          }],
+        } as never}
+      />,
+    );
+
+    expect(screen.getByText('84.1%')).toBeInTheDocument();
+    expect(screen.getByText('22.4%')).toBeInTheDocument();
+    expect(screen.getByText('3.2')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /full behaviour view/i })).toHaveAttribute('href', '/reports/games/grid');
+  });
+
+  it('renders nothing without a grid row', async () => {
+    const { GridBehaviourStrip } = await import('@/components/analytics/panels/GridBehaviourStrip');
+    const { container } = render(<GridBehaviourStrip data={{ by_game: [] } as never} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/components/analytics/panels/GridBehaviourStrip.tsx
+++ b/components/analytics/panels/GridBehaviourStrip.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import type { SummaryResponse } from '@/types/reports';
+import { ArrowRight } from 'lucide-react';
+import Link from 'next/link';
+import { StatTile } from '@/components/reports/primitives/StatTile';
+
+/**
+ * The behaviour glance, folded into the content page.
+ *
+ * Four numbers from the reporting summary so a reader judging Grid's
+ * content doesn't have to hold the player-behaviour picture in their head
+ * from another tab. The full behavioural view (activity, retention,
+ * durations, top players) stays in /reports/games/grid — this strip is
+ * the summary of it, and links there.
+ */
+export function GridBehaviourStrip({ data }: { data: SummaryResponse }) {
+  const row = data.by_game.find(entry => entry.game_type === 'grid');
+  if (!row) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        <StatTile
+          label="Completion"
+          metric="completion_pct"
+          value={row.completion_pct === null ? '—' : `${row.completion_pct}%`}
+          hint="Of games started"
+        />
+        <StatTile
+          label="Repeat rate"
+          metric="repeat_rate_pct"
+          value={row.repeat_rate_pct === null ? '—' : `${row.repeat_rate_pct}%`}
+          hint="Players who came back another day"
+        />
+        <StatTile
+          label="Sessions per player"
+          metric="sessions_per_player"
+          value={row.sessions_per_player?.toString() ?? '—'}
+        />
+        <StatTile
+          label="Share of platform"
+          metric="share_pct"
+          value={row.share_pct === null ? '—' : `${row.share_pct}%`}
+          hint="Of all games played"
+        />
+      </div>
+      <Link
+        href="/reports/games/grid"
+        className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
+      >
+        The full behaviour view — activity, retention, durations, top players
+        <ArrowRight className="size-4" />
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
Mission 2 said "fold in what /reports/games/grid shows today so it's all in one place" — we cross-linked; this actually folds.

`/analytics/grid` now opens with the **behaviour glance**: the four summary figures from reporting (completion, repeat rate, sessions per player, share of platform — same tiles, same glossary keys as the game report), fetched from `core/reporting/summary/` filtered to Grid with the page's own range. The bare "behaviour lives in Reports" link is replaced by a more specific one under the tiles ("the full behaviour view — activity, retention, durations, top players"), since the glance now answers the first-order question inline.

Reuses `StatTile` + the existing summary endpoint — no BE change. Renders nothing (not an empty card) when the window has no Grid row.

2 new tests; full suite **930 tests, 134 files, all passing**; gates clean.

Self-review (Copilot off limits): 3-file diff; tiles reuse the reports metric keys so `MetricInfo` definitions stay shared; the removed top-link is superseded, not lost.