### PR TITLE
feat: bait column on the pool worklist

### DIFF
--- a/components/analytics/__tests__/GridAnalytics.test.tsx
+++ b/components/analytics/__tests__/GridAnalytics.test.tsx
@@ -43,6 +43,7 @@ function footballer(over: Partial<GridFootballerRow> & Pick<GridFootballerRow, '
     placed: 10,
     wrong: 25,
     skipped: 5,
+    bait_guesses: 7,
     wrong_pct: 62.5,
     skip_pct: 12.5,
     ...over,
@@ -207,6 +208,7 @@ describe('GridPool', () => {
 
     expect(within(row).getByText('62.5%')).toBeInTheDocument();
     expect(within(row).getByText('12.5%')).toBeInTheDocument();
+    expect(within(row).getByText('7')).toBeInTheDocument();
   });
 
   it('shows the threshold hint when nothing qualifies', () => {

--- a/components/analytics/panels/GridPool.tsx
+++ b/components/analytics/panels/GridPool.tsx
@@ -34,9 +34,11 @@ export function GridPool({ data }: { data: GridAnalyticsResponse }) {
           <MetricInfo metric="grid_shown" />
         </CardTitle>
         <CardDescription>
-          Every appearance a player decided on — placed, misplaced or
-          deliberately skipped. High wrong rate reads as a data bug; high skip
-          rate reads as dead weight. Ordered worst first.
+          Placeable appearances a player decided on — placed, misplaced or
+          deliberately skipped. High wrong rate reads as a data bug or an
+          unguessably obscure career; high skip rate reads as dead weight.
+          Bait counts wrong guesses at distractor appearances (no valid cell
+          existed) and stays out of every rate. Ordered worst first.
         </CardDescription>
       </CardHeader>
       <CardContent className="overflow-x-auto">
@@ -54,7 +56,8 @@ export function GridPool({ data }: { data: GridAnalyticsResponse }) {
                   <Th align="right">Placed</Th>
                   <Th align="right">Wrong</Th>
                   <Th align="right">Skipped</Th>
-                  <Th align="right" title="Wrong placements as a share of shown">Wrong rate</Th>
+                  <Th align="right" title="Wrong guesses at distractor appearances — wrong by construction, excluded from the rates">Bait</Th>
+                  <Th align="right" title="Wrong placements as a share of shown (placeable decisions)">Wrong rate</Th>
                   <Th align="right" title="Deliberate skips as a share of shown">Skip rate</Th>
                 </ReportHead>
                 <tbody>
@@ -72,6 +75,7 @@ export function GridPool({ data }: { data: GridAnalyticsResponse }) {
                       <Td align="right">{row.placed.toLocaleString()}</Td>
                       <Td align="right">{row.wrong.toLocaleString()}</Td>
                       <Td align="right">{row.skipped.toLocaleString()}</Td>
+                      <Td align="right" className="text-muted-foreground">{row.bait_guesses.toLocaleString()}</Td>
                       <Td
                         align="right"
                         strong

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -1261,7 +1261,11 @@ export type GridVariationRow = {
   avg_score: number | null;
 };
 
-/** One pool footballer's outcome split, wrong-rate ordered (worklist). */
+/**
+ * One pool footballer's outcome split over PLACEABLE appearances,
+ * wrong-rate ordered (worklist). Distractor wrong-guesses live in
+ * bait_guesses and are excluded from every rate.
+ */
 export type GridFootballerRow = {
   footballer_id: number;
   name: string;
@@ -1269,6 +1273,8 @@ export type GridFootballerRow = {
   placed: number;
   wrong: number;
   skipped: number;
+  /** Wrong guesses on appearances with NO valid cell — wrong by construction. */
+  bait_guesses: number;
   wrong_pct: number;
   skip_pct: number;
 };


### PR DESCRIPTION
Automation half of App#1550 (merged + deployed): the pool worklist's rates are now placeable-scoped on the BE, and the panel shows the split — a muted **Bait** column (wrong guesses at distractor appearances, wrong by construction, excluded from every rate) with the definition in the column tooltip and the card copy updated to say what a high wrong rate now honestly means: a data bug or an unguessably obscure career, never a distractor artifact.

Gates green, full suite **930 tests, 134 files, all passing**; `tsc` clean.

Self-review (Copilot off limits): 3-file diff; the new response field is rendered (guard passes); bait stays muted so the amber wrong-rate remains the eye-catcher.