### PR TITLE
feat: daily column on the modes table

### DIFF
--- a/components/analytics/__tests__/GridAnalytics.test.tsx
+++ b/components/analytics/__tests__/GridAnalytics.test.tsx
@@ -16,6 +16,8 @@ function mode(over: Partial<GridModeRow>): GridModeRow {
     footballer_status: 'BOTH',
     grid_size: '4x4',
     sessions: 3758,
+    daily_sessions: 1200,
+    daily_pct: 31.9,
     finished: 3161,
     completion_pct: 84.1,
     perfect: 77,
@@ -92,7 +94,7 @@ describe('GridModes', () => {
         data={response({
           modes: [
             mode({}),
-            mode({ difficulty: 'EASY', footballer_status: 'NOT_ACTIVE', grid_size: '3x3', sessions: 12 }),
+            mode({ difficulty: 'EASY', footballer_status: 'NOT_ACTIVE', grid_size: '3x3', sessions: 12, daily_sessions: 0, daily_pct: 0.0 }),
           ],
         })}
       />,
@@ -101,6 +103,14 @@ describe('GridModes', () => {
     // The wire vocabulary never leaks: EASY reads Standard, NOT_ACTIVE reads
     // Retired, BOTH adds nothing.
     expect(screen.getByText('Hard · 4x4')).toBeInTheDocument();
+
+    // Header and cells stay aligned: the Daily column sits between the
+    // mode label and Sessions in BOTH.
+    const table = screen.getByText('Hard · 4x4').closest('table')!;
+    const headers = within(table).getAllByRole('columnheader').map(th => th.textContent);
+
+    expect(headers.slice(0, 3)).toEqual(['Mode', 'Daily', 'Sessions']);
+    expect(within(table).getByText('31.9%')).toBeInTheDocument();
     expect(screen.getByText('Standard · Retired · 3x3')).toBeInTheDocument();
     expect(screen.queryByText(/NOT_ACTIVE|BOTH/)).not.toBeInTheDocument();
   });

--- a/components/analytics/panels/GridModes.tsx
+++ b/components/analytics/panels/GridModes.tsx
@@ -104,6 +104,7 @@ export function GridModes({ data }: { data: GridAnalyticsResponse }) {
               <ReportTable>
                 <ReportHead>
                   <Th>Mode</Th>
+                  <Th align="right" title="Share of this bucket's sessions that were the Daily Grid">Daily</Th>
                   <Th align="right">Sessions</Th>
                   <Th align="right">Finished</Th>
                   <Th align="right" title="Finished as a share of started">Completion</Th>
@@ -115,6 +116,10 @@ export function GridModes({ data }: { data: GridAnalyticsResponse }) {
                   {data.modes.map(row => (
                     <ReportRow key={`${row.difficulty}-${row.footballer_status}-${row.grid_size}`}>
                       <Td strong>{modeLabel(row)}</Td>
+                      <Td align="right">
+                        {`${row.daily_pct}%`}
+                        <span className="ml-1 text-xs text-muted-foreground">{`(${row.daily_sessions.toLocaleString()})`}</span>
+                      </Td>
                       <OutcomeCells row={row} />
                       <Td align="right" className="text-muted-foreground">
                         {row.wrong_guesses.toLocaleString()}

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -1241,6 +1241,9 @@ export type GridModeRow = {
   footballer_status: string;
   grid_size: string;
   sessions: number;
+  /** Daily Grid sessions inside this bucket — the mode's front door. */
+  daily_sessions: number;
+  daily_pct: number;
   finished: number;
   completion_pct: number;
   perfect: number;


### PR DESCRIPTION
Automation half of App#1551 (merged + deployed): the modes table gains a **Daily** column (share + count, right after the mode label) — how much of each bucket's play arrives through the Daily Grid, which is most players' front door into a mode. Includes a header/cell alignment guard test (the review caught a genuine misalignment before commit: the header had Daily after Sessions while the cells rendered it before). Full suite **930 tests passing**, gates clean.

Self-review (Copilot off limits): 3-file diff; new response fields rendered (guard passes); the alignment guard is the regression net for the bug I nearly shipped.