### PR TITLE
feat: human criterion-type labels across the grid tables

### DIFF
--- a/components/analytics/__tests__/GridAnalytics.test.tsx
+++ b/components/analytics/__tests__/GridAnalytics.test.tsx
@@ -163,7 +163,8 @@ describe('GridCriteria', () => {
     const row = screen.getByText('ABW').closest('tr')!;
 
     expect(within(row).getByText('92.4%')).toBeInTheDocument();
-    expect(within(row).getByText('NATIONALITY')).toBeInTheDocument();
+    // Human label in the cell, wire value in the tooltip.
+    expect(within(row).getByText('Nationality')).toHaveAttribute('title', 'NATIONALITY');
   });
 });
 
@@ -182,7 +183,7 @@ describe('GridCriterionTypes', () => {
         })}
       />,
     );
-    const row = screen.getByText('PLAYED_FOR_CLUB').closest('tr')!;
+    const row = screen.getByText('Played for club').closest('tr')!;
 
     expect(within(row).getByText('287')).toBeInTheDocument();
     expect(within(row).getByText('66,330')).toBeInTheDocument();
@@ -201,7 +202,7 @@ describe('GridTeams', () => {
 
     expect(screen.getByText('Man Utd')).toBeInTheDocument();
     // Every row here is PLAYED_FOR_CLUB — a type column would be noise.
-    expect(screen.queryByText('PLAYED_FOR_CLUB')).not.toBeInTheDocument();
+    expect(screen.queryByText('Played for club')).not.toBeInTheDocument();
   });
 });
 

--- a/components/analytics/panels/GridAssists.tsx
+++ b/components/analytics/panels/GridAssists.tsx
@@ -7,6 +7,7 @@ import { MetricInfo } from '@/components/reports/primitives/MetricInfo';
 import { MetricRow } from '@/components/reports/primitives/MetricRow';
 import { ReportHead, ReportRow, ReportTable, Td, Th } from '@/components/reports/primitives/ReportTable';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { criterionTypeLabel } from '@/lib/criterion-type-label';
 import { editFootballerHref } from '@/lib/footballer-links';
 import { cn } from '@/lib/utils';
 
@@ -167,7 +168,9 @@ export function GridAssists({ data }: { data: GridAnalyticsResponse }) {
                 {et_criteria.map(row => (
                   <ReportRow key={`${row.criterion_type}:${row.label}`}>
                     <Td strong>{row.label}</Td>
-                    <Td className="text-muted-foreground">{row.criterion_type}</Td>
+                    <Td className="text-muted-foreground">
+                      <span title={row.criterion_type}>{criterionTypeLabel(row.criterion_type)}</span>
+                    </Td>
                     <Td align="right">{row.placements.toLocaleString()}</Td>
                   </ReportRow>
                 ))}

--- a/components/analytics/panels/GridContent.tsx
+++ b/components/analytics/panels/GridContent.tsx
@@ -5,6 +5,7 @@ import { EmptyState } from '@/components/reports/primitives/EmptyState';
 import { MetricInfo } from '@/components/reports/primitives/MetricInfo';
 import { ReportHead, ReportRow, ReportTable, Td, Th } from '@/components/reports/primitives/ReportTable';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { criterionTypeLabel } from '@/lib/criterion-type-label';
 import { cn } from '@/lib/utils';
 
 /**
@@ -36,7 +37,9 @@ function CriterionTable({ rows, showType = true }: { rows: GridCriterionRow[]; s
           <ReportRow key={`${row.criterion_type}:${row.label}`}>
             <Td strong>{row.label}</Td>
             {showType && (
-              <Td className="text-muted-foreground">{row.criterion_type}</Td>
+              <Td className="text-muted-foreground">
+                <span title={row.criterion_type}>{criterionTypeLabel(row.criterion_type)}</span>
+              </Td>
             )}
             <Td align="right">{row.sessions.toLocaleString()}</Td>
             <Td align="right">{row.attempts.toLocaleString()}</Td>
@@ -111,7 +114,9 @@ export function GridCriterionTypes({ data }: { data: GridAnalyticsResponse }) {
                 <tbody>
                   {data.criterion_types.map(row => (
                     <ReportRow key={row.criterion_type}>
-                      <Td strong>{row.criterion_type}</Td>
+                      <Td strong>
+                        <span title={row.criterion_type}>{criterionTypeLabel(row.criterion_type)}</span>
+                      </Td>
                       <Td align="right">{row.identities.toLocaleString()}</Td>
                       <Td align="right">{row.attempts.toLocaleString()}</Td>
                       <Td align="right">{row.wrong.toLocaleString()}</Td>

--- a/lib/__tests__/criterion-type-label.test.ts
+++ b/lib/__tests__/criterion-type-label.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { criterionTypeLabel } from '@/lib/criterion-type-label';
+
+describe('criterionTypeLabel', () => {
+  it('prettifies plain enum names', () => {
+    expect(criterionTypeLabel('PLAYED_FOR_CLUB')).toBe('Played for club');
+    expect(criterionTypeLabel('NATIONALITY')).toBe('Nationality');
+    expect(criterionTypeLabel('TOURNAMENT_TOP_SCORER')).toBe('Tournament top scorer');
+  });
+
+  it('uses explicit spellings where the prettifier would mangle', () => {
+    expect(criterionTypeLabel('BALLON_DOR_WINNER')).toBe('Ballon d\'Or winner');
+    expect(criterionTypeLabel('CLUB_GOALS_GTE')).toBe('Club goals threshold');
+  });
+
+  it('never breaks on a type it has not met', () => {
+    expect(criterionTypeLabel('SOME_FUTURE_TYPE')).toBe('Some future type');
+  });
+});

--- a/lib/criterion-type-label.ts
+++ b/lib/criterion-type-label.ts
@@ -1,0 +1,29 @@
+/**
+ * Human labels for Grid criterion-type enums.
+ *
+ * The analytics tables printed wire values ('PLAYED_FOR_CLUB',
+ * 'CLUB_GOALS_GTE') — legible to whoever wrote the enum, furniture to
+ * everyone else. Explicit entries cover the names the generic prettifier
+ * would mangle; everything unknown falls through to prettified words so a
+ * new BE type never renders as a crash or a blank.
+ */
+
+const EXPLICIT: Record<string, string> = {
+  BALLON_DOR_WINNER: 'Ballon d\'Or winner',
+  BALLON_DOR_TOP_N: 'Ballon d\'Or top N',
+  GOLDEN_SHOE_WINNER: 'Golden Shoe winner',
+  INTERNATIONAL_CAPS_GTE: 'International caps threshold',
+  INTERNATIONAL_GOALS_GTE: 'International goals threshold',
+  CLUB_GOALS_GTE: 'Club goals threshold',
+  TOURNAMENT_BEST_GOALKEEPER: 'Tournament best goalkeeper',
+  TOURNAMENT_BEST_YOUNG_PLAYER: 'Tournament best young player',
+};
+
+export function criterionTypeLabel(criterionType: string): string {
+  const explicit = EXPLICIT[criterionType];
+  if (explicit) {
+    return explicit;
+  }
+  const words = criterionType.toLowerCase().split('_').join(' ');
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}


### PR DESCRIPTION
Mission 5 polish: the three Grid tables that printed wire enums ('PLAYED_FOR_CLUB', 'CLUB_GOALS_GTE') now show human labels ('Played for club', 'Club goals threshold') via one shared `criterionTypeLabel` — explicit spellings where prettifying would mangle (Ballon d'Or, the GTE thresholds), generic word-splitting fallback so an unmet future type renders readably instead of raw. The wire value stays one hover away (title attribute) for anyone mapping back to the BE enum. 3 formatter tests + updated table assertions (labels in cells, wire values in tooltips); full suite **933 tests, 135 files, all passing**.

Self-review (Copilot off limits): 5-file diff; single source for the mapping; no table shape changes.