### PR TITLE
feat: mode drill-down on the grid analytics page

### DIFF
--- a/app/analytics/grid/page.tsx
+++ b/app/analytics/grid/page.tsx
@@ -1,7 +1,10 @@
 'use client';
 
 import type { RangeState } from '@/lib/report-range';
+import type { GridModeRow } from '@/types/reports';
 import { useMemo } from 'react';
+import { ActiveFilterChips } from '@/components/analytics/ActiveFilterChips';
+import { modeLabel } from '@/components/analytics/panels/grid-mode';
 import { GridAssists } from '@/components/analytics/panels/GridAssists';
 import { GridBehaviourStrip } from '@/components/analytics/panels/GridBehaviourStrip';
 import { GridCriteria, GridCriterionTypes, GridTeams } from '@/components/analytics/panels/GridContent';
@@ -46,12 +49,26 @@ export default function GridAnalyticsPage() {
     game: null,
     metric: 'games_started',
   });
-  const { range, includeBots } = filters;
+  const { range, includeBots, gridDifficulty, gridRoster, gridSize } = filters;
   const setRange = (next: RangeState) => update({ range: next });
   const setIncludeBots = (next: boolean) => update({ includeBots: next });
+  // Mode drill-down: the three axes ride the URL (shareable) and the API
+  // request together. Selecting a row sets all three; clearing nulls them.
+  const selectedKey = gridDifficulty || gridRoster || gridSize
+    ? `${gridDifficulty}|${gridRoster}|${gridSize}`
+    : null;
+  const selectMode = (row: GridModeRow | null) => update(row
+    ? { gridDifficulty: row.difficulty, gridRoster: row.footballer_status, gridSize: row.grid_size }
+    : { gridDifficulty: null, gridRoster: null, gridSize: null });
   const params = useMemo(
-    () => ({ ...rangeToParams(range), include_bots: includeBots }),
-    [range, includeBots],
+    () => ({
+      ...rangeToParams(range),
+      include_bots: includeBots,
+      ...(gridDifficulty ? { difficulty: gridDifficulty } : {}),
+      ...(gridRoster ? { footballer_status: gridRoster } : {}),
+      ...(gridSize ? { grid_size: gridSize } : {}),
+    }),
+    [range, includeBots, gridDifficulty, gridRoster, gridSize],
   );
 
   const state = useReport(
@@ -82,6 +99,33 @@ export default function GridAnalyticsPage() {
         />
       </FilterBar>
 
+      <ActiveFilterChips
+        chips={[
+          ...(selectedKey
+            ? [{
+                key: 'mode',
+                kind: 'Mode',
+                label: modeLabel({
+                  difficulty: gridDifficulty,
+                  footballer_status: gridRoster ?? 'BOTH',
+                  grid_size: gridSize ?? '',
+                } as GridModeRow),
+                onClear: () => selectMode(null),
+              }]
+            : []),
+          ...(range.start || range.window !== 90
+            ? [{
+                key: 'range',
+                kind: 'Range',
+                label: range.start
+                  ? `${range.start} → ${range.end ?? 'today'}`
+                  : `Last ${range.window} days`,
+                onClear: () => setRange({ window: 90 }),
+              }]
+            : []),
+        ]}
+      />
+
       <ReportPanel state={summary} skeletonClassName="h-28 w-full">
         {data => <GridBehaviourStrip data={data} />}
       </ReportPanel>
@@ -99,7 +143,7 @@ export default function GridAnalyticsPage() {
       </ReportPanel>
 
       <ReportPanel state={state} skeletonClassName="h-96 w-full">
-        {data => <GridModes data={data} />}
+        {data => <GridModes data={data} selectedKey={selectedKey} onSelectMode={selectMode} />}
       </ReportPanel>
 
       <SectionHeader

--- a/components/analytics/ActiveFilterChips.tsx
+++ b/components/analytics/ActiveFilterChips.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { X } from 'lucide-react';
+
+/**
+ * What the page is currently narrowed to, as removable chips.
+ *
+ * The pickers themselves (range control, mode table) show state where they
+ * live, which is scattered down the page — this row says it in one place,
+ * right under the filter bar, and every chip clears with one click. No
+ * chips render when nothing is narrowed, so the default view carries no
+ * furniture.
+ */
+
+export type FilterChip = {
+  key: string;
+  /** "Mode", "Range" — what kind of narrowing this is. */
+  kind: string;
+  label: string;
+  onClear: () => void;
+};
+
+export function ActiveFilterChips({ chips }: { chips: FilterChip[] }) {
+  if (chips.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <span className="text-xs text-muted-foreground">Narrowed to</span>
+      {chips.map(chip => (
+        <span
+          key={chip.key}
+          className="inline-flex items-center gap-1.5 rounded-full border border-primary/30 bg-primary/10 py-1 pr-1.5 pl-3 text-xs font-medium text-foreground"
+        >
+          <span className="text-muted-foreground">{chip.kind}</span>
+          {chip.label}
+          <button
+            type="button"
+            aria-label={`Clear ${chip.kind.toLowerCase()} filter`}
+            onClick={chip.onClear}
+            className="rounded-full p-0.5 text-muted-foreground transition-colors hover:bg-primary/20 hover:text-foreground"
+          >
+            <X className="size-3" />
+          </button>
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/components/analytics/__tests__/GridAnalytics.test.tsx
+++ b/components/analytics/__tests__/GridAnalytics.test.tsx
@@ -5,7 +5,7 @@ import type {
   GridModeRow,
 } from '@/types/reports';
 import { render, screen, within } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { GridCriteria, GridCriterionTypes, GridTeams } from '@/components/analytics/panels/GridContent';
 import { GridModes } from '@/components/analytics/panels/GridModes';
 import { GridPool } from '@/components/analytics/panels/GridPool';
@@ -447,6 +447,70 @@ describe('GridBehaviourStrip', () => {
   it('renders nothing without a grid row', async () => {
     const { GridBehaviourStrip } = await import('@/components/analytics/panels/GridBehaviourStrip');
     const { container } = render(<GridBehaviourStrip data={{ by_game: [] } as never} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe('mode drill-down UI', () => {
+  it('selecting a mode row reports the row, selecting it again clears', async () => {
+    const { GridModes } = await import('@/components/analytics/panels/GridModes');
+    const { modeKey } = await import('@/components/analytics/panels/grid-mode');
+    const row = mode({});
+    const onSelectMode = vi.fn();
+    render(
+      <GridModes
+        data={response({ modes: [row] })}
+        selectedKey={null}
+        onSelectMode={onSelectMode}
+      />,
+    );
+
+    const button = screen.getByRole('button', { name: 'Hard · 4x4' });
+
+    expect(button).toHaveAttribute('aria-pressed', 'false');
+
+    button.click();
+
+    expect(onSelectMode).toHaveBeenCalledWith(row);
+
+    // Re-render as selected: same click now clears.
+    onSelectMode.mockClear();
+    render(
+      <GridModes
+        data={response({ modes: [row] })}
+        selectedKey={modeKey(row)}
+        onSelectMode={onSelectMode}
+      />,
+    );
+    const selected = screen.getAllByRole('button', { name: 'Hard · 4x4' })[1]!;
+
+    expect(selected).toHaveAttribute('aria-pressed', 'true');
+
+    selected.click();
+
+    expect(onSelectMode).toHaveBeenCalledWith(null);
+  });
+
+  it('chips render the narrowing and clear on click', async () => {
+    const { ActiveFilterChips } = await import('@/components/analytics/ActiveFilterChips');
+    const clear = vi.fn();
+    render(
+      <ActiveFilterChips
+        chips={[{ key: 'mode', kind: 'Mode', label: 'Hard · Retired · 3x3', onClear: clear }]}
+      />,
+    );
+
+    expect(screen.getByText('Hard · Retired · 3x3')).toBeInTheDocument();
+
+    screen.getByRole('button', { name: 'Clear mode filter' }).click();
+
+    expect(clear).toHaveBeenCalled();
+  });
+
+  it('renders nothing with no chips', async () => {
+    const { ActiveFilterChips } = await import('@/components/analytics/ActiveFilterChips');
+    const { container } = render(<ActiveFilterChips chips={[]} />);
 
     expect(container).toBeEmptyDOMElement();
   });

--- a/components/analytics/panels/GridModes.tsx
+++ b/components/analytics/panels/GridModes.tsx
@@ -7,6 +7,7 @@ import { MetricRow } from '@/components/reports/primitives/MetricRow';
 import { ReportHead, ReportRow, ReportTable, Td, Th } from '@/components/reports/primitives/ReportTable';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
+import { modeKey, modeLabel } from './grid-mode';
 
 /**
  * How each Grid mode and variation actually plays.
@@ -20,20 +21,6 @@ import { cn } from '@/lib/utils';
 
 /** Below this, completion is worth a look whatever the mode promises. */
 const LOW_COMPLETION_PCT = 60;
-
-function modeLabel(row: GridModeRow): string {
-  const difficulty = row.difficulty === 'EASY'
-    ? 'Standard'
-    : row.difficulty === 'HARD'
-      ? 'Hard'
-      : row.difficulty ?? 'Unclassified';
-  const roster = row.footballer_status === 'ACTIVE'
-    ? ' · Active'
-    : row.footballer_status === 'NOT_ACTIVE'
-      ? ' · Retired'
-      : '';
-  return `${difficulty}${roster} · ${row.grid_size}`;
-}
 
 function OutcomeCells({ row }: { row: GridModeRow | GridVariationRow }) {
   return (
@@ -59,7 +46,13 @@ function OutcomeCells({ row }: { row: GridModeRow | GridVariationRow }) {
   );
 }
 
-export function GridModes({ data }: { data: GridAnalyticsResponse }) {
+export function GridModes({ data, selectedKey = null, onSelectMode }: {
+  data: GridAnalyticsResponse;
+  /** modeKey() of the drilled-into bucket, or null. */
+  selectedKey?: string | null;
+  /** Called with the row to drill in, or null to clear (same row clicked). */
+  onSelectMode?: (row: GridModeRow | null) => void;
+}) {
   const totalSessions = data.modes.reduce((sum, row) => sum + row.sessions, 0);
   const totalFinished = data.modes.reduce((sum, row) => sum + row.finished, 0);
   const totalPerfect = data.modes.reduce((sum, row) => sum + row.perfect, 0);
@@ -75,6 +68,7 @@ export function GridModes({ data }: { data: GridAnalyticsResponse }) {
           Every difficulty × roster × size bucket that was played, and every
           variation. A new mode appears here the day it gets its first player —
           judge it on completion and errors before anyone has to complain.
+          {onSelectMode && ' Click a mode to narrow the worklists below to it.'}
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4 overflow-x-auto">
@@ -113,19 +107,41 @@ export function GridModes({ data }: { data: GridAnalyticsResponse }) {
                   <Th align="right" title="Player-made wrong placements (Extra-Time excluded)">Wrong guesses</Th>
                 </ReportHead>
                 <tbody>
-                  {data.modes.map(row => (
-                    <ReportRow key={`${row.difficulty}-${row.footballer_status}-${row.grid_size}`}>
-                      <Td strong>{modeLabel(row)}</Td>
-                      <Td align="right">
-                        {`${row.daily_pct}%`}
-                        <span className="ml-1 text-xs text-muted-foreground">{`(${row.daily_sessions.toLocaleString()})`}</span>
-                      </Td>
-                      <OutcomeCells row={row} />
-                      <Td align="right" className="text-muted-foreground">
-                        {row.wrong_guesses.toLocaleString()}
-                      </Td>
-                    </ReportRow>
-                  ))}
+                  {data.modes.map((row) => {
+                    const isSelected = selectedKey === modeKey(row);
+                    return (
+                      <ReportRow
+                        key={modeKey(row)}
+                        className={cn(isSelected && 'bg-primary/10 hover:bg-primary/15')}
+                      >
+                        <Td strong>
+                          {onSelectMode
+                            ? (
+                                <button
+                                  type="button"
+                                  aria-pressed={isSelected}
+                                  onClick={() => onSelectMode(isSelected ? null : row)}
+                                  className={cn(
+                                    'text-left hover:text-primary hover:underline',
+                                    isSelected && 'text-primary',
+                                  )}
+                                >
+                                  {modeLabel(row)}
+                                </button>
+                              )
+                            : modeLabel(row)}
+                        </Td>
+                        <Td align="right">
+                          {`${row.daily_pct}%`}
+                          <span className="ml-1 text-xs text-muted-foreground">{`(${row.daily_sessions.toLocaleString()})`}</span>
+                        </Td>
+                        <OutcomeCells row={row} />
+                        <Td align="right" className="text-muted-foreground">
+                          {row.wrong_guesses.toLocaleString()}
+                        </Td>
+                      </ReportRow>
+                    );
+                  })}
                 </tbody>
               </ReportTable>
             )}

--- a/components/analytics/panels/GridPopularity.tsx
+++ b/components/analytics/panels/GridPopularity.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import type { GridAnalyticsResponse, GridModeRow } from '@/types/reports';
+import type { GridAnalyticsResponse } from '@/types/reports';
 import { PopularityBars } from '@/components/analytics/charts/PopularityBars';
 import { EmptyState } from '@/components/reports/primitives/EmptyState';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { useGameColor, useGameMeta } from '@/hooks/use-game-meta';
 import { difficultyTier } from '@/lib/data-colours';
+import { modeLabel } from './grid-mode';
 
 /**
  * What Grid players actually pick — modes and variations as lengths on one
@@ -21,20 +22,6 @@ import { difficultyTier } from '@/lib/data-colours';
  * surface here; variation bars use the game's registry colour — ranking is
  * the message there, not identity.
  */
-
-function modeLabel(row: GridModeRow): string {
-  const difficulty = row.difficulty === 'EASY'
-    ? 'Standard'
-    : row.difficulty === 'HARD'
-      ? 'Hard'
-      : row.difficulty ?? 'Unclassified';
-  const roster = row.footballer_status === 'ACTIVE'
-    ? ' · Active'
-    : row.footballer_status === 'NOT_ACTIVE'
-      ? ' · Retired'
-      : '';
-  return `${difficulty}${roster} · ${row.grid_size}`;
-}
 
 export function GridPopularity({ data }: { data: GridAnalyticsResponse }) {
   const { meta } = useGameMeta(true);

--- a/components/analytics/panels/grid-mode.ts
+++ b/components/analytics/panels/grid-mode.ts
@@ -1,0 +1,25 @@
+import type { GridModeRow } from '@/types/reports';
+
+/**
+ * The one translation from mode wire vocabulary to reader words —
+ * shared by the modes table, the popularity chart and the filter chip
+ * so the same bucket never renders under two names.
+ */
+export function modeLabel(row: GridModeRow): string {
+  const difficulty = row.difficulty === 'EASY'
+    ? 'Standard'
+    : row.difficulty === 'HARD'
+      ? 'Hard'
+      : row.difficulty ?? 'Unclassified';
+  const roster = row.footballer_status === 'ACTIVE'
+    ? ' · Active'
+    : row.footballer_status === 'NOT_ACTIVE'
+      ? ' · Retired'
+      : '';
+  const size = row.grid_size ? ` · ${row.grid_size}` : '';
+  return `${difficulty}${roster}${size}`;
+}
+
+export function modeKey(row: GridModeRow): string {
+  return `${row.difficulty}|${row.footballer_status}|${row.grid_size}`;
+}

--- a/hooks/use-report-filters.ts
+++ b/hooks/use-report-filters.ts
@@ -34,7 +34,24 @@ export type ReportFilters = {
   /** An explicitly named comparison period, for "this month vs launch month". */
   compareStart?: string;
   compareEnd?: string;
+  /**
+   * Grid analytics mode drill-down — only that page sets these (the same
+   * way search/limit belong to the leaderboards and compare* to the
+   * summary). Wire vocabulary, validated against the same allowlists the
+   * API enforces so a mistyped shared link degrades to unfiltered.
+   */
+  gridDifficulty: string | null;
+  gridRoster: string | null;
+  gridSize: string | null;
 };
+
+const GRID_DIFFICULTIES = ['EASY', 'HARD'];
+const GRID_ROSTERS = ['ACTIVE', 'NOT_ACTIVE', 'BOTH'];
+const GRID_SIZES = ['3x3', '4x4', '5x4', '6x4'];
+
+function allowlisted(value: string | null, allowed: string[]): string | null {
+  return value && allowed.includes(value) ? value : null;
+}
 
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -96,6 +113,9 @@ function parse(search: string, fallback: ReportFilters): ReportFilters {
     compareOffset,
     compareStart: hasCompare ? compareStart : undefined,
     compareEnd: hasCompare ? (compareEnd ?? undefined) : undefined,
+    gridDifficulty: allowlisted(params.get('difficulty'), GRID_DIFFICULTIES),
+    gridRoster: allowlisted(params.get('roster'), GRID_ROSTERS),
+    gridSize: allowlisted(params.get('size'), GRID_SIZES),
   };
 }
 
@@ -137,6 +157,15 @@ function serialise(filters: ReportFilters, defaults: ReportFilters): string {
   } else if (filters.compareOffset !== defaults.compareOffset) {
     params.set('compare_offset', String(filters.compareOffset));
   }
+  if (filters.gridDifficulty) {
+    params.set('difficulty', filters.gridDifficulty);
+  }
+  if (filters.gridRoster) {
+    params.set('roster', filters.gridRoster);
+  }
+  if (filters.gridSize) {
+    params.set('size', filters.gridSize);
+  }
   const query = params.toString();
   return query ? `?${query}` : '';
 }
@@ -145,7 +174,7 @@ export function useReportFilters(
   // `limit` is optional: only the leaderboard views paginate, and requiring it
   // on the other seven pages would put a number in front of readers that means
   // nothing there.
-  suppliedDefaults: Omit<ReportFilters, 'limit' | 'search' | 'compareOffset'> & {
+  suppliedDefaults: Omit<ReportFilters, 'limit' | 'search' | 'compareOffset' | 'gridDifficulty' | 'gridRoster' | 'gridSize'> & {
     limit?: number;
     search?: string;
     compareOffset?: number;
@@ -156,6 +185,10 @@ export function useReportFilters(
     search: '',
     // Only the summary compares periods; the other pages never mention it.
     compareOffset: 1,
+    // Only grid analytics drills into a mode; everywhere else stays null.
+    gridDifficulty: null,
+    gridRoster: null,
+    gridSize: null,
     ...suppliedDefaults,
   };
   const [filters, setFilters] = useState<ReportFilters>(defaults);

--- a/lib/__tests__/report-filters.test.ts
+++ b/lib/__tests__/report-filters.test.ts
@@ -12,6 +12,9 @@ const defaults = {
   limit: 25,
   search: '',
   compareOffset: 1,
+  gridDifficulty: null,
+  gridRoster: null,
+  gridSize: null,
 };
 
 describe('report filter URL state', () => {
@@ -187,5 +190,24 @@ describe('every report page can be exported', () => {
       offenders.map(f => f.replace(process.cwd(), '')),
       'Report pages with no CSV export — the data can be read but not taken anywhere',
     ).toEqual([]);
+  });
+});
+
+describe('grid mode drill-down params', () => {
+  it('round-trips the three axes and drops junk values', () => {
+    const filters = { ...defaults, gridDifficulty: 'HARD', gridRoster: 'NOT_ACTIVE', gridSize: '3x3' };
+
+    expect(__test.serialise(filters, defaults)).toBe('?difficulty=HARD&roster=NOT_ACTIVE&size=3x3');
+    expect(__test.parse('?difficulty=HARD&roster=NOT_ACTIVE&size=3x3', defaults)).toMatchObject({
+      gridDifficulty: 'HARD',
+      gridRoster: 'NOT_ACTIVE',
+      gridSize: '3x3',
+    });
+    // A mistyped shared link degrades to unfiltered, never to a 400.
+    expect(__test.parse('?difficulty=LEGEND&roster=ROBOTS&size=9x9', defaults)).toMatchObject({
+      gridDifficulty: null,
+      gridRoster: null,
+      gridSize: null,
+    });
   });
 });


### PR DESCRIPTION
Part A (FE) — backed by App#1552 (merged + deployed).

## What

**Click a mode, see everything about it.** In the Modes table, each mode label is now a button: clicking it narrows the criteria worklist, the footballer pool, "Where the help goes" and the Reach tables to that difficulty × roster × size bucket. Clicking again (or the chip's ✕) clears it.

**It's always clear what you're looking at:**
- a **"Narrowed to" chip row** under the filter bar shows the active mode and the range whenever either is non-default — each chip clears with one click;
- the selected row is highlighted (`aria-pressed` on the button);
- the modes table, popularity charts and pool stock stay global — they're the picker, and the card copy says so.

**Shareable**: the selection rides the URL (`?difficulty=HARD&roster=NOT_ACTIVE&size=3x3`) via the same filter machinery every report page uses, with allowlisted parsing so a mistyped shared link degrades to unfiltered instead of erroring. The three fields join the hook the same way `search`/`limit` (leaderboards-only) and `compare*` (summary-only) already do.

Also dedupes `modeLabel` into one shared module — table, chart and chip can never render the same bucket under two names.

## Testing

3 new UI tests (select/clear round-trip with `aria-pressed`, chip render + clear, chip row absent when nothing is narrowed) + a URL round-trip test incl. junk-value degradation. Full suite **937 tests, 135 files, all passing**; gates clean.

Self-review (Copilot off limits): mode params only attach to the analytics request, never the summary strip; the hook keeps only-non-defaults-in-URL discipline.