### PR TITLE
feat: daily pulse shows all four activity metrics as equal panels

### DIFF
--- a/app/reports/page.tsx
+++ b/app/reports/page.tsx
@@ -161,6 +161,11 @@ export default function ReportsPage() {
             series={data.series}
             metric={metric}
             color={game ? resolveColor(meta, game) : undefined}
+            // All four metrics as equal panels: the pulse question is "how is
+            // everything moving", not "how is one metric moving" — that view
+            // stays on the per-game pages. The metric toggle above keeps
+            // driving the games leaderboard below.
+            layout="grid"
             title={`${selectedLabel ?? 'All games'} — last ${data.window} days`}
             description={`${data.totals.games_started.toLocaleString()} played, ${data.totals.games_finished.toLocaleString()} finished, ${data.totals.distinct_players.toLocaleString()} distinct players.`}
           />

--- a/components/reports/__tests__/ActivityChart.grid.test.tsx
+++ b/components/reports/__tests__/ActivityChart.grid.test.tsx
@@ -1,0 +1,46 @@
+import type { ActivityDay } from '@/types/reports';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ActivityChart } from '@/components/reports/charts/ActivityChart';
+
+function day(date: string): ActivityDay {
+  return {
+    date,
+    covered: true,
+    games_started: 120,
+    games_finished: 90,
+    distinct_players: 40,
+    mp_player_sessions: 12,
+  };
+}
+
+const PROPS = {
+  series: [day('2026-08-25'), day('2026-08-26')],
+  title: 'All games — last 30 days',
+  description: 'test',
+  metric: 'games_started' as const,
+  granularity: 'day' as const,
+  onGranularityChange: () => {},
+};
+
+describe('ActivityChart grid layout', () => {
+  it('renders all four metrics as equal panels with their totals', () => {
+    render(<ActivityChart {...PROPS} layout="grid" />);
+
+    for (const label of ['Played', 'Finished', 'Players', 'Multiplayer']) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+
+    // Totals ride each panel header: played summed across the two days.
+    expect(screen.getByText('240')).toBeInTheDocument();
+  });
+
+  it('keeps the primary layout by default', () => {
+    render(<ActivityChart {...PROPS} />);
+
+    // In primary layout the selected metric is NOT a small panel header —
+    // only the three context metrics carry the muted header treatment.
+    expect(screen.queryByText('Played')).not.toBeInTheDocument();
+    expect(screen.getByText('Finished')).toBeInTheDocument();
+  });
+});

--- a/components/reports/charts/ActivityChart.tsx
+++ b/components/reports/charts/ActivityChart.tsx
@@ -68,13 +68,21 @@ function metricColor(theme: ChartTheme, metric: MetricKey): string {
  * alternative is the one thing worse than both — it lets the author choose
  * where the lines cross.
  */
-export function ActivityChart({ series, title, description, metric, color, granularity, onGranularityChange }: {
+export function ActivityChart({ series, title, description, metric, color, granularity, onGranularityChange, layout = 'primary' }: {
   series: ActivityDay[];
   title: string;
   description: string;
   metric: MetricKey;
   /** Overrides the metric colour — used to match the selected game's badge. */
   color?: string;
+  /**
+   * 'primary' = the selected metric large with the other three as context
+   * sparklines. 'grid' = all four as EQUAL panels — the Daily Pulse view,
+   * where no one metric outranks the rest. Both keep one y-axis per
+   * metric: magnitudes differ by orders, and a shared axis flattens the
+   * small series while implying the gaps are comparable.
+   */
+  layout?: 'primary' | 'grid';
   /**
    * Controlled, because the bucketing happens server-side: a week's distinct
    * players must be computed, not summed, so changing this refetches rather
@@ -150,65 +158,104 @@ export function ActivityChart({ series, title, description, metric, color, granu
           )}
         </CardDescription>
       </CardHeader>
-      <CardContent className="h-72 sm:h-80">
-        <ResponsiveContainer width="100%" height="100%">
-          <LineChart data={data} margin={{ top: 8, right: 8, bottom: 8, left: -12 }}>
-            <CartesianGrid strokeDasharray="3 3" stroke={theme.grid.stroke} />
-            <XAxis dataKey="label" tick={theme.tick} interval="preserveStartEnd" minTickGap={24} />
-            <YAxis tick={theme.tick} allowDecimals={false} width={44} />
-            <Tooltip content={<ChartTooltip />} cursor={theme.tooltip.cursor} />
-            {/* One line, its own axis. The others are below at their own
-                scales rather than squashed onto this one. */}
-            <Line
-              type="monotone"
-              dataKey={primaryOption.key}
-              name={primaryOption.label}
-              stroke={primaryColor}
-              strokeWidth={2.5}
-              dot={false}
-              activeDot={{ r: 4 }}
-              connectNulls={false}
-            />
-          </LineChart>
-        </ResponsiveContainer>
-      </CardContent>
-
-      {/* The other three, each on its own scale. Same x-axis, no shared y —
-          so the shapes can be compared without the numbers being implied to
-          be comparable. */}
-      <CardContent className="grid grid-cols-1 gap-4 pt-0 sm:grid-cols-3">
-        {panels.context.map(key => METRIC_OPTIONS.find(option => option.key === key)!).map(option => (
-          <div key={option.key} className="space-y-1">
-            <p className="text-xs font-medium text-muted-foreground">
-              {option.label}
-              <span className="ml-1 font-normal text-muted-foreground/70 tabular-nums">
-                {total(data, option.key).toLocaleString()}
-              </span>
-            </p>
-            <div className="h-20">
+      {layout === 'grid'
+        ? (
+            <CardContent className="grid grid-cols-1 gap-6 sm:grid-cols-2">
+              {METRIC_OPTIONS.map(option => (
+                <div key={option.key} className="space-y-1">
+                  <p className="text-sm font-medium">
+                    {option.label}
+                    <span className="ml-1.5 text-xs font-normal text-muted-foreground tabular-nums">
+                      {total(data, option.key).toLocaleString()}
+                    </span>
+                  </p>
+                  <div className="h-44">
+                    <ResponsiveContainer width="100%" height="100%">
+                      <LineChart data={data} margin={{ top: 4, right: 4, bottom: 0, left: -12 }}>
+                        <CartesianGrid strokeDasharray="3 3" stroke={theme.grid.stroke} />
+                        <XAxis dataKey="label" tick={theme.tick} interval="preserveStartEnd" minTickGap={24} />
+                        <YAxis tick={theme.tick} allowDecimals={false} width={44} />
+                        <Tooltip content={<ChartTooltip />} cursor={theme.tooltip.cursor} />
+                        <Line
+                          type="monotone"
+                          dataKey={option.key}
+                          name={option.label}
+                          stroke={metricColor(theme, option.key)}
+                          strokeWidth={2}
+                          dot={false}
+                          activeDot={{ r: 3 }}
+                          connectNulls={false}
+                        />
+                      </LineChart>
+                    </ResponsiveContainer>
+                  </div>
+                </div>
+              ))}
+            </CardContent>
+          )
+        : (
+            <CardContent className="h-72 sm:h-80">
               <ResponsiveContainer width="100%" height="100%">
-                <LineChart data={data} margin={{ top: 4, right: 4, bottom: 0, left: 0 }}>
-                  <XAxis dataKey="label" hide />
-                  {/* Its own domain, which is the entire point: on the shared
-                      axis above, a series in the tens beside one in the
-                      thousands was a flat line along the bottom. */}
-                  <YAxis hide domain={['dataMin', 'dataMax']} />
+                <LineChart data={data} margin={{ top: 8, right: 8, bottom: 8, left: -12 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke={theme.grid.stroke} />
+                  <XAxis dataKey="label" tick={theme.tick} interval="preserveStartEnd" minTickGap={24} />
+                  <YAxis tick={theme.tick} allowDecimals={false} width={44} />
                   <Tooltip content={<ChartTooltip />} cursor={theme.tooltip.cursor} />
+                  {/* One line, its own axis. The others are below at their own
+                      scales rather than squashed onto this one. */}
                   <Line
                     type="monotone"
-                    dataKey={option.key}
-                    name={option.label}
-                    stroke={metricColor(theme, option.key)}
-                    strokeWidth={1.5}
+                    dataKey={primaryOption.key}
+                    name={primaryOption.label}
+                    stroke={primaryColor}
+                    strokeWidth={2.5}
                     dot={false}
+                    activeDot={{ r: 4 }}
                     connectNulls={false}
                   />
                 </LineChart>
               </ResponsiveContainer>
+            </CardContent>
+          )}
+
+      {/* The other three, each on its own scale. Same x-axis, no shared y —
+          so the shapes can be compared without the numbers being implied to
+          be comparable. */}
+      {layout === 'primary' && (
+        <CardContent className="grid grid-cols-1 gap-4 pt-0 sm:grid-cols-3">
+          {panels.context.map(key => METRIC_OPTIONS.find(option => option.key === key)!).map(option => (
+            <div key={option.key} className="space-y-1">
+              <p className="text-xs font-medium text-muted-foreground">
+                {option.label}
+                <span className="ml-1 font-normal text-muted-foreground/70 tabular-nums">
+                  {total(data, option.key).toLocaleString()}
+                </span>
+              </p>
+              <div className="h-20">
+                <ResponsiveContainer width="100%" height="100%">
+                  <LineChart data={data} margin={{ top: 4, right: 4, bottom: 0, left: 0 }}>
+                    <XAxis dataKey="label" hide />
+                    {/* Its own domain, which is the entire point: on the shared
+                      axis above, a series in the tens beside one in the
+                      thousands was a flat line along the bottom. */}
+                    <YAxis hide domain={['dataMin', 'dataMax']} />
+                    <Tooltip content={<ChartTooltip />} cursor={theme.tooltip.cursor} />
+                    <Line
+                      type="monotone"
+                      dataKey={option.key}
+                      name={option.label}
+                      stroke={metricColor(theme, option.key)}
+                      strokeWidth={1.5}
+                      dot={false}
+                      connectNulls={false}
+                    />
+                  </LineChart>
+                </ResponsiveContainer>
+              </div>
             </div>
-          </div>
-        ))}
-      </CardContent>
+          ))}
+        </CardContent>
+      )}
     </Card>
   );
 }


### PR DESCRIPTION
Ask B: the Daily Pulse's activity chart previously showed ONE chosen metric large with the other three as tiny sparklines — you toggled to see each. It now shows **all four together as equal panels** (Played · Finished · Players · Multiplayer, 2×2 on desktop), each with its own visible axis and its range total in the header.

Deliberately four panels rather than four lines on one chart, keeping the file's documented rationale: distinct players runs in the tens where games run in the thousands — a shared axis flattens the small series into a floor line *and* implies the gaps between lines are comparable when they aren't. Equal panels give "together" without either lie.

- `ActivityChart` gains a `layout` prop (`'primary'` default — per-game report pages unchanged; `'grid'` on the pulse).
- The metric toggle stays in the filter bar: it still drives the games leaderboard below (a code comment on the call site says so).
- Uncovered days keep rendering as gaps, not zeroes, in every panel.

2 new layout tests; full suite **939 tests, 136 files, all passing**; gates clean.

Self-review (Copilot off limits): the primary layout path is byte-identical behaviour (conditional wrap only); grid panels reuse the same null-for-uncovered data pipeline and per-metric colours.