### PR TITLE
feat: behaviour and content tabs tie each game's two surfaces

### DIFF
--- a/app/analytics/career-path/page.tsx
+++ b/app/analytics/career-path/page.tsx
@@ -2,6 +2,7 @@
 
 import type { RangeState } from '@/lib/report-range';
 import { useMemo } from 'react';
+import { SurfaceTabs } from '@/components/admin/SurfaceTabs';
 import { DifficultyTiers } from '@/components/analytics/panels/DifficultyTiers';
 import { FootballerContent } from '@/components/analytics/panels/FootballerContent';
 import { ModeRates } from '@/components/analytics/panels/ModeRates';
@@ -77,6 +78,8 @@ export default function CareerPathAnalyticsPage() {
       title="Career Path content"
       description="Which footballers are too hard, which are merely common, and whether the grading means anything."
     >
+      <SurfaceTabs gameKey="career_path" active="content" />
+
       <FilterBar>
         <RangePicker
           value={range}

--- a/app/analytics/grid/page.tsx
+++ b/app/analytics/grid/page.tsx
@@ -3,6 +3,7 @@
 import type { RangeState } from '@/lib/report-range';
 import type { GridModeRow } from '@/types/reports';
 import { useMemo } from 'react';
+import { SurfaceTabs } from '@/components/admin/SurfaceTabs';
 import { ActiveFilterChips } from '@/components/analytics/ActiveFilterChips';
 import { modeLabel } from '@/components/analytics/panels/grid-mode';
 import { GridAssists } from '@/components/analytics/panels/GridAssists';
@@ -90,6 +91,8 @@ export default function GridAnalyticsPage() {
       title="Grid content"
       description="Which criteria mislead, which pool footballers are broken or dead weight, and whether each mode and variation actually plays."
     >
+      <SurfaceTabs gameKey="grid" active="content" />
+
       <FilterBar>
         <RangePicker
           value={range}

--- a/app/analytics/lineups/page.tsx
+++ b/app/analytics/lineups/page.tsx
@@ -2,6 +2,7 @@
 
 import type { RangeState } from '@/lib/report-range';
 import { useMemo } from 'react';
+import { SurfaceTabs } from '@/components/admin/SurfaceTabs';
 import { LineupSlots } from '@/components/analytics/panels/LineupSlots';
 import { LineupWorkload } from '@/components/analytics/panels/LineupWorkload';
 import { AnalyticsShell } from '@/components/analytics/shell/AnalyticsShell';
@@ -55,6 +56,8 @@ export default function LineupsAnalyticsPage() {
       title="Lineup content"
       description="Which slots cost the most guesses, and which lineups ask the most of a player."
     >
+      <SurfaceTabs gameKey="missing11" active="content" />
+
       <FilterBar>
         <RangePicker
           value={range}

--- a/app/reports/games/[key]/page.tsx
+++ b/app/reports/games/[key]/page.tsx
@@ -2,10 +2,11 @@
 
 import type { RangeState } from '@/lib/report-range';
 import type { Granularity } from '@/types/reports';
-import { ArrowLeft, ArrowRight } from 'lucide-react';
+import { ArrowLeft } from 'lucide-react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { useMemo, useState } from 'react';
+import { SurfaceTabs } from '@/components/admin/SurfaceTabs';
 import { ActivityChart } from '@/components/reports/charts/ActivityChart';
 import { DurationHistogram } from '@/components/reports/charts/DurationHistogram';
 import { GameHourProfile } from '@/components/reports/charts/GameHourProfile';
@@ -26,7 +27,6 @@ import { useGameColor, useGameMeta } from '@/hooks/use-game-meta';
 import { useReport } from '@/hooks/use-report';
 import { useReportFilters } from '@/hooks/use-report-filters';
 import { useAuth } from '@/lib/auth';
-import { CONTENT_ANALYTICS_BY_GAME } from '@/lib/global-nav';
 import { compareToParams, rangeToParams } from '@/lib/report-range';
 import { ReportsAPI } from '@/lib/reports-api';
 
@@ -107,16 +107,8 @@ export default function GameDetailPage() {
         </Link>
         {/* The other half of this game's story: this page is behaviour, the
             analytics page is content quality. Games without a content page
-            simply don't offer the link. */}
-        {CONTENT_ANALYTICS_BY_GAME[gameKey] && (
-          <Link
-            href={CONTENT_ANALYTICS_BY_GAME[gameKey]}
-            className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
-          >
-            Content analytics
-            <ArrowRight className="size-4" />
-          </Link>
-        )}
+            render no tabs. */}
+        <SurfaceTabs gameKey={gameKey} active="behaviour" />
       </div>
 
       <FilterBar>

--- a/components/admin/SurfaceTabs.tsx
+++ b/components/admin/SurfaceTabs.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import Link from 'next/link';
+import { CONTENT_ANALYTICS_BY_GAME } from '@/lib/global-nav';
+import { cn } from '@/lib/utils';
+
+/**
+ * The two halves of one game's story, as tabs.
+ *
+ * A game with a content-analytics page has two surfaces answering two
+ * questions — Behaviour (how players behave: /reports/games/<key>) and
+ * Content (whether the material is any good: /analytics/<page>). They
+ * were tied by prose links, which made them read as two places that
+ * happen to mention each other; tabs make them one place with two views.
+ * Games without a content page render nothing — no empty chrome.
+ *
+ * The URLs (and each side's own default range) stay as they are: a tab
+ * is a link, not shared state.
+ */
+export function SurfaceTabs({ gameKey, active }: {
+  gameKey: string;
+  active: 'behaviour' | 'content';
+}) {
+  const contentHref = CONTENT_ANALYTICS_BY_GAME[gameKey];
+  if (!contentHref) {
+    return null;
+  }
+
+  const tabs = [
+    { key: 'behaviour' as const, label: 'Behaviour', href: `/reports/games/${gameKey}` },
+    { key: 'content' as const, label: 'Content', href: contentHref },
+  ];
+
+  return (
+    <div role="tablist" aria-label="Game surface" className="inline-flex gap-1 rounded-lg border bg-background/60 p-1">
+      {tabs.map(tab => (
+        <Link
+          key={tab.key}
+          role="tab"
+          aria-selected={active === tab.key}
+          href={tab.href}
+          className={cn(
+            'rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
+            active === tab.key
+              ? 'bg-primary/10 text-primary'
+              : 'text-muted-foreground hover:text-foreground',
+          )}
+        >
+          {tab.label}
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/components/admin/__tests__/SurfaceTabs.test.tsx
+++ b/components/admin/__tests__/SurfaceTabs.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { SurfaceTabs } from '@/components/admin/SurfaceTabs';
+
+describe('SurfaceTabs', () => {
+  it('links the two surfaces of a game that has both', () => {
+    render(<SurfaceTabs gameKey="grid" active="content" />);
+
+    expect(screen.getByRole('tab', { name: 'Behaviour' })).toHaveAttribute('href', '/reports/games/grid');
+    expect(screen.getByRole('tab', { name: 'Content' })).toHaveAttribute('href', '/analytics/grid');
+    expect(screen.getByRole('tab', { name: 'Content' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tab', { name: 'Behaviour' })).toHaveAttribute('aria-selected', 'false');
+  });
+
+  it('renders nothing for a game without a content page', () => {
+    const { container } = render(<SurfaceTabs gameKey="quiz" active="behaviour" />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});


### PR DESCRIPTION
Ask C: `/reports/games/grid` and `/analytics/grid` were tied by prose links, which read as two places that happen to mention each other. A shared **Behaviour | Content** tab switcher now sits at the top of both — one place, two views.

- New `SurfaceTabs` (driven by the existing `CONTENT_ANALYTICS_BY_GAME` map): on `/reports/games/[key]` it replaces the prose "Content analytics" link; the analytics side mirrors it — and since the map already covers them, **Career Path and Lineups get the same tabs for free** on both their surfaces.
- Games without a content page render no tabs — no empty chrome.
- URLs and each side's own default range stay as they are: a tab is a link, not shared state (stated in the component).

2 tests (both-surfaces hrefs + aria-selected, nothing for tab-less games); full suite **941 tests, 137 files, all passing**; gates clean.

Self-review (Copilot off limits): the removed prose link is superseded by the tab, not lost; `ArrowRight` import cleaned; the behaviour-strip's deep link inside `/analytics/grid` stays (it points at the *sections* of the behaviour page, which the tab doesn't).